### PR TITLE
chore: run PR preview on pull_request

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,6 @@
 name: 🔂 Surge PR Preview
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   preview:


### PR DESCRIPTION
解决第一次 push 时 PR 还没有创建拿不到 `pr.number` 的问题。

afc163/surge-preview#13