### PR TITLE
Feat/procard ghost

### DIFF
--- a/packages/card/demos/colspan.tsx
+++ b/packages/card/demos/colspan.tsx
@@ -24,7 +24,7 @@ export default () => {
           colSpan-6
         </ProCard>
       </ProCard>
-      <ProCard style={{ marginTop: 8 }} gutter={8} title="指定宽度px">
+      <ProCard style={{ marginTop: 8 }} gutter={8} ghost>
         <ProCard colSpan="200px" layout="center" bordered>
           colSpan - 200px
         </ProCard>
@@ -32,7 +32,7 @@ export default () => {
           Auto
         </ProCard>
       </ProCard>
-      <ProCard style={{ marginTop: 8 }} gutter={8} title="指定宽度百分比">
+      <ProCard style={{ marginTop: 8 }} gutter={8} ghost>
         <ProCard bordered>Auto</ProCard>
         <ProCard colSpan="30%" bordered>
           colSpan - 30%

--- a/packages/card/docs/card.md
+++ b/packages/card/docs/card.md
@@ -28,7 +28,7 @@ group:
 
 ### 栅格布局
 
-当嵌套子卡片时, 组件会自动切换为 `flex` 弹性盒布局。你还可以通过配置 `ghost` 方便页内布局。
+当嵌套子卡片时, 组件会自动切换为 `flex` 弹性盒布局。你还可以通过配置 `ghost` 属性为 `true` 方便页内布局。
 
  <code src="../demos/colspan.tsx"  background="#f0f2f5" />
 
@@ -125,7 +125,7 @@ group:
 |  gutter | 数字或使用数组形式同时设置 [水平间距, 垂直间距], 支持响应式的对象写法 `{ xs: 8, sm: 16, md: 24}` | `number` \| `array` | 0 |
 |  split | 拆分卡片的方向 | `vertical` \| `horizontal`  | - |
 | bordered | 是否有边框 | `boolean` | false |
-| ghost | 幽灵模式，即是否取消卡片内容区域的 padding 和 背景颜色。 | `boolean` | false |
+| ghost | 幽灵模式，即是否取消卡片内容区域的 padding 和 卡片的背景颜色。 | `boolean` | false |
 | headerBordered | 页头是否有分割线 | `boolean` | false |
 | collapsed | 受控属性，是否折叠 | `boolean` | false |
 | collapsible | 配置是否可折叠，受控时无效 | `boolean` | false |

--- a/packages/card/docs/card.md
+++ b/packages/card/docs/card.md
@@ -28,9 +28,9 @@ group:
 
 ### 栅格布局
 
-当嵌套子卡片时, 组件会自动切换为 `flex` 弹性盒布局。
+当嵌套子卡片时, 组件会自动切换为 `flex` 弹性盒布局。你还可以通过配置 `ghost` 方便页内布局。
 
-<code src="../demos/colspan.tsx"  background="#f0f2f5" />
+ <code src="../demos/colspan.tsx"  background="#f0f2f5" />
 
 ### 响应式
 
@@ -125,6 +125,7 @@ group:
 |  gutter | 数字或使用数组形式同时设置 [水平间距, 垂直间距], 支持响应式的对象写法 `{ xs: 8, sm: 16, md: 24}` | `number` \| `array` | 0 |
 |  split | 拆分卡片的方向 | `vertical` \| `horizontal`  | - |
 | bordered | 是否有边框 | `boolean` | false |
+| ghost | 幽灵模式，即是否取消卡片内容区域的 padding 和 背景颜色。 | `boolean` | false |
 | headerBordered | 页头是否有分割线 | `boolean` | false |
 | collapsed | 受控属性，是否折叠 | `boolean` | false |
 | collapsible | 配置是否可折叠，受控时无效 | `boolean` | false |

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ant-design/pro-card",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0",
   "description": "@ant-design/pro-card",
   "keywords": [
     "antd",
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "authors": [
-    "chencheng <sorrycc@gmail.com> (https://github.com/sorrycc)",
+    "rdmclin2 <rdmclin2@gmail.com> (https://github.com/rdmclin2)",
     "chenshuai2144 <qixian.cs@outlook.com> (https://github.com/chenshuai2144)"
   ]
 }

--- a/packages/card/src/index.tsx
+++ b/packages/card/src/index.tsx
@@ -78,6 +78,10 @@ export type ProCardProps = {
    */
   bordered?: boolean;
   /**
+   * 幽灵模式，即是否取消卡片内容区域的 padding 和 背景颜色。
+   */
+  ghost?: boolean;
+  /**
    * 是否可折叠
    */
   collapsible?: boolean;
@@ -109,9 +113,10 @@ const ProCard: ProCardType = (props) => {
     colSpan,
     gutter = 0,
     split,
-    headerBordered,
-    bordered,
+    headerBordered = false,
+    bordered = false,
     children,
+    ghost = false,
     collapsed: controlCollapsed,
     collapsible = false,
     defaultCollapsed = false,
@@ -242,6 +247,7 @@ const ProCard: ProCardType = (props) => {
           [`${prefixCls}-contain-card`]: containProCard,
           [`${prefixCls}-loading`]: loading,
           [`${prefixCls}-split`]: split === 'vertical' || split === 'horizontal',
+          [`${prefixCls}-ghost`]: ghost,
         });
 
         const headerCls = classNames(`${prefixCls}-header`, {
@@ -253,6 +259,7 @@ const ProCard: ProCardType = (props) => {
           [`${prefixCls}-body-center`]: layout === 'center',
           [`${prefixCls}-body-column`]: split === 'horizontal',
           [`${prefixCls}-body-collapse`]: collapsed,
+          [`${prefixCls}-body-ghost`]: ghost,
         });
 
         const loadingBlockStyle =

--- a/packages/card/src/style/index.less
+++ b/packages/card/src/style/index.less
@@ -18,6 +18,10 @@
     border: @border-width-base @border-style-base @border-color-split;
   }
 
+  &-ghost {
+    background-color: transparent;
+  }
+
   &-split > &-body {
     padding: 0;
   }
@@ -43,7 +47,6 @@
   &-header {
     display: flex;
     justify-content: space-between;
-    background-color: white;
     padding: @padding-md;
     padding-bottom: 0;
     &-border {
@@ -87,6 +90,11 @@
 
     &-collapse {
       display: none;
+    }
+
+    &-ghost {
+      padding: 0;
+      background-color: transparent;
     }
   }
 

--- a/tests/card/__snapshots__/demo.test.ts.snap
+++ b/tests/card/__snapshots__/demo.test.ts.snap
@@ -299,23 +299,11 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-pro-card ant-pro-card-contain-card"
+    class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-header"
-    >
-      <div
-        class="ant-pro-card-title"
-      >
-        指定宽度px
-      </div>
-      <div
-        class="ant-pro-card-extra"
-      />
-    </div>
-    <div
-      class="ant-pro-card-body"
+      class="ant-pro-card-body ant-pro-card-body-ghost"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -339,23 +327,11 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-pro-card ant-pro-card-contain-card"
+    class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-header"
-    >
-      <div
-        class="ant-pro-card-title"
-      >
-        指定宽度百分比
-      </div>
-      <div
-        class="ant-pro-card-extra"
-      />
-    </div>
-    <div
-      class="ant-pro-card-body"
+      class="ant-pro-card-body ant-pro-card-body-ghost"
     >
       <div
         class="ant-pro-card ant-pro-card-border"

--- a/tests/skeleton/__snapshots__/demo.test.ts.snap
+++ b/tests/skeleton/__snapshots__/demo.test.ts.snap
@@ -299,23 +299,11 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-pro-card ant-pro-card-contain-card"
+    class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-header"
-    >
-      <div
-        class="ant-pro-card-title"
-      >
-        指定宽度px
-      </div>
-      <div
-        class="ant-pro-card-extra"
-      />
-    </div>
-    <div
-      class="ant-pro-card-body"
+      class="ant-pro-card-body ant-pro-card-body-ghost"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -339,23 +327,11 @@ Array [
     </div>
   </div>,
   <div
-    class="ant-pro-card ant-pro-card-contain-card"
+    class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-header"
-    >
-      <div
-        class="ant-pro-card-title"
-      >
-        指定宽度百分比
-      </div>
-      <div
-        class="ant-pro-card-extra"
-      />
-    </div>
-    <div
-      class="ant-pro-card-body"
+      class="ant-pro-card-body ant-pro-card-body-ghost"
     >
       <div
         class="ant-pro-card ant-pro-card-border"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4705237/90368511-b7b78880-e09c-11ea-90aa-a12e55147abb.png)

1. 添加`ghost`属性配置取消卡片的背景颜色以及内容区域的padding，方便进行卡片布局。
2. 版本提到1.0.0 正式发布。