### PR TITLE
💥 feat(compiler): 添加ProTable查询表单中的字段重命名

### DIFF
--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -6,16 +6,18 @@ import ProForm, { QueryFilter, ProFormField, BaseQueryFilterProps } from '@ant-d
 import classNames from 'classnames';
 import { ProFieldValueType } from '@ant-design/pro-field';
 import { ConfigContext } from 'antd/lib/config-provider/context';
+import { Store } from 'antd/lib/form/interface';
 import {
   useDeepCompareEffect,
   ProSchemaComponentTypes,
   conversionSubmitValue,
+  renameKeySubmitValue,
 } from '@ant-design/pro-utils';
 import warningOnce from 'rc-util/lib/warning';
 
 import { genColumnKey } from '../utils';
 import Container from '../container';
-import { ProColumns } from '../index';
+import { ProColumns, ProColumnType } from '../index';
 import './index.less';
 
 export interface TableFormItem<T> extends Omit<FormItemProps, 'children' | 'onReset'> {
@@ -86,7 +88,7 @@ export const formInputRender: React.FC<{
         {...rest}
         ref={ref}
         initialValue={item.initialValue}
-        name={item.dataIndex}
+        name={item.key || item.dataIndex}
       >
         {React.cloneElement(dom, { ...rest, ...defaultProps })}
       </ProFormField>
@@ -103,7 +105,7 @@ export const formInputRender: React.FC<{
       ref={ref}
       isDefaultDom
       valueEnum={item.valueEnum}
-      name={item.dataIndex}
+      name={item.key || item.dataIndex}
       onChange={onChange}
       // @ts-ignore
       fieldProps={restFieldProps || item.formItemProps}
@@ -196,11 +198,30 @@ const FormSearch = <T, U = any>({
     [key: string]: ProFieldValueType;
   }>({});
 
+  /**
+   * 保存 renameKeyRef，用于对表单key rename
+   */
+  const renameKeyRef = useRef<{
+    [key: string]: ProColumnType['renameKey'];
+  }>({});
+
   // 这么做是为了在用户修改了输入的时候触发一下子节点的render
   const [, updateState] = React.useState();
   const forceUpdate = useCallback(() => updateState({}), []);
 
   const isForm = type === 'form';
+
+  // 触发onSubmit
+  const triggerSubmit = (value: Store) => {
+    if (onSubmit) {
+      onSubmit(
+        renameKeySubmitValue(
+          conversionSubmitValue(value, dateFormatter, valueTypeRef.current) as T,
+          renameKeyRef.current,
+        ),
+      );
+    }
+  };
 
   /**
    *提交表单，根据两种模式不同，方法不相同
@@ -209,16 +230,12 @@ const FormSearch = <T, U = any>({
     // 如果不是表单模式，不用进行验证
     if (!isForm) {
       const value = form.getFieldsValue();
-      if (onSubmit) {
-        onSubmit(conversionSubmitValue(value, dateFormatter, valueTypeRef.current) as T);
-      }
+      triggerSubmit(value);
       return;
     }
     try {
       const value = await form.validateFields();
-      if (onSubmit) {
-        onSubmit(conversionSubmitValue(value, dateFormatter, valueTypeRef.current) as T);
-      }
+      triggerSubmit(value);
     } catch (error) {
       // console.log(error)
     }
@@ -248,9 +265,14 @@ const FormSearch = <T, U = any>({
       return;
     }
     const tempMap = {};
+    const renameKeyMap = {};
+
     counter.proColumns.forEach((item) => {
-      tempMap[genColumnKey(item.key, item.index)] = item.valueType;
+      const { dataIndex, key, index, valueType, renameKey } = item;
+      tempMap[genColumnKey(key, index)] = valueType;
+      renameKeyMap[genColumnKey((key || dataIndex) as string, index)] = renameKey;
     });
+    renameKeyRef.current = renameKeyMap;
     valueTypeRef.current = tempMap;
   }, [counter.proColumns]);
 

--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -88,6 +88,7 @@ export const formInputRender: React.FC<{
         {...rest}
         ref={ref}
         initialValue={item.initialValue}
+        // 优先设置key作为name
         name={item.key || item.dataIndex}
       >
         {React.cloneElement(dom, { ...rest, ...defaultProps })}
@@ -105,6 +106,7 @@ export const formInputRender: React.FC<{
       ref={ref}
       isDefaultDom
       valueEnum={item.valueEnum}
+      // 优先设置key作为name
       name={item.key || item.dataIndex}
       onChange={onChange}
       // @ts-ignore

--- a/packages/table/src/demos/renameSubmit.tsx
+++ b/packages/table/src/demos/renameSubmit.tsx
@@ -1,0 +1,127 @@
+import { PlusOutlined } from '@ant-design/icons';
+import ProTable, { ProColumns } from '@ant-design/pro-table';
+import { Button } from 'antd';
+import React from 'react';
+
+const valueEnum = {
+  0: 'close',
+  1: 'running',
+  2: 'online',
+  3: 'error',
+};
+
+export interface TableListItem {
+  key: number;
+  name: string;
+  status: string;
+  updatedAt: number;
+  createdAt: number;
+  progress: number;
+  money: number;
+}
+const tableListDataSource: TableListItem[] = [];
+
+for (let i = 0; i < 100; i += 1) {
+  tableListDataSource.push({
+    key: i,
+    name: `TradeCode ${i}`,
+    status: valueEnum[Math.floor(Math.random() * 10) % 4],
+    updatedAt: Date.now() - Math.floor(Math.random() * 1000),
+    createdAt: Date.now() - Math.floor(Math.random() * 2000),
+    money: Math.floor(Math.random() * 2000) * i,
+    progress: Math.ceil(Math.random() * 100) + 1,
+  });
+}
+
+const columns: ProColumns<TableListItem>[] = [
+  {
+    title: '序号',
+    dataIndex: 'index',
+    valueType: 'index',
+    width: 80,
+  },
+  {
+    title: '状态',
+    dataIndex: 'status',
+    initialValue: 'all',
+    renameKey: 'state',
+    width: 100,
+    filters: true,
+    valueEnum: {
+      all: { text: '全部', status: 'Default' },
+      close: { text: '关闭', status: 'Default' },
+      running: { text: '运行中', status: 'Processing' },
+      online: { text: '已上线', status: 'Success' },
+      error: { text: '异常', status: 'Error' },
+    },
+  },
+  {
+    title: '进度',
+    key: 'progress',
+    renameKey: 'schedule',
+    dataIndex: 'progress',
+    valueType: (item) => ({
+      type: 'progress',
+      status: item.status !== 'error' ? 'active' : 'exception',
+    }),
+    width: 200,
+  },
+  {
+    title: '更新时间',
+    key: 'since',
+    width: 120,
+    dataIndex: 'createdAt',
+    valueType: 'dateRange',
+    renameKey: ['startTime', 'endTime'],
+  },
+  {
+    title: '更新时间2',
+    hideInTable: true,
+    key: 'since2',
+    valueType: 'time',
+    renameKey: 'createdAt2',
+  },
+  {
+    title: '更新时间3',
+    hideInTable: true,
+    key: 'since3',
+    valueType: 'dateTime',
+    renameKey: ['createdAt3'],
+  },
+  {
+    title: '更新时间4',
+    hideInTable: true,
+    key: 'since4',
+    valueType: 'dateTimeRange',
+    renameKey: ['createStartTime', 'createEndTime'],
+  },
+];
+
+export default () => {
+  return (
+    <ProTable<TableListItem>
+      columns={columns}
+      rowKey="key"
+      request={() =>
+        Promise.resolve({
+          data: tableListDataSource,
+          success: true,
+        })
+      }
+      pagination={{
+        showSizeChanger: true,
+      }}
+      onSubmit={(values) => {
+        console.log('onSubmit values:', values);
+      }}
+      dateFormatter="string"
+      headerTitle="重命名查询表单字段"
+      toolBarRender={() => [
+        <Button key="3" type="primary">
+          <PlusOutlined />
+          新建
+        </Button>,
+      ]}
+    />
+  );
+};

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -445,6 +445,10 @@ const enUSIntl = createIntl('en_US', enUS);
 
 <code src="./demos/dataSource.tsx" background="#f5f5f5"/>
 
+#### 重命名查询表单字段
+
+<code src="./demos/renameSubmit.tsx" background="#f5f5f5"/>
+
 #### 受控的列显示隐藏
 
 可以默认隐藏某些栏，但是在操作栏中可以选择

--- a/packages/utils/src/conversionSubmitValue/index.ts
+++ b/packages/utils/src/conversionSubmitValue/index.ts
@@ -63,7 +63,7 @@ const conversionSubmitValue = <T = any>(
   Object.keys(value).forEach((key) => {
     const valueType = valueTypeMap[key] || 'text';
     const itemValue = value[key];
-    if (itemValue === undefined || itemValue === null || itemValue === '') {
+    if (itemValue === undefined || itemValue === null) {
       return;
     }
     // 都没命中，原样返回

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -14,10 +14,15 @@ import pickUndefinedAndArray from './pickUndefinedAndArray';
  */
 import useDebounceFn from './hooks/useDebounceFn';
 import usePrevious from './hooks/usePrevious';
-import conversionSubmitValue from './conversionSubmitValue';
-import parseValueToMoment from './parseValueToMoment';
 import useDeepCompareEffect from './hooks/useDeepCompareEffect';
 import useDocumentTitle from './hooks/useDocumentTitle';
+
+/**
+ * transform
+ */
+import conversionSubmitValue from './conversionSubmitValue';
+import renameKeySubmitValue from './renameKeySubmitValue';
+import parseValueToMoment from './parseValueToMoment';
 
 /**
  * type
@@ -41,6 +46,7 @@ export type {
 export {
   LabelIconTip,
   conversionSubmitValue,
+  renameKeySubmitValue,
   parseValueToMoment,
   FieldDropdown,
   FieldLabel,

--- a/packages/utils/src/renameKeySubmitValue/index.ts
+++ b/packages/utils/src/renameKeySubmitValue/index.ts
@@ -1,0 +1,30 @@
+import { ProColumnType } from '@ant-design/pro-table';
+
+const renameKeySubmitValue = <T = any>(
+  values: T,
+  renameMap: { [key: string]: ProColumnType['renameKey'] },
+) => {
+  const result = {} as T;
+  Object.keys(values).forEach((key) => {
+    const renameKey = renameMap[key];
+    if (renameKey) {
+      // 如果是['startTime','endTime']的情况
+      if (Array.isArray(renameKey) && renameKey.length === 2 && Array.isArray(values[key])) {
+        renameKey.forEach((rKey, rInx) => {
+          result[rKey] = values[key][rInx];
+        });
+      } else {
+        // 如果是['renameKey']或者'renameKey'的情况
+        const finalKey = (Array.isArray(renameKey) && renameKey.length === 1
+          ? renameKey[0]
+          : renameKey) as string;
+        result[finalKey] = values[key];
+      }
+    } else {
+      result[key] = values[key];
+    }
+  });
+  return result;
+};
+
+export default renameKeySubmitValue;

--- a/packages/utils/src/renameKeySubmitValue/index.ts
+++ b/packages/utils/src/renameKeySubmitValue/index.ts
@@ -1,8 +1,6 @@
-import { ProColumnType } from '@ant-design/pro-table';
-
 const renameKeySubmitValue = <T = any>(
   values: T,
-  renameMap: { [key: string]: ProColumnType['renameKey'] },
+  renameMap: { [key: string]: string | [string] | [string, string] | undefined },
 ) => {
   const result = {} as T;
   Object.keys(values).forEach((key) => {

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -117,4 +117,9 @@ export type ProSchema<T = unknown, U = string, Extra = unknown> = {
    * 隐藏在 descriptions
    */
   hideInDescriptions?: boolean;
+
+  /**
+   * 在表单中的key重命名
+   */
+  renameKey?: string | [string] | [string, string];
 } & Extra;


### PR DESCRIPTION
新增一个column字段 `renameKey`,通过该字段可以实现表单搜索的字段重命名, 支持`string | [string] | [string, string]`类型,这是我的实现方式,或许有更好的呢? #180

例如:
```jsx
const columns = [
  {
    title: '状态',
    dataIndex: 'status',
    initialValue: 'all',
    renameKey: 'state',
    valueEnum: {
      all: { text: '全部', status: 'Default' },
      running: { text: '运行中', status: 'Processing' },
      online: { text: '已上线', status: 'Success' },
      error: { text: '异常', status: 'Error' },
    },
  },
  {
    title: '进度',
    key: 'progress',
    renameKey: 'schedule',
    dataIndex: 'progress',
    valueType: item => ({
      type: 'progress',
      status: item.status !== 'error' ? 'active' : 'exception',
    }),
  },
  {
    title: '更新时间',
    key: 'since',
    width: 120,
    dataIndex: 'createdAt',
    valueType: 'dateRange',
    renameKey: ['startTime', 'endTime'],
  },
  {
    title: '创建时间',
    hideInTable: true,
    key: 'created',
    valueType: 'dateTime',
    renameKey: ['createdAt'],
  },
]
```

最终生成的查询values:
```js
const values = {
 state: '',
 schedule: '',
 startTime: '',
 endTime: '',
 createdAt: ''
}
```