### PR TITLE
🐛 fix(compiler): 修复ProTable column key表现异常

### DIFF
--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -86,7 +86,7 @@ export const formInputRender: React.FC<{
         {...rest}
         ref={ref}
         initialValue={item.initialValue}
-        name={item.dataIndex}
+        name={item.key || item.dataIndex}
       >
         {React.cloneElement(dom, { ...rest, ...defaultProps })}
       </ProFormField>
@@ -103,7 +103,7 @@ export const formInputRender: React.FC<{
       ref={ref}
       isDefaultDom
       valueEnum={item.valueEnum}
-      name={item.dataIndex}
+      name={item.key || item.dataIndex}
       onChange={onChange}
       // @ts-ignore
       fieldProps={restFieldProps || item.formItemProps}
@@ -251,7 +251,8 @@ const FormSearch = <T, U = any>({
     }
     const tempMap = {};
     counter.proColumns.forEach((item) => {
-      tempMap[genColumnKey(item.key, item.index)] = item.valueType;
+      // 以key为主,理论上key唯一
+      tempMap[genColumnKey((item.key || item.dataIndex) as string, item.index)] = item.valueType;
     });
     valueTypeRef.current = tempMap;
   }, [counter.proColumns]);

--- a/tests/table/__snapshots__/demo.test.ts.snap
+++ b/tests/table/__snapshots__/demo.test.ts.snap
@@ -186,7 +186,7 @@ exports[`table demos renders ./packages/table/src/demos/batchOption.tsx correctl
           >
             <label
               class=""
-              for="created_at"
+              for="since"
               title=""
             >
               创建时间
@@ -210,7 +210,7 @@ exports[`table demos renders ./packages/table/src/demos/batchOption.tsx correctl
                   >
                     <input
                       autocomplete="off"
-                      id="created_at"
+                      id="since"
                       placeholder="请选择"
                       readonly=""
                       size="21"
@@ -4842,7 +4842,7 @@ exports[`table demos renders ./packages/table/src/demos/dataSource.tsx correctly
           >
             <label
               class=""
-              for="createdAt"
+              for="since2"
               title=""
             >
               更新时间
@@ -4866,7 +4866,7 @@ exports[`table demos renders ./packages/table/src/demos/dataSource.tsx correctly
                   >
                     <input
                       autocomplete="off"
-                      id="createdAt"
+                      id="since2"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -5561,7 +5561,7 @@ exports[`table demos renders ./packages/table/src/demos/form.tsx correctly 1`] =
             >
               <label
                 class=""
-                for="createdAt"
+                for="since"
                 title=""
               >
                 创建时间
@@ -5585,7 +5585,7 @@ exports[`table demos renders ./packages/table/src/demos/form.tsx correctly 1`] =
                     >
                       <input
                         autocomplete="off"
-                        id="createdAt"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -7528,7 +7528,7 @@ Array [
             >
               <label
                 class=""
-                for="created_at"
+                for="since"
                 title=""
               >
                 Created Time
@@ -7552,7 +7552,7 @@ Array [
                     >
                       <input
                         autocomplete="off"
-                        id="created_at"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -11728,7 +11728,7 @@ exports[`table demos renders ./packages/table/src/demos/linkage_form.tsx correct
             >
               <label
                 class=""
-                for="created_at"
+                for="since"
                 title=""
               >
                 创建时间
@@ -11752,7 +11752,7 @@ exports[`table demos renders ./packages/table/src/demos/linkage_form.tsx correct
                     >
                       <input
                         autocomplete="off"
-                        id="created_at"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -14881,7 +14881,7 @@ exports[`table demos renders ./packages/table/src/demos/pollinga.tsx correctly 1
           >
             <label
               class=""
-              for="createdAt"
+              for="since2"
               title=""
             >
               更新时间
@@ -14905,7 +14905,7 @@ exports[`table demos renders ./packages/table/src/demos/pollinga.tsx correctly 1
                   >
                     <input
                       autocomplete="off"
-                      id="createdAt"
+                      id="since2"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -15866,7 +15866,7 @@ exports[`table demos renders ./packages/table/src/demos/renderTable.tsx correctl
           >
             <label
               class=""
-              for="createdAt"
+              for="since2"
               title=""
             >
               更新时间
@@ -15890,7 +15890,7 @@ exports[`table demos renders ./packages/table/src/demos/renderTable.tsx correctl
                   >
                     <input
                       autocomplete="off"
-                      id="createdAt"
+                      id="since2"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -17271,7 +17271,7 @@ Array [
             >
               <label
                 class=""
-                for="created_at"
+                for="since"
                 title=""
               >
                 创建时间
@@ -17295,7 +17295,7 @@ Array [
                     >
                       <input
                         autocomplete="off"
-                        id="created_at"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -21132,7 +21132,7 @@ exports[`table demos renders ./packages/table/src/demos/search_option.tsx correc
             >
               <label
                 class=""
-                for="created_at"
+                for="since"
                 title=""
               >
                 创建时间
@@ -21156,7 +21156,7 @@ exports[`table demos renders ./packages/table/src/demos/search_option.tsx correc
                     >
                       <input
                         autocomplete="off"
-                        id="created_at"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -24886,7 +24886,7 @@ exports[`table demos renders ./packages/table/src/demos/single.tsx correctly 1`]
           >
             <label
               class=""
-              for="created_at"
+              for="since"
               title=""
             >
               创建时间
@@ -24910,7 +24910,7 @@ exports[`table demos renders ./packages/table/src/demos/single.tsx correctly 1`]
                   >
                     <input
                       autocomplete="off"
-                      id="created_at"
+                      id="since"
                       placeholder="请选择"
                       readonly=""
                       size="21"
@@ -29266,7 +29266,7 @@ exports[`table demos renders ./packages/table/src/demos/table-nested.tsx correct
           >
             <label
               class=""
-              for="createdAt"
+              for="since2"
               title=""
             >
               更新时间
@@ -29290,7 +29290,7 @@ exports[`table demos renders ./packages/table/src/demos/table-nested.tsx correct
                   >
                     <input
                       autocomplete="off"
-                      id="createdAt"
+                      id="since2"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -31225,7 +31225,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
             >
               <label
                 class=""
-                for="createdAt"
+                for="since"
                 title=""
               >
                 创建时间
@@ -31249,7 +31249,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
                     >
                       <input
                         autocomplete="off"
-                        id="createdAt"
+                        id="since"
                         placeholder="请选择"
                         readonly=""
                         size="21"
@@ -31297,7 +31297,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
           >
             <label
               class=""
-              for="createdAtRange"
+              for="dateRange"
               title=""
             >
               日期区间
@@ -31321,7 +31321,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
                   >
                     <input
                       autocomplete="off"
-                      id="createdAtRange"
+                      id="dateRange"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -31411,7 +31411,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
           >
             <label
               class=""
-              for="createdAtRange"
+              for="dateTimeRange"
               title=""
             >
               时间区间
@@ -31435,7 +31435,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
                   >
                     <input
                       autocomplete="off"
-                      id="createdAtRange"
+                      id="dateTimeRange"
                       placeholder="请选择"
                       readonly=""
                       size="21"
@@ -31525,7 +31525,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
           >
             <label
               class=""
-              for="createdAt"
+              for="since2"
               title=""
             >
               更新时间
@@ -31549,7 +31549,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
                   >
                     <input
                       autocomplete="off"
-                      id="createdAt"
+                      id="since2"
                       placeholder="请选择"
                       readonly=""
                       size="12"
@@ -31596,7 +31596,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
           >
             <label
               class=""
-              for="updatedAt"
+              for="since3"
               title=""
             >
               关闭时间
@@ -31620,7 +31620,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeDate.tsx correc
                   >
                     <input
                       autocomplete="off"
-                      id="updatedAt"
+                      id="since3"
                       placeholder="Select time"
                       readonly=""
                       size="10"
@@ -32553,7 +32553,7 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeNumber.tsx corr
           >
             <label
               class=""
-              for="money"
+              for="digit"
               title=""
             >
               数字
@@ -32638,10 +32638,10 @@ exports[`table demos renders ./packages/table/src/demos/valueTypeNumber.tsx corr
                       aria-valuemin="0"
                       autocomplete="off"
                       class="ant-input-number-input"
-                      id="money"
+                      id="digit"
                       max="9007199254740991"
                       min="0"
-                      name="money"
+                      name="digit"
                       placeholder="请输入"
                       role="spinbutton"
                       step="1"

--- a/tests/table/__snapshots__/index.test.tsx.snap
+++ b/tests/table/__snapshots__/index.test.tsx.snap
@@ -1269,7 +1269,7 @@ exports[`BasicTable 🎏 base use 1`] = `
           >
             <label
               class=""
-              for="date"
+              for="dateTime"
               title=""
             >
               dateTime
@@ -1293,7 +1293,7 @@ exports[`BasicTable 🎏 base use 1`] = `
                   >
                     <input
                       autocomplete="off"
-                      id="date"
+                      id="dateTime"
                       placeholder="请选择"
                       readonly=""
                       size="21"
@@ -1340,7 +1340,7 @@ exports[`BasicTable 🎏 base use 1`] = `
           >
             <label
               class=""
-              for="date"
+              for="time"
               title=""
             >
               time
@@ -1364,7 +1364,7 @@ exports[`BasicTable 🎏 base use 1`] = `
                   >
                     <input
                       autocomplete="off"
-                      id="date"
+                      id="time"
                       placeholder="Select time"
                       readonly=""
                       size="10"


### PR DESCRIPTION
```tsx
<ProFormField name={key || dataIndex} />

useDeepCompareEffect(() => {
  const tempMap = {};
  counter.proColumns.forEach((item) => {
    // 以key为主,理论上key唯一
    tempMap[genColumnKey((item.key || item.dataIndex) as string, item.index)] = item.valueType;
  });
  valueTypeRef.current = tempMap;
}, [counter.proColumns]);
```
理论上column key是唯一的,所有优先以column key为主,如果没有key则已dataIndex为主,也就是更改`<ProFormField name={key || dataIndex} />`以达到valueTypeRef与values字段的统一,从而达到在`conversionSubmitValue`进行`Moment -> string`的表现中正确.



close #375  close #349 