### PR TITLE
🐛 fix(table): 修复valueType函数返回date等日期类型格式化异常

### DIFF
--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -251,8 +251,12 @@ const FormSearch = <T, U = any>({
     }
     const tempMap = {};
     counter.proColumns.forEach((item) => {
+      const { key, dataIndex, index, valueType } = item;
       // 以key为主,理论上key唯一
-      tempMap[genColumnKey((item.key || item.dataIndex) as string, item.index)] = item.valueType;
+      const finalKey = genColumnKey((key || dataIndex) as string, index);
+      // 如果是() => ValueType
+      const finalValueType = typeof valueType === 'function' ? valueType(item) : valueType;
+      tempMap[finalKey] = finalValueType;
     });
     valueTypeRef.current = tempMap;
   }, [counter.proColumns]);


### PR DESCRIPTION
```tsx
const columns = [
  {
    title: '创建时间',
    dataIndex: 'createdAt',
    valueType: () => 'dateTime',
  },
];
```

如果`valueType`是函数并且返回`date`、`time`、`dateTime`、`dateRange`、`dateTimeRange`的话, 依然会出现`conversionSubmitValue`日期不能正常从`moment -> string | number`.
