### PR TITLE
🐛 fix(layout): fix splitMenus error in mobile mode

### DIFF
--- a/packages/layout/src/SiderMenu/SiderMenu.tsx
+++ b/packages/layout/src/SiderMenu/SiderMenu.tsx
@@ -152,7 +152,7 @@ const SiderMenu: React.FC<SiderMenuProps> = (props) => {
         collapsedWidth={48}
         style={{
           overflow: 'hidden',
-          paddingTop: layout === 'mix' ? headerHeight : undefined,
+          paddingTop: layout === 'mix' && !isMobile ? headerHeight : undefined,
           ...style,
         }}
         width={siderWidth}

--- a/packages/layout/src/SiderMenu/index.tsx
+++ b/packages/layout/src/SiderMenu/index.tsx
@@ -60,12 +60,13 @@ const SiderMenuWrapper: React.FC<SiderMenuProps> = (props) => {
         ...style,
       }}
       width={siderWidth}
-      bodyStyle={{ height: '100vh', padding: 0 }}
+      bodyStyle={{ height: '100vh', padding: 0, display: 'flex', flexDirection: 'row' }}
     >
       <SiderMenu
         {...omitProps}
         className={classNames(`${prefixCls}-sider`, className)}
         collapsed={isMobile ? false : collapsed}
+        splitMenus={false}
       />
     </Drawer>
   ) : (


### PR DESCRIPTION
close https://github.com/ant-design/pro-components/issues/136
close https://github.com/ant-design/ant-design-pro/issues/7114