### PR TITLE
feat(table): 修改table列设置，重置按钮

### DIFF
--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -11,7 +11,6 @@ import {
   ProSchemaComponentTypes,
   conversionSubmitValue,
 } from '@ant-design/pro-utils';
-import warningOnce from 'rc-util/lib/warning';
 
 import { genColumnKey } from '../utils';
 import Container from '../container';
@@ -92,9 +91,6 @@ export const formInputRender: React.FC<{
       </ProFormField>
     );
   }
-
-  // @ts-ignore
-  warningOnce(!item.formItemProps, `'formItemProps' will be deprecated, please use 'fieldProps'`);
 
   const { onChange, ...restFieldProps } = item.fieldProps || {};
   return (
@@ -315,6 +311,11 @@ const FormSearch = <T, U = any>({
   const formClassName = getPrefixCls('pro-table-form');
   const FormCompetent = isForm ? ProForm : QueryFilter;
 
+  const queryFilterProps = {
+    labelWidth: searchConfig ? searchConfig?.labelWidth : undefined,
+    defaultCollapsed: true,
+    ...searchConfig,
+  };
   return (
     <div
       className={classNames(className, {
@@ -322,8 +323,7 @@ const FormSearch = <T, U = any>({
       })}
     >
       <FormCompetent
-        defaultCollapsed
-        {...(searchConfig || {})}
+        {...(!isForm ? queryFilterProps : {})}
         {...formConfig}
         form={form}
         onValuesChange={(change, all) => {
@@ -342,7 +342,6 @@ const FormSearch = <T, U = any>({
           submit();
         }}
         initialValues={formConfig.initialValues}
-        labelWidth={searchConfig ? searchConfig?.labelWidth : undefined}
       >
         {domList}
       </FormCompetent>


### PR DESCRIPTION
在table初始化时，缓存初始化设置的columnsStateMap。
在操作列设置的重置按钮时，设置成初始化的列展示字段

close https://github.com/ant-design/pro-components/issues/515