### PR TITLE
feat(Table): Fix column reset to default column display

### DIFF
--- a/packages/table/src/component/ColumnSetting/index.tsx
+++ b/packages/table/src/component/ColumnSetting/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useIntl } from '@ant-design/pro-provider';
 import { ConfigContext } from 'antd/lib/config-provider';
 import {
@@ -10,7 +10,6 @@ import {
 import { Checkbox, Popover, Tooltip } from 'antd';
 import { DndProvider } from 'react-dnd';
 import classNames from 'classnames';
-import { cloneDeep } from "lodash";
 import Backend from 'react-dnd-html5-backend';
 
 import Container, { ColumnsState } from '../../container';
@@ -236,11 +235,9 @@ const GroupCheckboxList: React.FC<{
   );
 };
 
-let defaultColumnsMap: {
-  [key: string]: ColumnsState;
-} = {};
 
 const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
+  const columnRef = useRef({});
   const counter = Container.useContainer();
   const localColumns: Omit<ProColumns<any> & { index?: number }, 'ellipsis'>[] =
     props.columns || counter.columns || [];
@@ -248,7 +245,7 @@ const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
   const { columnsMap, setColumnsMap, setSortKeyColumns } = counter;
           
   useEffect(() => {
-    defaultColumnsMap = cloneDeep(columnsMap);
+    columnRef.current = JSON.parse(JSON.stringify(columnsMap));
   }, []);
           
   /**
@@ -300,7 +297,7 @@ const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
           </Checkbox>
           <a
             onClick={() => {
-              setColumnsMap(defaultColumnsMap);
+              setColumnsMap(columnRef.current);
               setSortKeyColumns([]);
             }}
           >

--- a/packages/table/src/component/ColumnSetting/index.tsx
+++ b/packages/table/src/component/ColumnSetting/index.tsx
@@ -235,7 +235,6 @@ const GroupCheckboxList: React.FC<{
   );
 };
 
-
 const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
   const columnRef = useRef({});
   const counter = Container.useContainer();
@@ -243,11 +242,11 @@ const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
     props.columns || counter.columns || [];
 
   const { columnsMap, setColumnsMap, setSortKeyColumns } = counter;
-          
+
   useEffect(() => {
     columnRef.current = JSON.parse(JSON.stringify(columnsMap));
   }, []);
-          
+
   /**
    * 设置全部选中，或全部未选中
    * @param show

--- a/packages/table/src/component/ColumnSetting/index.tsx
+++ b/packages/table/src/component/ColumnSetting/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useIntl } from '@ant-design/pro-provider';
 import { ConfigContext } from 'antd/lib/config-provider';
 import {
@@ -10,6 +10,7 @@ import {
 import { Checkbox, Popover, Tooltip } from 'antd';
 import { DndProvider } from 'react-dnd';
 import classNames from 'classnames';
+import { cloneDeep } from "lodash";
 import Backend from 'react-dnd-html5-backend';
 
 import Container, { ColumnsState } from '../../container';
@@ -235,12 +236,19 @@ const GroupCheckboxList: React.FC<{
   );
 };
 
+let defaultColumnsMap: object = {};
+
 const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
   const counter = Container.useContainer();
   const localColumns: Omit<ProColumns<any> & { index?: number }, 'ellipsis'>[] =
     props.columns || counter.columns || [];
 
   const { columnsMap, setColumnsMap, setSortKeyColumns } = counter;
+          
+  useEffect(() => {
+    defaultColumnsMap = cloneDeep(columnsMap);
+  }, []);
+          
   /**
    * 设置全部选中，或全部未选中
    * @param show
@@ -290,7 +298,7 @@ const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
           </Checkbox>
           <a
             onClick={() => {
-              setColumnsMap({});
+              setColumnsMap(defaultColumnsMap);
               setSortKeyColumns([]);
             }}
           >

--- a/packages/table/src/component/ColumnSetting/index.tsx
+++ b/packages/table/src/component/ColumnSetting/index.tsx
@@ -236,7 +236,9 @@ const GroupCheckboxList: React.FC<{
   );
 };
 
-let defaultColumnsMap: object = {};
+let defaultColumnsMap: {
+  [key: string]: ColumnsState;
+} = {};
 
 const ColumnSetting = <T, U = {}>(props: ColumnSettingProps<T>) => {
   const counter = Container.useContainer();


### PR DESCRIPTION
在table初始化时，缓存初始化设置的columnsStateMap。
在操作列设置的重置按钮时，设置成初始化的列展示字段

close https://github.com/ant-design/pro-components/issues/515