### PR TITLE
fix(table): 将 table 的loading 属性改为全受控

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -718,6 +718,7 @@ const ProTable = <T extends {}, U extends ParamsType>(
     />
   );
   const dataSource = request ? (action.dataSource as T[]) : props.dataSource || [];
+  const loading = props.loading !== undefined ? props.loading : action.loading;
   const tableDom = (
     <Table<T>
       {...rest}
@@ -737,7 +738,7 @@ const ProTable = <T extends {}, U extends ParamsType>(
         }
         return true;
       })}
-      loading={action.loading || props.loading}
+      loading={loading}
       dataSource={request ? (action.dataSource as T[]) : props.dataSource || []}
       pagination={pagination}
       onChange={(

--- a/tests/table/index.test.tsx
+++ b/tests/table/index.test.tsx
@@ -412,4 +412,37 @@ describe('BasicTable', () => {
 
     expect(fn).toBeCalledWith('middle');
   });
+
+  it('🎏 loading test', async () => {
+    const html = mount(
+      <ProTable
+        columns={[
+          {
+            title: 'money',
+            dataIndex: 'money',
+            valueType: 'money',
+          },
+        ]}
+        request={async () => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              resolve({ data: [] });
+            }, 5000);
+          });
+        }}
+        rowKey="key"
+      />,
+    );
+    await waitForComponentToPaint(html, 1200);
+    expect(html.find('.ant-spin').exists()).toBeTruthy();
+
+    act(() => {
+      html.setProps({
+        loading: false,
+      });
+    });
+    await waitForComponentToPaint(html, 1200);
+    // props 指定为 false 后，无论 request 完成与否都不会出现 spin
+    expect(html.find('.ant-spin').exists()).toBeFalsy();
+  });
 });


### PR DESCRIPTION
当前的写法一旦 action.loading 为 true 时，props 中传入的 loading 会失效。
改造为：props.loading 只要传入，优先选择 props.loading 的值。