### PR TITLE
feat(card): 添加卡片组展开

### DIFF
--- a/packages/card/src/card.md
+++ b/packages/card/src/card.md
@@ -74,6 +74,12 @@ group:
 
 <code src="./demos/collapsible.tsx" background="#f0f2f5" />
 
+### 卡片组展开
+
+配合 `ghost`幽灵模式和可折叠能力可以实现卡片组展开。
+
+<code src="./demos/group.tsx" background="#f0f2f5" />
+
 ### 内容居中
 
 配置 `layout`属性为`center`控制内容垂直居中。

--- a/packages/card/src/card.md
+++ b/packages/card/src/card.md
@@ -47,7 +47,11 @@ group:
 
 <code src="./demos/split2.tsx" background="#f0f2f5"/>
 
+### 左右分栏
+
 <code src="./demos/split23.tsx" background="#f0f2f5"/>
+
+### 复杂切分
 
 <code src="./demos/split.tsx" background="#f0f2f5"/>
 
@@ -117,6 +121,8 @@ group:
 `Steps` 组件结合 `ProCard` 组件完成竖向步骤示例。
 
 <code src="./demos/steps-v.tsx" background="#f0f2f5" />
+
+### 横向步骤条
 
 ## API
 

--- a/packages/card/src/demos/group.tsx
+++ b/packages/card/src/demos/group.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ProCard from '@ant-design/pro-card';
+
+export default () => {
+  return (
+    <>
+      <ProCard title="卡片组展开" ghost gutter={8} collapsible>
+        <ProCard layout="center" bordered>
+          卡片内容
+        </ProCard>
+        <ProCard layout="center" bordered>
+          卡片内容
+        </ProCard>
+        <ProCard layout="center" bordered>
+          卡片内容
+        </ProCard>
+      </ProCard>
+    </>
+  );
+};

--- a/packages/card/src/index.tsx
+++ b/packages/card/src/index.tsx
@@ -278,18 +278,16 @@ const ProCard: ProCardType = (props) => {
     [`${prefixCls}-split`]: split === 'vertical' || split === 'horizontal',
     [`${prefixCls}-ghost`]: ghost,
     [`${prefixCls}-type-${type}`]: type,
+    [`${prefixCls}-collapse`]: collapsed,
   });
 
   const headerCls = classNames(`${prefixCls}-header`, {
     [`${prefixCls}-header-border`]: headerBordered,
-    [`${prefixCls}-header-collapse`]: collapsed,
   });
 
   const bodyCls = classNames(`${prefixCls}-body`, {
     [`${prefixCls}-body-center`]: layout === 'center',
     [`${prefixCls}-body-column`]: split === 'horizontal',
-    [`${prefixCls}-body-collapse`]: collapsed,
-    [`${prefixCls}-body-ghost`]: ghost,
   });
 
   const loadingBlockStyle =
@@ -317,8 +315,8 @@ const ProCard: ProCardType = (props) => {
       {(title || extra || collapsibleButton) && (
         <div className={headerCls} style={headStyle}>
           <div className={`${prefixCls}-title`}>
-            <LabelIconTip label={title} tooltip={tooltip || tip} subTitle={subTitle} />
             {collapsibleButton}
+            <LabelIconTip label={title} tooltip={tooltip || tip} subTitle={subTitle} />
           </div>
           <div className={`${prefixCls}-extra`}>{extra}</div>
         </div>

--- a/packages/card/src/style/index.less
+++ b/packages/card/src/style/index.less
@@ -20,6 +20,19 @@
 
   &-ghost {
     background-color: transparent;
+
+    > .@{pro-card-prefix-cls} {
+      &-header {
+        padding-left: 0;
+        padding-right: 0;
+        padding-bottom: @padding-md;
+      }
+
+      &-body {
+        padding: 0;
+        background-color: transparent;
+      }
+    }
   }
 
   &-split > &-body {
@@ -43,6 +56,18 @@
     flex-direction: column;
   }
 
+  &-collapse {
+    > .@{pro-card-prefix-cls} {
+      &-header {
+        padding-bottom: @padding-md;
+      }
+
+      &-body {
+        display: none;
+      }
+    }
+  }
+
   &-header {
     display: flex;
     justify-content: space-between;
@@ -53,12 +78,6 @@
         padding-bottom: @padding-md;
       }
       border-bottom: @border-width-base @border-style-base @border-color-split;
-    }
-
-    &-collapse {
-      & {
-        padding-bottom: @padding-md;
-      }
     }
   }
 
@@ -128,7 +147,7 @@
 
   &-collapsible-icon {
     color: @icon-color-hover;
-    margin-left: 8px;
+    margin-right: 8px;
 
     & svg {
       transition: transform @animation-duration-base;
@@ -149,15 +168,6 @@
       display: flex;
       justify-content: center;
       align-items: center;
-    }
-
-    &-collapse {
-      display: none;
-    }
-
-    &-ghost {
-      padding: 0;
-      background-color: transparent;
     }
   }
 

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -40,10 +40,6 @@ ProTable 的诞生是为了解决项目中需要写很多 table 的样板代码�
 
 <code src="./demos/batchOption.tsx" background="#f5f5f5"/>
 
-### toolbar 搜索
-
-<code src="./demos/search.tsx" background="#f5f5f5"/>
-
 ### form 操作
 
 <code src="./demos/form.tsx" background="#f5f5f5"/>

--- a/tests/card/__snapshots__/demo.test.ts.snap
+++ b/tests/card/__snapshots__/demo.test.ts.snap
@@ -129,15 +129,14 @@ exports[`card demos renders ./packages/card/src/demos/bordered.tsx correctly 1`]
 exports[`card demos renders ./packages/card/src/demos/collapsible.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-pro-card"
+    class="ant-pro-card ant-pro-card-collapse"
   >
     <div
-      class="ant-pro-card-header ant-pro-card-header-border ant-pro-card-header-collapse"
+      class="ant-pro-card-header ant-pro-card-header-border"
     >
       <div
         class="ant-pro-card-title"
       >
-        可折叠
         <span
           aria-label="right"
           class="anticon anticon-right ant-pro-card-collapsible-icon"
@@ -159,23 +158,24 @@ Array [
             />
           </svg>
         </span>
+        可折叠
       </div>
       <div
         class="ant-pro-card-extra"
       />
     </div>
     <div
-      class="ant-pro-card-body ant-pro-card-body-collapse"
+      class="ant-pro-card-body"
     >
       内容
     </div>
   </div>,
   <div
-    class="ant-pro-card"
+    class="ant-pro-card ant-pro-card-collapse"
     style="margin-top: 16px;"
   >
     <div
-      class="ant-pro-card-header ant-pro-card-header-border ant-pro-card-header-collapse"
+      class="ant-pro-card-header ant-pro-card-header-border"
     >
       <div
         class="ant-pro-card-title"
@@ -209,7 +209,7 @@ Array [
       </div>
     </div>
     <div
-      class="ant-pro-card-body ant-pro-card-body-collapse"
+      class="ant-pro-card-body"
     >
       内容
     </div>
@@ -303,7 +303,7 @@ Array [
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-body ant-pro-card-body-ghost"
+      class="ant-pro-card-body"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -331,7 +331,7 @@ Array [
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-body ant-pro-card-body-ghost"
+      class="ant-pro-card-body"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -356,6 +356,80 @@ Array [
     </div>
   </div>,
 ]
+`;
+
+exports[`card demos renders ./packages/card/src/demos/group.tsx correctly 1`] = `
+<div
+  class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
+>
+  <div
+    class="ant-pro-card-header"
+  >
+    <div
+      class="ant-pro-card-title"
+    >
+      <span
+        aria-label="right"
+        class="anticon anticon-right ant-pro-card-collapsible-icon"
+        role="img"
+        tabindex="-1"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="right"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          style="transform: rotate(90deg);"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+          />
+        </svg>
+      </span>
+      卡片组展开
+    </div>
+    <div
+      class="ant-pro-card-extra"
+    />
+  </div>
+  <div
+    class="ant-pro-card-body"
+  >
+    <div
+      class="ant-pro-card ant-pro-card-border"
+      style="margin-right: 8px;"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+    <div
+      class="ant-pro-card ant-pro-card-border"
+      style="margin-right: 8px;"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+    <div
+      class="ant-pro-card ant-pro-card-border"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`card demos renders ./packages/card/src/demos/gutter.tsx correctly 1`] = `

--- a/tests/card/index.test.tsx
+++ b/tests/card/index.test.tsx
@@ -23,7 +23,7 @@ describe('Field', () => {
       </ProCard>,
     );
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find('.ant-pro-card-body-collapse').exists()).toBeTruthy();
+    expect(wrapper.find('.ant-pro-card-collapse').exists()).toBeTruthy();
   });
 
   it('🥩 collapsible collapsed', async () => {
@@ -33,14 +33,14 @@ describe('Field', () => {
       </ProCard>,
     );
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find('.ant-pro-card-body-collapse').exists()).toBeTruthy();
+    expect(wrapper.find('.ant-pro-card-collapse').exists()).toBeTruthy();
 
     wrapper.setProps({
       collapsed: false,
     });
 
     await waitForComponentToPaint(wrapper);
-    expect(wrapper.find('.ant-pro-card-body-collapse').exists()).toBeFalsy();
+    expect(wrapper.find('.ant-pro-card-collapse').exists()).toBeFalsy();
   });
 
   it('🥩 tabs onChange', async () => {

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -7217,7 +7217,6 @@ exports[`form demos renders ./packages/form/src/demos/multi-card-step-form.tsx c
             <div
               class="ant-pro-card-title"
             >
-              源和目标
               <span
                 aria-label="right"
                 class="anticon anticon-right ant-pro-card-collapsible-icon"
@@ -7240,6 +7239,7 @@ exports[`form demos renders ./packages/form/src/demos/multi-card-step-form.tsx c
                   />
                 </svg>
               </span>
+              源和目标
             </div>
             <div
               class="ant-pro-card-extra"
@@ -7523,7 +7523,6 @@ exports[`form demos renders ./packages/form/src/demos/multi-card-step-form.tsx c
             <div
               class="ant-pro-card-title"
             >
-              顶部对齐
               <span
                 aria-label="right"
                 class="anticon anticon-right ant-pro-card-collapsible-icon"
@@ -7546,6 +7545,7 @@ exports[`form demos renders ./packages/form/src/demos/multi-card-step-form.tsx c
                   />
                 </svg>
               </span>
+              顶部对齐
             </div>
             <div
               class="ant-pro-card-extra"

--- a/tests/skeleton/__snapshots__/demo.test.ts.snap
+++ b/tests/skeleton/__snapshots__/demo.test.ts.snap
@@ -129,15 +129,14 @@ exports[`card demos renders ./packages/card/src/demos/bordered.tsx correctly 1`]
 exports[`card demos renders ./packages/card/src/demos/collapsible.tsx correctly 1`] = `
 Array [
   <div
-    class="ant-pro-card"
+    class="ant-pro-card ant-pro-card-collapse"
   >
     <div
-      class="ant-pro-card-header ant-pro-card-header-border ant-pro-card-header-collapse"
+      class="ant-pro-card-header ant-pro-card-header-border"
     >
       <div
         class="ant-pro-card-title"
       >
-        可折叠
         <span
           aria-label="right"
           class="anticon anticon-right ant-pro-card-collapsible-icon"
@@ -159,23 +158,24 @@ Array [
             />
           </svg>
         </span>
+        可折叠
       </div>
       <div
         class="ant-pro-card-extra"
       />
     </div>
     <div
-      class="ant-pro-card-body ant-pro-card-body-collapse"
+      class="ant-pro-card-body"
     >
       内容
     </div>
   </div>,
   <div
-    class="ant-pro-card"
+    class="ant-pro-card ant-pro-card-collapse"
     style="margin-top: 16px;"
   >
     <div
-      class="ant-pro-card-header ant-pro-card-header-border ant-pro-card-header-collapse"
+      class="ant-pro-card-header ant-pro-card-header-border"
     >
       <div
         class="ant-pro-card-title"
@@ -209,7 +209,7 @@ Array [
       </div>
     </div>
     <div
-      class="ant-pro-card-body ant-pro-card-body-collapse"
+      class="ant-pro-card-body"
     >
       内容
     </div>
@@ -303,7 +303,7 @@ Array [
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-body ant-pro-card-body-ghost"
+      class="ant-pro-card-body"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -331,7 +331,7 @@ Array [
     style="margin-top: 8px;"
   >
     <div
-      class="ant-pro-card-body ant-pro-card-body-ghost"
+      class="ant-pro-card-body"
     >
       <div
         class="ant-pro-card ant-pro-card-border"
@@ -356,6 +356,80 @@ Array [
     </div>
   </div>,
 ]
+`;
+
+exports[`card demos renders ./packages/card/src/demos/group.tsx correctly 1`] = `
+<div
+  class="ant-pro-card ant-pro-card-contain-card ant-pro-card-ghost"
+>
+  <div
+    class="ant-pro-card-header"
+  >
+    <div
+      class="ant-pro-card-title"
+    >
+      <span
+        aria-label="right"
+        class="anticon anticon-right ant-pro-card-collapsible-icon"
+        role="img"
+        tabindex="-1"
+      >
+        <svg
+          aria-hidden="true"
+          class=""
+          data-icon="right"
+          fill="currentColor"
+          focusable="false"
+          height="1em"
+          style="transform: rotate(90deg);"
+          viewBox="64 64 896 896"
+          width="1em"
+        >
+          <path
+            d="M765.7 486.8L314.9 134.7A7.97 7.97 0 00302 141v77.3c0 4.9 2.3 9.6 6.1 12.6l360 281.1-360 281.1c-3.9 3-6.1 7.7-6.1 12.6V883c0 6.7 7.7 10.4 12.9 6.3l450.8-352.1a31.96 31.96 0 000-50.4z"
+          />
+        </svg>
+      </span>
+      卡片组展开
+    </div>
+    <div
+      class="ant-pro-card-extra"
+    />
+  </div>
+  <div
+    class="ant-pro-card-body"
+  >
+    <div
+      class="ant-pro-card ant-pro-card-border"
+      style="margin-right: 8px;"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+    <div
+      class="ant-pro-card ant-pro-card-border"
+      style="margin-right: 8px;"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+    <div
+      class="ant-pro-card ant-pro-card-border"
+    >
+      <div
+        class="ant-pro-card-body ant-pro-card-body-center"
+      >
+        卡片内容
+      </div>
+    </div>
+  </div>
+</div>
 `;
 
 exports[`card demos renders ./packages/card/src/demos/gutter.tsx correctly 1`] = `


### PR DESCRIPTION
1. 添加卡片组展开demo
![image](https://user-images.githubusercontent.com/4705237/95857071-a1246980-0d8d-11eb-901a-095546ff7653.png)

2. 调整展开按钮的位置