### PR TITLE
fix(table): should do nothing when component unmounted before getData resolved, close #692

### DIFF
--- a/packages/table/src/useFetchData.tsx
+++ b/packages/table/src/useFetchData.tsx
@@ -78,7 +78,6 @@ const useFetchData = <T extends RequestData<any>>(
    * 请求数据
    */
   const fetchList = async () => {
-    // 组件被卸载时不要继续设值
     if (loading || !mountRef.current) {
       return;
     }
@@ -94,7 +93,10 @@ const useFetchData = <T extends RequestData<any>>(
             }
           : undefined,
       );
-
+      // Do nothing when component unmounted before getData resolved
+      if (!mountRef.current) {
+        return;
+      }
       if (success !== false) {
         setDataAndLoading(data, dataTotal);
       } else {


### PR DESCRIPTION
This bug was fixed by #693 but reintroduced by #706.
The second `if` is still necessary because there is an `await` before it.