### PR TITLE
feat: add effective style to LightFilter when collapse

### DIFF
--- a/packages/form/src/demos/light-filter-collapse.tsx
+++ b/packages/form/src/demos/light-filter-collapse.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { FilterOutlined } from '@ant-design/icons';
 import { LightFilter, ProFormSelect, ProFormDateTimePicker } from '@ant-design/pro-form';
 
 export default () => {
@@ -9,7 +8,6 @@ export default () => {
         sex: 'man',
       }}
       collapse
-      collapseLabel={<FilterOutlined />}
       onFinish={async (values) => console.log(values)}
     >
       <ProFormSelect

--- a/packages/form/src/layouts/LightFilter/index.less
+++ b/packages/form/src/layouts/LightFilter/index.less
@@ -53,4 +53,17 @@
   .@{ant-prefix}-form-item {
     margin-bottom: 0;
   }
+
+  &-collapse-icon {
+    height: @height-base;
+    width: @height-base;
+    line-height: @height-base + 3px;
+    border-radius: 50%;
+  }
+
+  &-effective {
+    .@{pro-form-light-filter-prefix-cls}-collapse-icon {
+      background-color: fade(@black, 4%);
+    }
+  }
 }

--- a/packages/form/src/layouts/LightFilter/index.tsx
+++ b/packages/form/src/layouts/LightFilter/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect, useMemo } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import { FormProps } from 'antd/lib/form/Form';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 import classNames from 'classnames';

--- a/packages/form/src/layouts/LightFilter/index.tsx
+++ b/packages/form/src/layouts/LightFilter/index.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect, useMemo } from 'react';
 import { FormProps } from 'antd/lib/form/Form';
 import { SizeType } from 'antd/lib/config-provider/SizeContext';
 import classNames from 'classnames';
 import { Form, ConfigProvider } from 'antd';
 import { FieldDropdown, FieldLabel } from '@ant-design/pro-utils';
 import { useIntl } from '@ant-design/pro-provider';
+import { FilterOutlined } from '@ant-design/icons';
 import BaseForm, { CommonFormProps } from '../../BaseForm';
 import './index.less';
 
@@ -32,7 +33,7 @@ const LightFilterContainer: React.FC<{
   const {
     items,
     prefixCls,
-    size,
+    size = 'middle',
     collapse,
     collapseLabel,
     onValuesChange,
@@ -60,8 +61,28 @@ const LightFilterContainer: React.FC<{
     }
   });
 
+  const collapseLabelRender = () => {
+    if (collapseLabel) {
+      return collapseLabel;
+    }
+    if (collapse) {
+      return <FilterOutlined className={`${lightFilterClassName}-collapse-icon`} />;
+    }
+    return (
+      <FieldLabel
+        size={size}
+        label={intl.getMessage('form.lightFilter.more', '更多筛选')}
+        expanded={open}
+      />
+    );
+  };
+
   return (
-    <div className={classNames(lightFilterClassName, `${lightFilterClassName}-${size}`)}>
+    <div
+      className={classNames(lightFilterClassName, `${lightFilterClassName}-${size}`, {
+        [`${lightFilterClassName}-effective`]: Object.keys(values).some((key) => values[key]),
+      })}
+    >
       <div className={`${lightFilterClassName}-container`}>
         {outsideItems.map((child: any) => {
           const { key } = child;
@@ -85,15 +106,7 @@ const LightFilterContainer: React.FC<{
               padding={24}
               onVisibleChange={setOpen}
               visible={open}
-              label={
-                collapseLabel || (
-                  <FieldLabel
-                    size={size}
-                    label={intl.getMessage('form.lightFilter.more', '更多筛选')}
-                    expanded={open}
-                  />
-                )
-              }
+              label={collapseLabelRender()}
               footer={{
                 onConfirm: () => {
                   onValuesChange({

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -5694,7 +5694,7 @@ exports[`form demos renders ./packages/form/src/demos/light-filter.tsx correctly
     class="ant-form ant-form-horizontal ant-form-middle"
   >
     <div
-      class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
+      class="ant-pro-form-light-filter ant-pro-form-light-filter-middle ant-pro-form-light-filter-effective"
     >
       <div
         class="ant-pro-form-light-filter-container"
@@ -6595,7 +6595,7 @@ exports[`form demos renders ./packages/form/src/demos/light-filter-bordered.tsx 
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+    class="ant-pro-form-light-filter ant-pro-form-light-filter-middle ant-pro-form-light-filter-effective"
   >
     <div
       class="ant-pro-form-light-filter-container"
@@ -6965,7 +6965,7 @@ exports[`form demos renders ./packages/form/src/demos/light-filter-collapse.tsx 
   class="ant-form ant-form-horizontal"
 >
   <div
-    class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+    class="ant-pro-form-light-filter ant-pro-form-light-filter-middle ant-pro-form-light-filter-effective"
   >
     <div
       class="ant-pro-form-light-filter-container"
@@ -6978,7 +6978,7 @@ exports[`form demos renders ./packages/form/src/demos/light-filter-collapse.tsx 
         >
           <span
             aria-label="filter"
-            class="anticon anticon-filter"
+            class="anticon anticon-filter ant-pro-form-light-filter-collapse-icon"
             role="img"
           >
             <svg

--- a/tests/form/lightFilter.test.tsx
+++ b/tests/form/lightFilter.test.tsx
@@ -355,6 +355,8 @@ describe('LightFilter', () => {
       </LightFilter>,
     );
 
+    expect(wrapper.find('.collapselabel').text()).toEqual('open');
+    expect(wrapper.find('.ant-pro-form-light-filter-effective').length).toEqual(1);
     wrapper.find('.collapselabel').simulate('click');
     expect(wrapper.find('.ant-select-selection-item').text()).toEqual('蚂蚁');
 
@@ -363,6 +365,7 @@ describe('LightFilter', () => {
     wrapper.find('.ant-btn-primary').simulate('click');
 
     expect(onChange).toHaveBeenCalledWith(undefined);
+    expect(wrapper.find('.ant-pro-form-light-filter-effective').length).toEqual(0);
 
     wrapper.unmount();
   });

--- a/tests/list/__snapshots__/demo.test.ts.snap
+++ b/tests/list/__snapshots__/demo.test.ts.snap
@@ -1099,7 +1099,7 @@ exports[`list demos renders ./packages/list/src/demos/filter.tsx correctly 1`] =
                   class="ant-form ant-form-horizontal"
                 >
                   <div
-                    class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+                    class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
                   >
                     <div
                       class="ant-pro-form-light-filter-container"

--- a/tests/table/__snapshots__/demo.test.ts.snap
+++ b/tests/table/__snapshots__/demo.test.ts.snap
@@ -117,7 +117,7 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/basic.tsx co
             style="margin-top: 16px;"
           >
             <div
-              class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+              class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
             >
               <div
                 class="ant-pro-form-light-filter-container"
@@ -1105,7 +1105,7 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/multipleLine
           style="margin-top: 8px;"
         >
           <div
-            class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+            class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
           >
             <div
               class="ant-pro-form-light-filter-container"
@@ -1275,7 +1275,7 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/no-title.tsx
           style="margin-top: 16px;"
         >
           <div
-            class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+            class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
           >
             <div
               class="ant-pro-form-light-filter-container"
@@ -2011,7 +2011,7 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/tabs.tsx cor
                 style="margin-top: 8px;"
               >
                 <div
-                  class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+                  class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
                 >
                   <div
                     class="ant-pro-form-light-filter-container"
@@ -6152,7 +6152,7 @@ exports[`table demos renders ./packages/table/src/demos/lightfilter.tsx correctl
                   class="ant-form ant-form-horizontal"
                 >
                   <div
-                    class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+                    class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
                   >
                     <div
                       class="ant-pro-form-light-filter-container"
@@ -9003,7 +9003,7 @@ exports[`table demos renders ./packages/table/src/demos/listToolBar.tsx correctl
                     style="margin-top: 8px;"
                   >
                     <div
-                      class="ant-pro-form-light-filter ant-pro-form-light-filter-undefined"
+                      class="ant-pro-form-light-filter ant-pro-form-light-filter-middle"
                     >
                       <div
                         class="ant-pro-form-light-filter-container"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1061968/96227871-52faaa80-0fc7-11eb-966e-90e814dfb873.png)

在筛选生效状态，加一个灰色的底。色值 4% 000000。