### PR TITLE
refactor(layout): SettingDrawer card style

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        # Fail the status if coverage drops by >= 0.1%
+        threshold: 0.1

--- a/packages/layout/src/SettingDrawer/BlockCheckbox.tsx
+++ b/packages/layout/src/SettingDrawer/BlockCheckbox.tsx
@@ -9,7 +9,6 @@ export interface BlockCheckboxProps {
   list?: {
     title: string;
     key: string;
-    url: string;
   }[];
   configType: string;
   prefixCls: string;

--- a/packages/layout/src/SettingDrawer/BlockCheckbox.tsx
+++ b/packages/layout/src/SettingDrawer/BlockCheckbox.tsx
@@ -1,7 +1,7 @@
-import { CheckOutlined } from '@ant-design/icons';
-import { Tooltip } from 'antd';
-
 import React, { useState, useEffect } from 'react';
+import { Tooltip } from 'antd';
+import { CheckOutlined } from '@ant-design/icons';
+import classNames from 'classnames';
 
 export interface BlockCheckboxProps {
   value: string;
@@ -26,25 +26,23 @@ const BlockCheckbox: React.FC<BlockCheckboxProps> = ({
   const [dom, setDom] = useState<JSX.Element[]>([]);
   useEffect(() => {
     const domList = (list || []).map((item) => (
-      <div
-        key={item.key}
-        className={`${baseClassName}-item  ${baseClassName}-${configType}-item`}
-        onClick={() => {
-          onChange(item.key);
-        }}
-      >
-        <Tooltip title={item.title} key={item.key}>
-          <img src={item.url} alt={item.key} />
-        </Tooltip>
+      <Tooltip title={item.title} key={item.key}>
         <div
-          className={`${baseClassName}-selectIcon`}
-          style={{
-            display: value === item.key ? 'block' : 'none',
-          }}
+          className={classNames(
+            `${baseClassName}-item`,
+            `${baseClassName}-item-${item.key}`,
+            `${baseClassName}-${configType}-item`,
+          )}
+          onClick={() => onChange(item.key)}
         >
-          <CheckOutlined />
+          <CheckOutlined
+            className={`${baseClassName}-selectIcon`}
+            style={{
+              display: value === item.key ? 'block' : 'none',
+            }}
+          />
         </div>
-      </div>
+      </Tooltip>
     ));
     setDom(domList);
   }, [value, list?.length]);

--- a/packages/layout/src/SettingDrawer/index.less
+++ b/packages/layout/src/SettingDrawer/index.less
@@ -18,11 +18,79 @@
     &-item {
       position: relative;
       margin-right: 16px;
-      box-shadow: 0 2px 3px rgba(0, 0, 0, 0.12);
-      border-radius: @border-radius-base;
+      box-shadow: 0 1px 2.5px 0 rgba(0, 0, 0, 0.18);
+      border-radius: 4px;
+      overflow: hidden;
       cursor: pointer;
-      width: 48px;
-      height: 48px;
+      width: 44px;
+      height: 36px;
+      background-color: #f0f2f5;
+
+      &::before {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 33%;
+        height: 100%;
+        background-color: #fff;
+        content: '';
+      }
+      &::after {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 25%;
+        background-color: #fff;
+        content: '';
+      }
+
+      // 亮色主题
+      &-light {
+        &::before {
+          background-color: #fff;
+          content: '';
+        }
+        &::after {
+          background-color: #fff;
+        }
+      }
+
+      // 暗色主题
+      &-dark,
+      // 侧边菜单布局
+      &-side {
+        &::before {
+          background-color: @menu-dark-bg;
+          content: '';
+          z-index: 1;
+        }
+        &::after {
+          background-color: #fff;
+        }
+      }
+
+      // 顶部菜单布局
+      &-top {
+        &::before {
+          background-color: transparent;
+          content: '';
+        }
+        &::after {
+          background-color: @menu-dark-bg;
+        }
+      }
+
+      // 顶部菜单布局
+      &-mix {
+        &::before {
+          background-color: #fff;
+          content: '';
+        }
+        &::after {
+          background-color: @menu-dark-bg;
+        }
+      }
     }
     &-selectIcon {
       position: absolute;

--- a/packages/layout/src/SettingDrawer/index.less
+++ b/packages/layout/src/SettingDrawer/index.less
@@ -18,24 +18,20 @@
     &-item {
       position: relative;
       margin-right: 16px;
-      // box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+      box-shadow: 0 2px 3px rgba(0, 0, 0, 0.12);
       border-radius: @border-radius-base;
       cursor: pointer;
-      img {
-        width: 48px;
-      }
+      width: 48px;
+      height: 48px;
     }
     &-selectIcon {
       position: absolute;
-      top: 0;
-      right: 0;
-      width: 100%;
-      height: 100%;
-      padding-top: 15px;
-      padding-left: 24px;
+      bottom: 4px;
+      right: 6px;
       color: @primary-color;
       font-weight: bold;
       font-size: 14px;
+      pointer-events: none;
       .action {
         color: @primary-color;
       }

--- a/packages/layout/src/SettingDrawer/index.tsx
+++ b/packages/layout/src/SettingDrawer/index.tsx
@@ -186,7 +186,6 @@ const getThemeList = (settings: Partial<ProSettings>) => {
   const themeList = [
     {
       key: 'light',
-      url: 'https://gw.alipayobjects.com/zos/antfincdn/NQ%24zoisaD2/jpRkZQMyYRryryPNtyIC.svg',
       title: formatMessage({ id: 'app.setting.pagestyle.light' }),
     },
   ];
@@ -217,7 +216,6 @@ const getThemeList = (settings: Partial<ProSettings>) => {
   if (settings.layout !== 'mix') {
     themeList.push({
       key: 'dark',
-      url: 'https://gw.alipayobjects.com/zos/antfincdn/XwFOFbLkSM/LCkqqYNmvBEbokSDscrm.svg',
       title: formatMessage({
         id: 'app.setting.pagestyle.dark',
         defaultMessage: '',
@@ -228,7 +226,6 @@ const getThemeList = (settings: Partial<ProSettings>) => {
   if (list.find((item) => item.theme === 'dark')) {
     themeList.push({
       key: 'realDark',
-      url: 'https://gw.alipayobjects.com/zos/antfincdn/hmKaLQvmY2/LCkqqYNmvBEbokSDscrm.svg',
       title: formatMessage({
         id: 'app.setting.pagestyle.dark',
         defaultMessage: '',
@@ -578,20 +575,14 @@ const SettingDrawer: React.FC<SettingDrawerProps> = (props) => {
             list={[
               {
                 key: 'side',
-                url:
-                  'https://gw.alipayobjects.com/zos/antfincdn/XwFOFbLkSM/LCkqqYNmvBEbokSDscrm.svg',
                 title: formatMessage({ id: 'app.setting.sidemenu' }),
               },
               {
                 key: 'top',
-                url:
-                  'https://gw.alipayobjects.com/zos/antfincdn/URETY8%24STp/KDNDBbriJhLwuqMoxcAr.svg',
                 title: formatMessage({ id: 'app.setting.topmenu' }),
               },
               {
                 key: 'mix',
-                url:
-                  'https://gw.alipayobjects.com/zos/antfincdn/x8Ob%26B8cy8/LCkqqYNmvBEbokSDscrm.svg',
                 title: formatMessage({ id: 'app.setting.mixmenu' }),
               },
             ]}

--- a/packages/layout/src/SettingDrawer/index.tsx
+++ b/packages/layout/src/SettingDrawer/index.tsx
@@ -650,8 +650,8 @@ const SettingDrawer: React.FC<SettingDrawerProps> = (props) => {
             text={genCopySettingJson(settingState)}
             onCopy={() => message.success(formatMessage({ id: 'app.setting.copyinfo' }))}
           >
-            <Button block>
-              <CopyOutlined /> {formatMessage({ id: 'app.setting.copy' })}
+            <Button block icon={<CopyOutlined />} style={{ marginBottom: 24 }}>
+              {formatMessage({ id: 'app.setting.copy' })}
             </Button>
           </CopyToClipboard>
         )}

--- a/tests/layout/__snapshots__/demo.test.ts.snap
+++ b/tests/layout/__snapshots__/demo.test.ts.snap
@@ -7606,70 +7606,54 @@ Array [
                   style="min-height: 42px;"
                 >
                   <div
-                    class="ant-pro-setting-drawer-block-checkbox-item  ant-pro-setting-drawer-block-checkbox-theme-item"
+                    class="ant-pro-setting-drawer-block-checkbox-item ant-pro-setting-drawer-block-checkbox-item-light ant-pro-setting-drawer-block-checkbox-theme-item"
                   >
-                    <img
-                      alt="light"
-                      src="https://gw.alipayobjects.com/zos/antfincdn/NQ%24zoisaD2/jpRkZQMyYRryryPNtyIC.svg"
-                    />
-                    <div
-                      class="ant-pro-setting-drawer-block-checkbox-selectIcon"
+                    <span
+                      aria-label="check"
+                      class="anticon anticon-check ant-pro-setting-drawer-block-checkbox-selectIcon"
+                      role="img"
                       style="display: none;"
                     >
-                      <span
-                        aria-label="check"
-                        class="anticon anticon-check"
-                        role="img"
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="check"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class=""
-                          data-icon="check"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                          />
-                        </svg>
-                      </span>
-                    </div>
+                        <path
+                          d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                        />
+                      </svg>
+                    </span>
                   </div>
                   <div
-                    class="ant-pro-setting-drawer-block-checkbox-item  ant-pro-setting-drawer-block-checkbox-theme-item"
+                    class="ant-pro-setting-drawer-block-checkbox-item ant-pro-setting-drawer-block-checkbox-item-dark ant-pro-setting-drawer-block-checkbox-theme-item"
                   >
-                    <img
-                      alt="dark"
-                      src="https://gw.alipayobjects.com/zos/antfincdn/XwFOFbLkSM/LCkqqYNmvBEbokSDscrm.svg"
-                    />
-                    <div
-                      class="ant-pro-setting-drawer-block-checkbox-selectIcon"
+                    <span
+                      aria-label="check"
+                      class="anticon anticon-check ant-pro-setting-drawer-block-checkbox-selectIcon"
+                      role="img"
                       style="display: block;"
                     >
-                      <span
-                        aria-label="check"
-                        class="anticon anticon-check"
-                        role="img"
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="check"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class=""
-                          data-icon="check"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                          />
-                        </svg>
-                      </span>
-                    </div>
+                        <path
+                          d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                        />
+                      </svg>
+                    </span>
                   </div>
                 </div>
               </div>
@@ -7732,103 +7716,79 @@ Array [
                   style="min-height: 42px;"
                 >
                   <div
-                    class="ant-pro-setting-drawer-block-checkbox-item  ant-pro-setting-drawer-block-checkbox-layout-item"
+                    class="ant-pro-setting-drawer-block-checkbox-item ant-pro-setting-drawer-block-checkbox-item-side ant-pro-setting-drawer-block-checkbox-layout-item"
                   >
-                    <img
-                      alt="side"
-                      src="https://gw.alipayobjects.com/zos/antfincdn/XwFOFbLkSM/LCkqqYNmvBEbokSDscrm.svg"
-                    />
-                    <div
-                      class="ant-pro-setting-drawer-block-checkbox-selectIcon"
+                    <span
+                      aria-label="check"
+                      class="anticon anticon-check ant-pro-setting-drawer-block-checkbox-selectIcon"
+                      role="img"
                       style="display: block;"
                     >
-                      <span
-                        aria-label="check"
-                        class="anticon anticon-check"
-                        role="img"
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="check"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class=""
-                          data-icon="check"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                          />
-                        </svg>
-                      </span>
-                    </div>
+                        <path
+                          d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                        />
+                      </svg>
+                    </span>
                   </div>
                   <div
-                    class="ant-pro-setting-drawer-block-checkbox-item  ant-pro-setting-drawer-block-checkbox-layout-item"
+                    class="ant-pro-setting-drawer-block-checkbox-item ant-pro-setting-drawer-block-checkbox-item-top ant-pro-setting-drawer-block-checkbox-layout-item"
                   >
-                    <img
-                      alt="top"
-                      src="https://gw.alipayobjects.com/zos/antfincdn/URETY8%24STp/KDNDBbriJhLwuqMoxcAr.svg"
-                    />
-                    <div
-                      class="ant-pro-setting-drawer-block-checkbox-selectIcon"
+                    <span
+                      aria-label="check"
+                      class="anticon anticon-check ant-pro-setting-drawer-block-checkbox-selectIcon"
+                      role="img"
                       style="display: none;"
                     >
-                      <span
-                        aria-label="check"
-                        class="anticon anticon-check"
-                        role="img"
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="check"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class=""
-                          data-icon="check"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                          />
-                        </svg>
-                      </span>
-                    </div>
+                        <path
+                          d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                        />
+                      </svg>
+                    </span>
                   </div>
                   <div
-                    class="ant-pro-setting-drawer-block-checkbox-item  ant-pro-setting-drawer-block-checkbox-layout-item"
+                    class="ant-pro-setting-drawer-block-checkbox-item ant-pro-setting-drawer-block-checkbox-item-mix ant-pro-setting-drawer-block-checkbox-layout-item"
                   >
-                    <img
-                      alt="mix"
-                      src="https://gw.alipayobjects.com/zos/antfincdn/x8Ob%26B8cy8/LCkqqYNmvBEbokSDscrm.svg"
-                    />
-                    <div
-                      class="ant-pro-setting-drawer-block-checkbox-selectIcon"
+                    <span
+                      aria-label="check"
+                      class="anticon anticon-check ant-pro-setting-drawer-block-checkbox-selectIcon"
+                      role="img"
                       style="display: none;"
                     >
-                      <span
-                        aria-label="check"
-                        class="anticon anticon-check"
-                        role="img"
+                      <svg
+                        aria-hidden="true"
+                        class=""
+                        data-icon="check"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
                       >
-                        <svg
-                          aria-hidden="true"
-                          class=""
-                          data-icon="check"
-                          fill="currentColor"
-                          focusable="false"
-                          height="1em"
-                          viewBox="64 64 896 896"
-                          width="1em"
-                        >
-                          <path
-                            d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
-                          />
-                        </svg>
-                      </span>
-                    </div>
+                        <path
+                          d="M912 190h-69.9c-9.8 0-19.1 4.5-25.1 12.2L404.7 724.5 207 474a32 32 0 00-25.1-12.2H112c-6.7 0-10.4 7.7-6.3 12.9l273.9 347c12.8 16.2 37.4 16.2 50.3 0l488.4-618.9c4.1-5.1.4-12.8-6.3-12.8z"
+                        />
+                      </svg>
+                    </span>
                   </div>
                 </div>
               </div>
@@ -8249,6 +8209,7 @@ Array [
               </div>
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom: 24px;"
                 type="button"
               >
                 <span
@@ -8272,7 +8233,7 @@ Array [
                   </svg>
                 </span>
                 <span>
-                   拷贝设置
+                  拷贝设置
                 </span>
               </button>
             </div>

--- a/tests/layout/__snapshots__/settingDrawer.test.tsx.snap
+++ b/tests/layout/__snapshots__/settingDrawer.test.tsx.snap
@@ -546,6 +546,7 @@ exports[`settingDrawer.test base user 1`] = `
               </div>
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom:24px"
                 type="button"
               >
                 <span
@@ -569,7 +570,7 @@ exports[`settingDrawer.test base user 1`] = `
                   </svg>
                 </span>
                 <span>
-                   Copy Setting
+                  Copy Setting
                 </span>
               </button>
             </div>
@@ -1119,6 +1120,7 @@ exports[`settingDrawer.test hideColors = true 1`] = `
               </div>
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom:24px"
                 type="button"
               >
                 <span
@@ -1142,7 +1144,7 @@ exports[`settingDrawer.test hideColors = true 1`] = `
                   </svg>
                 </span>
                 <span>
-                   Copy Setting
+                  Copy Setting
                 </span>
               </button>
             </div>
@@ -2268,6 +2270,7 @@ exports[`settingDrawer.test hideHintAlert = true 1`] = `
               />
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom:24px"
                 type="button"
               >
                 <span
@@ -2291,7 +2294,7 @@ exports[`settingDrawer.test hideHintAlert = true 1`] = `
                   </svg>
                 </span>
                 <span>
-                   Copy Setting
+                  Copy Setting
                 </span>
               </button>
             </div>
@@ -2874,6 +2877,7 @@ exports[`settingDrawer.test hideLoading = true 1`] = `
               </div>
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom:24px"
                 type="button"
               >
                 <span
@@ -2897,7 +2901,7 @@ exports[`settingDrawer.test hideLoading = true 1`] = `
                   </svg>
                 </span>
                 <span>
-                   Copy Setting
+                  Copy Setting
                 </span>
               </button>
             </div>
@@ -3479,6 +3483,7 @@ exports[`settingDrawer.test settings = undefined 1`] = `
               </div>
               <button
                 class="ant-btn ant-btn-block"
+                style="margin-bottom:24px"
                 type="button"
               >
                 <span
@@ -3502,7 +3507,7 @@ exports[`settingDrawer.test settings = undefined 1`] = `
                   </svg>
                 </span>
                 <span>
-                   Copy Setting
+                  Copy Setting
                 </span>
               </button>
             </div>


### PR DESCRIPTION
- [x] **移除这几个 svg 文件，直接用 css 伪类 + 阴影实现**。
- [x] 修复当前选中的主题/布局 hover 没有 tooltip 的问题。
- [x] 修复最下面的拷贝 button 没有 margin bottom。
- [x] 简单优化了一下 dom 结构。

对比一下效果
| svg | css 伪类 :new: |
| --- | --- |
| <img width="292" alt="截屏2020-10-22 下午1 23 49" src="https://user-images.githubusercontent.com/507615/96828747-c3437900-146a-11eb-8771-e7a1e925514d.png"> | <img width="223" alt="image" src="https://user-images.githubusercontent.com/507615/96828685-ad35b880-146a-11eb-90a7-1bed132cc6c0.png"> |



