### PR TITLE
fix(pro-table):  table 工具栏：options为false时，不显示父级节点

### DIFF
--- a/packages/table/src/component/ListToolBar/index.tsx
+++ b/packages/table/src/component/ListToolBar/index.tsx
@@ -192,17 +192,19 @@ const ListToolBar: React.FC<ListToolBarProps> = ({
           {hasTitle && searchNode && <div className={`${prefixCls}-search`}>{searchNode}</div>}
           {!multipleLine && filtersNode}
           <Space align="center">{actions}</Space>
-          <Space size={24} align="center" className={`${prefixCls}-setting-items`}>
-            {settings.map((setting, index) => {
-              const settingItem = getSettingItem(setting);
-              return (
-                // eslint-disable-next-line react/no-array-index-key
-                <div key={index} className={`${prefixCls}-setting-item`}>
-                  {settingItem}
-                </div>
-              );
-            })}
-          </Space>
+          {settings.length > 0 && (
+            <Space size={24} align="center" className={`${prefixCls}-setting-items`}>
+              {settings.map((setting, index) => {
+                const settingItem = getSettingItem(setting);
+                return (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div key={index} className={`${prefixCls}-setting-item`}>
+                    {settingItem}
+                  </div>
+                );
+              })}
+            </Space>
+          )}
         </Space>
       </div>
       {multipleLine && (
@@ -214,8 +216,8 @@ const ListToolBar: React.FC<ListToolBarProps> = ({
               ))}
             </Tabs>
           ) : (
-            filtersNode
-          )}
+              filtersNode
+            )}
         </div>
       )}
     </div>

--- a/tests/list/__snapshots__/demo.test.ts.snap
+++ b/tests/list/__snapshots__/demo.test.ts.snap
@@ -33,7 +33,6 @@ exports[`list demos renders ./packages/list/src/demos/base.tsx correctly 1`] = `
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -52,9 +51,6 @@ exports[`list demos renders ./packages/list/src/demos/base.tsx correctly 1`] = `
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -588,7 +584,6 @@ exports[`list demos renders ./packages/list/src/demos/expand.tsx correctly 1`] =
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -607,9 +602,6 @@ exports[`list demos renders ./packages/list/src/demos/expand.tsx correctly 1`] =
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -1293,7 +1285,6 @@ exports[`list demos renders ./packages/list/src/demos/filter.tsx correctly 1`] =
             </div>
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -1312,9 +1303,6 @@ exports[`list demos renders ./packages/list/src/demos/filter.tsx correctly 1`] =
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -1504,7 +1492,6 @@ exports[`list demos renders ./packages/list/src/demos/layout.tsx correctly 1`] =
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -1523,9 +1510,6 @@ exports[`list demos renders ./packages/list/src/demos/layout.tsx correctly 1`] =
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -2249,10 +2233,6 @@ exports[`list demos renders ./packages/list/src/demos/pagination.tsx correctly 1
           <div
             class="ant-space ant-space-horizontal ant-space-align-center ant-pro-table-list-toolbar-right"
           >
-            <div
-              class="ant-space-item"
-              style="margin-right: 8px;"
-            />
             <div
               class="ant-space-item"
             />
@@ -3170,7 +3150,6 @@ exports[`list demos renders ./packages/list/src/demos/selectedRow.tsx correctly 
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -3189,9 +3168,6 @@ exports[`list demos renders ./packages/list/src/demos/selectedRow.tsx correctly 
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -3857,7 +3833,6 @@ Array [
             >
               <div
                 class="ant-space-item"
-                style="margin-right: 8px;"
               >
                 <div
                   class="ant-space ant-space-horizontal ant-space-align-center"
@@ -3876,9 +3851,6 @@ Array [
                   </div>
                 </div>
               </div>
-              <div
-                class="ant-space-item"
-              />
             </div>
           </div>
         </div>
@@ -4345,7 +4317,6 @@ exports[`list demos renders ./packages/list/src/demos/special.tsx correctly 1`] 
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -4364,9 +4335,6 @@ exports[`list demos renders ./packages/list/src/demos/special.tsx correctly 1`] 
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>

--- a/tests/table/__snapshots__/demo.test.ts.snap
+++ b/tests/table/__snapshots__/demo.test.ts.snap
@@ -368,7 +368,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/custom-title
     >
       <div
         class="ant-space-item"
-        style="margin-right: 8px;"
       >
         <div
           class="ant-space ant-space-horizontal ant-space-align-center"
@@ -387,9 +386,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/custom-title
           </div>
         </div>
       </div>
-      <div
-        class="ant-space-item"
-      />
     </div>
   </div>
 </div>
@@ -522,7 +518,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/list.tsx cor
           </div>
           <div
             class="ant-space-item"
-            style="margin-right: 8px;"
           >
             <div
               class="ant-space ant-space-horizontal ant-space-align-center"
@@ -541,9 +536,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/list.tsx cor
               </div>
             </div>
           </div>
-          <div
-            class="ant-space-item"
-          />
         </div>
       </div>
     </div>
@@ -732,10 +724,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/menu.tsx cor
             </span>
           </div>
         </div>
-        <div
-          class="ant-space-item"
-          style="margin-right: 8px;"
-        />
         <div
           class="ant-space-item"
         />
@@ -1008,10 +996,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/menu.tsx cor
             </span>
           </div>
         </div>
-        <div
-          class="ant-space-item"
-          style="margin-right: 8px;"
-        />
         <div
           class="ant-space-item"
         />
@@ -1517,7 +1501,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/no-title.tsx
       </div>
       <div
         class="ant-space-item"
-        style="margin-right: 8px;"
       >
         <div
           class="ant-space ant-space-horizontal ant-space-align-center"
@@ -1536,9 +1519,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/no-title.tsx
           </div>
         </div>
       </div>
-      <div
-        class="ant-space-item"
-      />
     </div>
   </div>
 </div>
@@ -1667,7 +1647,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/table.tsx co
         </div>
         <div
           class="ant-space-item"
-          style="margin-right: 8px;"
         >
           <div
             class="ant-space ant-space-horizontal ant-space-align-center"
@@ -1686,9 +1665,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/table.tsx co
             </div>
           </div>
         </div>
-        <div
-          class="ant-space-item"
-        />
       </div>
     </div>
   </div>
@@ -2096,10 +2072,6 @@ exports[`table demos renders ./packages/table/src/demos/ListToolBar/tabs.tsx cor
         </div>
         <div
           class="ant-space-item"
-          style="margin-right: 8px;"
-        />
-        <div
-          class="ant-space-item"
         />
       </div>
     </div>
@@ -2366,7 +2338,6 @@ exports[`table demos renders ./packages/table/src/demos/batchOption.tsx correctl
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -2385,9 +2356,6 @@ exports[`table demos renders ./packages/table/src/demos/batchOption.tsx correctl
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -9555,7 +9523,6 @@ exports[`table demos renders ./packages/table/src/demos/form.tsx correctly 1`] =
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -9574,9 +9541,6 @@ exports[`table demos renders ./packages/table/src/demos/form.tsx correctly 1`] =
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>
@@ -28192,7 +28156,6 @@ exports[`table demos renders ./packages/table/src/demos/table-nested.tsx correct
           >
             <div
               class="ant-space-item"
-              style="margin-right: 8px;"
             >
               <div
                 class="ant-space ant-space-horizontal ant-space-align-center"
@@ -28257,9 +28220,6 @@ exports[`table demos renders ./packages/table/src/demos/table-nested.tsx correct
                 </div>
               </div>
             </div>
-            <div
-              class="ant-space-item"
-            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
fix  #865 