### PR TITLE
fix(table.md): 修改ProTable文档中参数actionRef返回的函数

### DIFF
--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -256,7 +256,7 @@ const defaultColConfig = {
 
 ```tsx | pure
 interface ActionType {
-  reload: () => void;
+  reload: (resetPageIndex?: boolean) => void;
   fetchMore: () => void;
   reset: () => void;
 }
@@ -268,8 +268,8 @@ const ref = useRef<ActionType>();
 // 刷新
 ref.current.reload();
 
-// 加载更多
-ref.current.fetchMore();
+// 刷新并清空
+ref.current.reloadAndRest;
 
 // 重置到默认值
 ref.current.reset();


### PR DESCRIPTION
现在的文档好像没更新，`actionRef`返回的函数已经没有`fetchMore`了，改成`reloadAndRest`

![image](https://user-images.githubusercontent.com/31716713/98217146-0af6f400-1f85-11eb-9d9e-0e6139c38e05.png)
