### PR TITLE
fix(SettingDrawer): 修复主题色 Tooltip 无提示信息问题

### DIFF
--- a/packages/layout/src/SettingDrawer/ThemeColor.less
+++ b/packages/layout/src/SettingDrawer/ThemeColor.less
@@ -1,7 +1,7 @@
 @import './index.less';
 .@{ant-pro-setting-drawer}-content {
   .theme-color {
-    margin-top: 24px;
+    margin-top: 16px;
     overflow: hidden;
     .theme-color-title {
       margin-bottom: 12px;
@@ -13,6 +13,7 @@
       width: 20px;
       height: 20px;
       margin-right: 8px;
+      margin-top: 8px;
       color: #fff;
       font-weight: bold;
       text-align: center;

--- a/packages/layout/src/SettingDrawer/ThemeColor.tsx
+++ b/packages/layout/src/SettingDrawer/ThemeColor.tsx
@@ -42,7 +42,7 @@ const ThemeColor: React.ForwardRefRenderFunction<HTMLDivElement, ThemeColorProps
     <div className="theme-color" ref={ref}>
       <div className="theme-color-content">
         {colorList.map(({ key, color }) => {
-          const themeKey = genThemeToString(key);
+          const themeKey = genThemeToString(color) || key;
           return (
             <Tooltip
               key={color}


### PR DESCRIPTION
在 ThemeColor.tsx 文件的 45 行的 genThemeToString() 方法是根据 color 获取到 key 值，而此时传入 colorList 中的 key 与方法需要的参数信息不一致，导致 genThemeToString(key) 一直返回 undefined 因此导致 Tooltip 无提示内容（50-54行）。

45行修改后在其后添加一个默认的 key 是为了在自定义主题色（不存在系统预设列表中）时也可以显示 Tooltip 内容