### PR TITLE
feat(card): add direction type

### DIFF
--- a/packages/card/src/index.tsx
+++ b/packages/card/src/index.tsx
@@ -80,7 +80,7 @@ export type ProCardProps = {
   /**
    * 指定 Flex 方向，仅在嵌套子卡片时有效
    */
-  direction?: 'column';
+  direction?: 'column' | 'row';
   /**
    * 加载中
    */


### PR DESCRIPTION
缺失类型，在做 `direction={screens.md ? 'row' : 'column'}` 这样的格式时会类型错误