### PR TITLE
fix: repeat loading, cache data

### DIFF
--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -25,6 +25,11 @@ import { ProFieldFC } from '../../index';
 
 let testId = 0;
 
+let cacheData: {
+  label: React.ReactNode;
+  value: React.ReactText;
+}[] = [];
+
 export type ProFieldValueEnumType = ProSchemaValueEnumMap | ProSchemaValueEnumObj;
 
 export const ObjToMap = (value: ProFieldValueEnumType | undefined): ProSchemaValueEnumMap => {
@@ -225,9 +230,10 @@ export const useFieldFetchData = (
   const { data, mutate } = useSWR(
     [proFieldKeyRef.current, JSON.stringify(props.params)],
     async () => {
-      if (props.request) {
+      if (props.request && !cacheData.length) {
         setLoading(true);
         const fetchData = await props.request(props.params, props);
+        cacheData = fetchData;
         setLoading(false);
         return fetchData;
       }
@@ -277,7 +283,6 @@ const FieldSelect: ProFieldFC<FieldSelectProps> = (props, ref) => {
   }, []);
 
   const [loading, options, fetchData] = useFieldFetchData(props);
-
   const size = useContext(SizeContext);
   useImperativeHandle(ref, () => ({
     ...(inputRef.current || {}),

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -235,7 +235,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 | searchText | 查询按钮的文本 | string | 查询 |
 | resetText | 重置按钮的文本 | string | 重置 |
 | submitText | 提交按钮的文本 | string | 提交 |
-| labelWidth | 标签的宽度 | number | 98 |
+| labelWidth | 标签的宽度 | `'number'` \| `'auto'` | 80 |
 | span | 配置查询表单的列数 | `'number'` \| [`'ColConfig'`](#ColConfig) | defaultColConfig |
 | collapseRender | 收起按钮的 render | `(collapsed: boolean,showCollapseButton?: boolean,) => React.ReactNode` | - |
 | defaultCollapsed | 默认是否收起 | boolean | false |


### PR DESCRIPTION
🐛 bug 描述
ProTable组件的搜索表单，在多个字段展开和收起的时候，会调用请求接口请求数据

📷 复现步骤
https://codesandbox.io/s/peaceful-dream-u0yol
点击展开和收起，会调用请求接口

🏞 期望结果
请求一次就可以缓存起来，不需要重复请求。

💻 复现代码
https://codesandbox.io/s/peaceful-dream-u0yol

🚑 其他信息
无