### PR TITLE
docs: labelWidth 增加'auto'，默认值修改为80

### DIFF
--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -235,7 +235,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 | searchText | 查询按钮的文本 | string | 查询 |
 | resetText | 重置按钮的文本 | string | 重置 |
 | submitText | 提交按钮的文本 | string | 提交 |
-| labelWidth | 标签的宽度 | number | 98 |
+| labelWidth | 标签的宽度 | `'number'` \| `'auto'` | 80 |
 | span | 配置查询表单的列数 | `'number'` \| [`'ColConfig'`](#ColConfig) | defaultColConfig |
 | collapseRender | 收起按钮的 render | `(collapsed: boolean,showCollapseButton?: boolean,) => React.ReactNode` | - |
 | defaultCollapsed | 默认是否收起 | boolean | false |


### PR DESCRIPTION
labelWidth是可以传`'auto'`这个属性的。而且默认值是80。
这些和文档都有出入。