### PR TITLE
feat(table):  add "colSize" in fieldProps within proTable's columns to customize query form item width

### DIFF
--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -129,6 +129,8 @@ export const formInputRender: React.FC<{
       ? (itemValueType({}, type) as ProFieldValueType)
       : itemValueType) as ProFieldValueType) || 'text';
 
+  const { onChange, colSize, ...restFieldProps } = item.fieldProps || {};
+
   /**
    * 自定义 render
    */
@@ -179,13 +181,12 @@ export const formInputRender: React.FC<{
           ...item.fieldProps,
         }}
         formItemProps={formItemProps}
+        colSize={colSize}
       >
         {React.cloneElement(dom, { ...rest, ...defaultProps })}
       </ProFormField>
     );
   }
-
-  const { onChange, ...restFieldProps } = item.fieldProps || {};
 
   const finalValueType =
     !valueType || (['textarea', 'jsonCode', 'code'].includes(valueType) && type === 'table')
@@ -216,6 +217,7 @@ export const formInputRender: React.FC<{
       }}
       rules={undefined}
       key={`${item.dataIndex || ''}-${item.key || ''}-${item.index}`}
+      colSize={colSize}
     />
   );
 };

--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -136,7 +136,7 @@ export const formInputRender: React.FC<{
       ? (itemValueType({}, type) as ProFieldValueType)
       : itemValueType) as ProFieldValueType) || 'text';
 
-  const { onChange, colSize, ...restFieldProps } = item.fieldProps || {};
+  const { colSize } = item.fieldProps || {};
 
   /**
    * 自定义 render

--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -136,7 +136,11 @@ export const formInputRender: React.FC<{
       ? (itemValueType({}, type) as ProFieldValueType)
       : itemValueType) as ProFieldValueType) || 'text';
 
-  const { colSize } = item.fieldProps || {};
+  const { onChange, colSize, ...restFieldProps } = getFieldPropsOrFormItemProps(
+    item.fieldProps || {},
+    form,
+    item,
+  );
 
   /**
    * 自定义 render
@@ -194,12 +198,6 @@ export const formInputRender: React.FC<{
       </ProFormField>
     );
   }
-
-  const { onChange, ...restFieldProps } = getFieldPropsOrFormItemProps(
-    item.fieldProps || {},
-    form,
-    item,
-  );
 
   const finalValueType =
     !valueType || (['textarea', 'jsonCode', 'code'].includes(valueType) && type === 'table')

--- a/packages/table/src/Form/index.tsx
+++ b/packages/table/src/Form/index.tsx
@@ -140,7 +140,7 @@ export const formInputRender: React.FC<{
     item.fieldProps || {},
     form,
     item,
-  );
+  ) as any; 
 
   /**
    * 自定义 render

--- a/packages/table/src/demos/linkage_form.tsx
+++ b/packages/table/src/demos/linkage_form.tsx
@@ -67,12 +67,6 @@ export default () => {
       valueType: 'indexBorder',
     },
     {
-      title: '日期范围',
-      dataIndex: 'dateRange',
-      valueType: 'dateRange',
-      fieldProps: { colSize: 2 },
-    },
-    {
       title: '标题',
       dataIndex: 'name',
     },

--- a/packages/table/src/demos/linkage_form.tsx
+++ b/packages/table/src/demos/linkage_form.tsx
@@ -142,7 +142,6 @@ export default () => {
       dateFormatter="string"
       headerTitle="动态自定义搜索栏"
       search={{
-        span: 6,
         defaultCollapsed: false,
         optionRender: ({ searchText, resetText }, { form }) => [
           <Button

--- a/packages/table/src/demos/linkage_form.tsx
+++ b/packages/table/src/demos/linkage_form.tsx
@@ -67,6 +67,12 @@ export default () => {
       valueType: 'indexBorder',
     },
     {
+      title: '日期范围',
+      dataIndex: 'dateRange',
+      valueType: 'dateRange',
+      fieldProps: { colSize: 2 },
+    },
+    {
       title: '标题',
       dataIndex: 'name',
     },
@@ -136,6 +142,7 @@ export default () => {
       dateFormatter="string"
       headerTitle="动态自定义搜索栏"
       search={{
+        span: 6,
         defaultCollapsed: false,
         optionRender: ({ searchText, resetText }, { form }) => [
           <Button

--- a/packages/table/src/utils.tsx
+++ b/packages/table/src/utils.tsx
@@ -482,6 +482,7 @@ export const getFieldPropsOrFormItemProps = (
   extraProps?: any,
 ): Object & {
   onChange: any;
+  colSize: number;
 } => {
   if (typeof fieldProps === 'function') {
     return fieldProps(form, extraProps);


### PR DESCRIPTION
feat(table): 在columns中的fieldPorps对象中添加colSize,对应QueryFilter组件的colSize属性,以自定义查询表单项的宽度