### PR TITLE
feat(layout): support menu type group

### DIFF
--- a/packages/layout/src/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/SiderMenu/BaseMenu.tsx
@@ -60,7 +60,7 @@ export interface BaseMenuProps
   postMenuData?: (menusData?: MenuDataItem[]) => MenuDataItem[];
 }
 
-const { SubMenu } = Menu;
+const { SubMenu, ItemGroup } = Menu;
 
 let IconFont = createFromIconfontCN({
   scriptUrl: defaultSettings.iconfontUrl,
@@ -102,7 +102,7 @@ class MenuUtil {
   getSubMenuOrItem = (item: MenuDataItem, isChildren: boolean): React.ReactNode => {
     if (Array.isArray(item.children) && item && item.children.length > 0) {
       const name = this.getIntlName(item);
-      const { subMenuItemRender, prefixCls } = this.props;
+      const { subMenuItemRender, prefixCls, menu } = this.props;
       //  get defaultTitle by menuItemRender
       const defaultTitle = item.icon ? (
         <span className={`${prefixCls}-menu-item`}>
@@ -117,11 +117,11 @@ class MenuUtil {
       const title = subMenuItemRender
         ? subMenuItemRender({ ...item, isUrl: false }, defaultTitle)
         : defaultTitle;
-
+      const MenuComponents: React.ElementType = menu?.type === 'group' ? ItemGroup : SubMenu;
       return (
-        <SubMenu title={title} key={item.key || item.path} onTitleClick={item.onTitleClick}>
+        <MenuComponents title={title} key={item.key || item.path} onTitleClick={item.onTitleClick}>
           {this.getNavMenuItems(item.children, true)}
-        </SubMenu>
+        </MenuComponents>
       );
     }
 

--- a/packages/layout/src/defaultSettings.ts
+++ b/packages/layout/src/defaultSettings.ts
@@ -41,7 +41,7 @@ export interface PureSettings {
   /**
    * @name menu 相关的一些配置
    */
-  menu?: { locale?: boolean; defaultOpenAll?: boolean; loading?: boolean };
+  menu?: { locale?: boolean; defaultOpenAll?: boolean; loading?: boolean; type?: 'sub' | 'group' };
   /**
    * @name Layout 的 title，也会显示在浏览器标签上
    * @description 设置为 false，在 layout 中只展示 pageName，而不是 pageName - title

--- a/packages/layout/src/demos/MenuGroup.tsx
+++ b/packages/layout/src/demos/MenuGroup.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import ProLayout, { PageContainer } from '@ant-design/pro-layout';
+import complexMenu from './complexMenu';
+
+export default () => (
+  <div
+    style={{
+      height: '100vh',
+    }}
+  >
+    <ProLayout
+      location={{
+        pathname: '/data_hui/data_hui2',
+      }}
+      route={{
+        routes: complexMenu,
+      }}
+      menu={{ type: 'group' }}
+    >
+      <PageContainer content="欢迎使用">
+        <div>Hello World</div>
+      </PageContainer>
+    </ProLayout>
+  </div>
+);

--- a/tests/layout/__snapshots__/demo.test.ts.snap
+++ b/tests/layout/__snapshots__/demo.test.ts.snap
@@ -986,6 +986,379 @@ exports[`layout demos renders ./packages/layout/src/demos/IconFont.tsx correctly
 </div>
 `;
 
+exports[`layout demos renders ./packages/layout/src/demos/MenuGroup.tsx correctly 1`] = `
+<div
+  style="height: 100vh;"
+>
+  <div
+    class="ant-design-pro ant-pro-basicLayout screen-md ant-pro-basicLayout-side"
+  >
+    <section
+      class="ant-layout ant-layout-has-sider"
+      style="min-height: 100%;"
+    >
+      <aside
+        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-layout-side"
+        style="overflow: hidden; flex: 0 0 208px; max-width: 208px; min-width: 208px; width: 208px;"
+      >
+        <div
+          class="ant-layout-sider-children"
+        >
+          <div
+            class="ant-pro-sider-logo"
+            id="logo"
+          >
+            <a>
+              <img
+                alt="logo"
+                src="https://gw.alipayobjects.com/zos/antfincdn/PmY%24TNNDBI/logo.svg"
+              />
+              <h1>
+                Ant Design Pro
+              </h1>
+            </a>
+          </div>
+          <div
+            style="flex: 1; overflow-y: auto; overflow-x: hidden;"
+          >
+            <ul
+              class="ant-menu ant-menu-dark ant-pro-sider-menu ant-menu-root ant-menu-inline"
+              role="menu"
+              style="width: 100%;"
+            >
+              <li
+                class="ant-menu-item ant-menu-item-only-child"
+                role="menuitem"
+                style="padding-left: 16px;"
+              >
+                <span
+                  class="ant-pro-menu-item"
+                >
+                  <span
+                    class="ant-pro-menu-item-title"
+                  >
+                    首页
+                  </span>
+                </span>
+              </li>
+              <li
+                class=" ant-menu-item-group"
+              >
+                <div
+                  class="ant-menu-item-group-title"
+                >
+                  <span
+                    class="ant-pro-menu-item"
+                  >
+                    汇总数据
+                  </span>
+                </div>
+                <ul
+                  class="ant-menu-item-group-list"
+                >
+                  <li
+                    class=" ant-menu-item-group"
+                  >
+                    <div
+                      class="ant-menu-item-group-title"
+                    >
+                      <span
+                        class="ant-pro-menu-item"
+                      >
+                        域买家维度交易
+                      </span>
+                    </div>
+                    <ul
+                      class="ant-menu-item-group-list"
+                    >
+                      <li
+                        class="ant-menu-item ant-menu-item-only-child"
+                        role="menuitem"
+                        style="padding-left: 16px;"
+                      >
+                        <span
+                          class="ant-pro-menu-item"
+                        >
+                          <span
+                            class="ant-pro-menu-item-title"
+                          >
+                            月表
+                          </span>
+                        </span>
+                      </li>
+                      <li
+                        class="ant-menu-item ant-menu-item-only-child ant-menu-item-selected"
+                        role="menuitem"
+                        style="padding-left: 16px;"
+                      >
+                        <span
+                          class="ant-pro-menu-item"
+                        >
+                          <span
+                            class="ant-pro-menu-item-title"
+                          >
+                            日表
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                  </li>
+                  <li
+                    class=" ant-menu-item-group"
+                  >
+                    <div
+                      class="ant-menu-item-group-title"
+                    >
+                      <span
+                        class="ant-pro-menu-item"
+                      >
+                        维度交易
+                      </span>
+                    </div>
+                    <ul
+                      class="ant-menu-item-group-list"
+                    >
+                      <li
+                        class="ant-menu-item ant-menu-item-only-child"
+                        role="menuitem"
+                        style="padding-left: 16px;"
+                      >
+                        <span
+                          class="ant-pro-menu-item"
+                        >
+                          <span
+                            class="ant-pro-menu-item-title"
+                          >
+                            月表
+                          </span>
+                        </span>
+                      </li>
+                      <li
+                        class="ant-menu-item ant-menu-item-only-child"
+                        role="menuitem"
+                        style="padding-left: 16px;"
+                      >
+                        <span
+                          class="ant-pro-menu-item"
+                        >
+                          <span
+                            class="ant-pro-menu-item-title"
+                          >
+                            日表
+                          </span>
+                        </span>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+              <li
+                class=" ant-menu-item-group"
+              >
+                <div
+                  class="ant-menu-item-group-title"
+                >
+                  <span
+                    class="ant-pro-menu-item"
+                  >
+                    明细数据
+                  </span>
+                </div>
+                <ul
+                  class="ant-menu-item-group-list"
+                >
+                  <li
+                    class="ant-menu-item ant-menu-item-only-child"
+                    role="menuitem"
+                    style="padding-left: 16px;"
+                  >
+                    <span
+                      class="ant-pro-menu-item"
+                    >
+                      <span
+                        class="ant-pro-menu-item-title"
+                      >
+                        概述导出
+                      </span>
+                    </span>
+                  </li>
+                </ul>
+              </li>
+              <li
+                class=" ant-menu-item-group"
+              >
+                <div
+                  class="ant-menu-item-group-title"
+                >
+                  <span
+                    class="ant-pro-menu-item"
+                  >
+                    其他
+                  </span>
+                </div>
+                <ul
+                  class="ant-menu-item-group-list"
+                >
+                  <li
+                    class="ant-menu-item ant-menu-item-only-child"
+                    role="menuitem"
+                    style="padding-left: 16px;"
+                  >
+                    <span
+                      class="ant-pro-menu-item"
+                    >
+                      <span
+                        class="ant-pro-menu-item-title"
+                      >
+                        odps同步导入
+                      </span>
+                    </span>
+                  </li>
+                  <li
+                    class="ant-menu-item ant-menu-item-only-child"
+                    role="menuitem"
+                    style="padding-left: 16px;"
+                  >
+                    <span
+                      class="ant-pro-menu-item"
+                    >
+                      <span
+                        class="ant-pro-menu-item-title"
+                      >
+                        菜单导入
+                      </span>
+                    </span>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+          <div
+            class="ant-pro-sider-links"
+          >
+            <ul
+              class="ant-menu ant-menu-dark ant-pro-sider-link-menu ant-menu-root ant-menu-inline"
+              role="menu"
+            >
+              <li
+                class="ant-menu-item ant-menu-item-only-child ant-pro-sider-collapsed-button"
+                role="menuitem"
+                style="padding-left: 16px;"
+              >
+                <span
+                  aria-label="menu-fold"
+                  class="anticon anticon-menu-fold"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="menu-fold"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M408 442h480c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H408c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8zm-8 204c0 4.4 3.6 8 8 8h480c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8H408c-4.4 0-8 3.6-8 8v56zm504-486H120c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zm0 632H120c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-56c0-4.4-3.6-8-8-8zM115.4 518.9L271.7 642c5.8 4.6 14.4.5 14.4-6.9V388.9c0-7.4-8.5-11.5-14.4-6.9L115.4 505.1a8.74 8.74 0 000 13.8z"
+                    />
+                  </svg>
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+      <div
+        class="ant-layout"
+        style="position: relative;"
+      >
+        <header
+          class="ant-layout-header"
+          style="padding: 0px; height: 48px; line-height: 48px; width: 100%; z-index: 19;"
+        >
+          <div
+            class="ant-pro-global-header ant-pro-global-header-layout-side"
+          >
+            <div
+              style="flex: 1;"
+            />
+          </div>
+        </header>
+        <main
+          class="ant-layout-content ant-pro-basicLayout-content ant-pro-basicLayout-has-header"
+        >
+          <div
+            class="ant-pro-page-container"
+          >
+            <div
+              class="ant-pro-page-container-warp"
+            >
+              <div
+                class="ant-page-header ant-page-header-ghost"
+              >
+                <div
+                  class="ant-page-header-heading"
+                >
+                  <div
+                    class="ant-page-header-heading-left"
+                  >
+                    <span
+                      class="ant-page-header-heading-title"
+                      title="Ant Design Pro"
+                    >
+                      Ant Design Pro
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="ant-page-header-content"
+                >
+                  <div
+                    class="ant-pro-page-container-detail"
+                  >
+                    <div
+                      class="ant-pro-page-container-main"
+                    >
+                      <div
+                        class="ant-pro-page-container-row"
+                      >
+                        <div
+                          class="ant-pro-page-container-content"
+                        >
+                          欢迎使用
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="ant-pro-grid-content"
+            >
+              <div
+                class="ant-pro-grid-content-children"
+              >
+                <div>
+                  <div
+                    class="ant-pro-page-container-children-content"
+                  >
+                    <div>
+                      Hello World
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </main>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`layout demos renders ./packages/layout/src/demos/MultipleMenuOnePath.tsx correctly 1`] = `
 <div
   style="height: 100vh;"


### PR DESCRIPTION
增加了 menu.type 的设置
- 默认值为原来的子菜单模式：`sub`
- 设置为 `group` 时，渲染为新增的 `Menu.ItemGroup`

麻烦提供下修改建议 @chenshuai2144 

close https://github.com/ant-design/pro-components/issues/1219
