### PR TITLE
🐛 fix(table): settings max height (#1376)

### DIFF
--- a/packages/table/src/component/ColumnSetting/index.less
+++ b/packages/table/src/component/ColumnSetting/index.less
@@ -23,6 +23,8 @@
   flex-direction: column;
   width: 100%;
   padding-top: 8px;
+  max-height: 280px;
+  overflow-x: hidden;
 
   &.@{pro-column-setting-prefix-cls}-list-group {
     padding-top: 0;


### PR DESCRIPTION
280 px = antd 的 264px + padding-top 8px + padding-bottom 8px
close https://github.com/ant-design/pro-components/issues/1376