### PR TITLE
fix(filed): moneySymbol support config

### DIFF
--- a/packages/field/src/components/Money/index.tsx
+++ b/packages/field/src/components/Money/index.tsx
@@ -3,6 +3,10 @@ import { InputNumber } from 'antd';
 import { useIntl } from '@ant-design/pro-provider';
 import type { ProFieldFC } from '../../index';
 
+const defaultMoneyIntl = new Intl.NumberFormat('zh-Hans-CN', {
+  currency: 'CNY',
+});
+
 const moneyIntl = new Intl.NumberFormat('zh-Hans-CN', {
   currency: 'CNY',
   style: 'currency',
@@ -24,7 +28,7 @@ const msMoneyIntl = new Intl.NumberFormat('ms-MY', {
   currency: 'MYR',
 });
 
-const getTextByLocale = (locale: string, paramsText: number) => {
+const getTextByLocale = (locale: string | undefined, paramsText: number) => {
   let text = paramsText;
   if (typeof text === 'string') {
     text = Number(text);
@@ -40,6 +44,9 @@ const getTextByLocale = (locale: string, paramsText: number) => {
   // malay
   if (locale === 'ms_MY') {
     return msMoneyIntl.format(text);
+  }
+  if (locale === undefined) {
+    return defaultMoneyIntl.format(text);
   }
   return moneyIntl.format(text);
 };
@@ -62,9 +69,15 @@ const FieldMoney: ProFieldFC<FieldMoneyProps> = (
   ref,
 ) => {
   const intl = useIntl();
-  const moneySymbol = intl.getMessage('moneySymbol', rest.moneySymbol || '￥');
+  const moneySymbol =
+    rest.moneySymbol === undefined ? intl.getMessage('moneySymbol', '￥') : rest.moneySymbol;
+
   if (type === 'read') {
-    const dom = <span ref={ref}>{getTextByLocale(locale || intl.locale, text)}</span>;
+    const dom = (
+      <span ref={ref}>
+        {getTextByLocale(moneySymbol ? locale || intl.locale || 'zh-CN' : undefined, text)}
+      </span>
+    );
     if (render) {
       return render(text, { mode: type, ...fieldProps }, dom);
     }

--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -88,6 +88,7 @@ const defaultRenderTextByObject = (
         {...props}
         fieldProps={pickFormItemProps}
         text={text as number}
+        moneySymbol={valueType.moneySymbol}
       />
     );
   }

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -63,6 +63,7 @@ export type ProFieldValueObjectType = {
   showSymbol?: boolean;
   showColor?: boolean;
   precision?: number;
+  moneySymbol?: string;
   request?: ProFieldRequestData;
 
   /** Image */

--- a/tests/field/__snapshots__/field.test.tsx.snap
+++ b/tests/field/__snapshots__/field.test.tsx.snap
@@ -2540,6 +2540,12 @@ exports[`Field 🐴 money valueType is Object 2`] = `
 </span>
 `;
 
+exports[`Field 🐴 money valueType is Object 3`] = `
+<span>
+  ￥ 100
+</span>
+`;
+
 exports[`Field 🐴 options support dom list 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center ant-pro-field-option"

--- a/tests/field/field.test.tsx
+++ b/tests/field/field.test.tsx
@@ -417,6 +417,19 @@ describe('Field', () => {
       />,
     );
     expect(html).toMatchSnapshot();
+
+    html = render(
+      <Field
+        text="100"
+        valueType={{
+          type: 'money',
+          moneySymbol: '',
+          locale: 'en_US',
+        }}
+        mode="read"
+      />,
+    );
+    expect(html).toMatchSnapshot();
   });
 
   it('🐴 percent valueType is Object', async () => {


### PR DESCRIPTION
close https://github.com/ant-design/pro-components/issues/1544

```
valueType: {
  type:"money",
  moneySymbol:""
}
```