### PR TITLE
fix: migrate title from demo to code tag & fix proform width doc

### DIFF
--- a/packages/card/src/card.md
+++ b/packages/card/src/card.md
@@ -65,7 +65,7 @@ group:
 
 你可以嵌套卡片组件来将内容分组, 以及 `Divider` 子组件来分隔这些内容。
 
-<code src="./demos/divider.tsx" background="#f0f2f5" />
+<code src="./demos/divider.tsx" background="#f0f2f5" title="分组指标" />
 
 ### 标题带分割线
 

--- a/packages/card/src/demos/divider.tsx
+++ b/packages/card/src/demos/divider.tsx
@@ -1,5 +1,3 @@
-/** Uuid: ff1e143f title: 分组指标 */
-
 import React from 'react';
 import { Statistic } from 'antd';
 import ProCard from '@ant-design/pro-card';

--- a/packages/form/src/components/FieldSet/index.md
+++ b/packages/form/src/components/FieldSet/index.md
@@ -90,7 +90,7 @@ ProForm 自带的 Filed ,与 valueType 基本上一一对应。
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| width | Field 的长度，我们归纳了常用的 Field 长度以及适合的场景，支持了一些枚举 "xs" , "s" , "m" , "l" , "x" | `number \| "xs" \| "s" \| "m" \| "l" \| "x"` | - |
+| width | Field 的长度，我们归纳了常用的 Field 长度以及适合的场景，支持了一些枚举 "xs" , "sm" , "md" ,"lg" , "xl" | `number \| "xs" \| "sm" \| "md" \| "lg" \| "xl"` | - |
 | tooltip | 会在 label 旁增加一个 icon，悬浮后展示配置的信息 | `string \| tooltipProps` | - |
 | secondary | 是否是次要控件，只针对 LightFilter 下有效 | `boolean` | `false` |
 | allowClear | 支持清除，针对 LightFilter 下有效，主动设置情况下同时也会透传给 `fieldProps` | `boolean` | `true` |
@@ -102,9 +102,9 @@ ProForm 自带的 Filed ,与 valueType 基本上一一对应。
 ![width info](https://gw.alipayobjects.com/zos/antfincdn/CyJPTSL07y/1574664269794-254db9de-2574-4361-bcf1-b82c6db0c80a.png)
 
 - `XS=104px` 适用于短数字、短文本或选项。
-- `S=216px` 适用于较短字段录入、如姓名、电话、ID 等。
-- `M=328px` 标准宽度，适用于大部分字段长度。
-- `L=440px` 适用于较长字段录入，如长网址、标签组、文件路径等。
+- `SM=216px` 适用于较短字段录入、如姓名、电话、ID 等。
+- `MD=328px` 标准宽度，适用于大部分字段长度。
+- `LG=440px` 适用于较长字段录入，如长网址、标签组、文件路径等。
 - `XL=552px` 适用于长文本录入，如长链接、描述、备注等，通常搭配自适应多行输入框或定高文本域使用。
 
 ### ProFormText

--- a/packages/layout/src/components/PageContainer/demos/basic.tsx
+++ b/packages/layout/src/components/PageContainer/demos/basic.tsx
@@ -1,4 +1,3 @@
-/** Uuid: 7adba566 title: 基本使用 desc: 基本使用情况 */
 import React from 'react';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { Button, Dropdown, Menu } from 'antd';

--- a/packages/layout/src/components/PageContainer/demos/fixHeader.tsx
+++ b/packages/layout/src/components/PageContainer/demos/fixHeader.tsx
@@ -1,4 +1,3 @@
-/** Uuid: da2b07c7 title: 固定表头 desc: 通过 `fixedHeader` 固定表头，只有在溢出容器时才会开始计算。 */
 import React from 'react';
 import { PageContainer } from '@ant-design/pro-layout';
 import ProCard from '@ant-design/pro-card';

--- a/packages/layout/src/components/PageContainer/demos/hideBreadMenu.tsx
+++ b/packages/layout/src/components/PageContainer/demos/hideBreadMenu.tsx
@@ -1,4 +1,3 @@
-/** Uuid: a4621ef5 title: 隐藏面包屑 desc: 不配置 `header` 属性中的 `breadcrumb` 即可。 */
 import React from 'react';
 import { Descriptions } from 'antd';
 import { PageContainer } from '@ant-design/pro-layout';

--- a/packages/layout/src/components/PageContainer/demos/loading.tsx
+++ b/packages/layout/src/components/PageContainer/demos/loading.tsx
@@ -1,4 +1,3 @@
-/** Uuid: 7f462cb4 title: 页面加载中 desc: 通过 `lodding` 属性配置页面加载。 */
 import React from 'react';
 import { PageContainer } from '@ant-design/pro-layout';
 

--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -50,19 +50,19 @@ PageContainer 封装了 antd 的 PageHeader 组件，增加了 tabList 和 conte
 
 ### 基本使用
 
-<code src="./demos/basic.tsx" iframe="500px"/>
+<code src="./demos/basic.tsx" iframe="500px" title="基本使用" desc="基本使用情况" />
 
 ### 固定表头
 
-<code src="./demos/fixHeader.tsx" iframe="500px"/>
+<code src="./demos/fixHeader.tsx" iframe="500px" title="固定表头" desc="通过 `fixedHeader` 固定表头，只有在溢出容器时才会开始计算。" />
 
 ### 隐藏面包屑
 
-<code src="./demos/hideBreadMenu.tsx" iframe="500px">
+<code src="./demos/hideBreadMenu.tsx" iframe="500px" title="隐藏面包屑" desc="不配置 `header` 属性中的 `breadcrumb` 即可。" />
 
 ### 页面加载中
 
-<code src="./demos/loading.tsx" iframe="500px"/>
+<code src="./demos/loading.tsx" iframe="500px" title="页面加载中" desc="通过 `lodding` 属性配置页面加载。"/>
 
 ## API
 

--- a/packages/table/src/components/EditableTable/demos/basic.tsx
+++ b/packages/table/src/components/EditableTable/demos/basic.tsx
@@ -1,4 +1,3 @@
-/** Title: 可编辑表格 */
 import React, { useState } from 'react';
 import type { ProColumns } from '@ant-design/pro-table';
 import { EditableProTable } from '@ant-design/pro-table';

--- a/packages/table/src/components/EditableTable/demos/custom.tsx
+++ b/packages/table/src/components/EditableTable/demos/custom.tsx
@@ -1,4 +1,3 @@
-/** Title: 自定义可编辑表格 */
 import React, { useRef, useState } from 'react';
 import type { ProColumns } from '@ant-design/pro-table';
 import { EditableProTable } from '@ant-design/pro-table';

--- a/packages/table/src/components/EditableTable/demos/real-time-editing.tsx
+++ b/packages/table/src/components/EditableTable/demos/real-time-editing.tsx
@@ -1,4 +1,3 @@
-/** Title: 可编辑表格 */
 import React, { useState } from 'react';
 import type { ProColumns } from '@ant-design/pro-table';
 import { EditableProTable } from '@ant-design/pro-table';

--- a/packages/table/src/components/EditableTable/index.md
+++ b/packages/table/src/components/EditableTable/index.md
@@ -15,15 +15,15 @@ nav:
 
 ### 可编辑表格
 
-<code src="./demos/basic.tsx" background="#f5f5f5" height="420px"/>
+<code src="./demos/basic.tsx" background="#f5f5f5" height="420px" title="可编辑表格" />
 
 ### 自定义可编辑表格
 
-<code src="./demos/custom.tsx" background="#f5f5f5" height="420px"/>
+<code src="./demos/custom.tsx" background="#f5f5f5" height="420px" title="自定义可编辑表格" />
 
 ### 实时保存的编辑表格
 
-<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="420px"/>
+<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="420px" title="实时保存的编辑表格" />
 
 ## API
 

--- a/packages/table/src/demos/ListToolBar/basic.tsx
+++ b/packages/table/src/demos/ListToolBar/basic.tsx
@@ -1,4 +1,3 @@
-/** Title: 基本使用 */
 import React from 'react';
 import { Button } from 'antd';
 import { EllipsisOutlined, SettingOutlined, FullscreenOutlined } from '@ant-design/icons';

--- a/packages/table/src/demos/ListToolBar/menu.tsx
+++ b/packages/table/src/demos/ListToolBar/menu.tsx
@@ -1,4 +1,3 @@
-/** Title: 标题下拉菜单 */
 import React from 'react';
 import { Button } from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';

--- a/packages/table/src/demos/ListToolBar/multipleLine.tsx
+++ b/packages/table/src/demos/ListToolBar/multipleLine.tsx
@@ -1,4 +1,3 @@
-/** Title: 双行布局 desc: 双行的情况下会有双行的布局形式。 */
 import React from 'react';
 import { Button, Dropdown, Menu } from 'antd';
 import { EllipsisOutlined, DownOutlined } from '@ant-design/icons';

--- a/packages/table/src/demos/ListToolBar/no-title.tsx
+++ b/packages/table/src/demos/ListToolBar/no-title.tsx
@@ -1,4 +1,3 @@
-/** Title: 无标题 desc: 没有标题的情况下搜索框会前置。 */
 import React from 'react';
 import { Button } from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';

--- a/packages/table/src/demos/ListToolBar/tabs.tsx
+++ b/packages/table/src/demos/ListToolBar/tabs.tsx
@@ -1,4 +1,3 @@
-/** Title: 带标签 desc: 标签需配合 `multipleLine` 为 `true` 时使用。 */
 import React from 'react';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { LightFilter, ProFormDatePicker } from '@ant-design/pro-form';

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -575,15 +575,15 @@ Form 的列是根据 `valueType` 来生成不同的类型。
 
 #### 代码演示
 
-<code src="./demos/ListToolBar/basic.tsx" background="#f0f2f5"/>
+<code src="./demos/ListToolBar/basic.tsx" background="#f0f2f5" title="基本使用" />
 
-<code src="./demos/ListToolBar/no-title.tsx" background="#f0f2f5"/>
+<code src="./demos/ListToolBar/no-title.tsx" background="#f0f2f5" title="无标题" desc="没有标题的情况下搜索框会前置。" />
 
-<code src="./demos/ListToolBar/multipleLine.tsx" background="#f0f2f5"/>
+<code src="./demos/ListToolBar/multipleLine.tsx" background="#f0f2f5" title="双行布局" desc="双行的情况下会有双行的布局形式。" />
 
-<code src="./demos/ListToolBar/tabs.tsx" background="#f0f2f5"/>
+<code src="./demos/ListToolBar/tabs.tsx" background="#f0f2f5"  title="带标签" desc="标签需配合 `multipleLine` 为 `true` 时使用。" />
 
-<code src="./demos/ListToolBar/menu.tsx" background="#f0f2f5"/>
+<code src="./demos/ListToolBar/menu.tsx" background="#f0f2f5" title="标题下拉菜单"/>
 
 #### ListToolBarProps
 


### PR DESCRIPTION
1. 将 title 从 demo 文件迁移到  code 标签中
2. 修复 ProForm 的width 相关文档