### PR TITLE
fix(table): center the index column

### DIFF
--- a/packages/field/src/components/IndexColumn/index.less
+++ b/packages/field/src/components/IndexColumn/index.less
@@ -8,6 +8,7 @@
   justify-content: center;
   width: 18px;
   height: 18px;
+  margin: 0 auto;
 
   &-border {
     color: #fff;


### PR DESCRIPTION
Before:
<img width="320" alt="before" src="https://user-images.githubusercontent.com/18243819/104997334-686aef00-5a64-11eb-917c-520b1e14677b.png">

After:
<img width="318" alt="after" src="https://user-images.githubusercontent.com/18243819/104997377-7456b100-5a64-11eb-885b-6a255062332f.png">
