### PR TITLE
fix: fixed header collapse animation

### DIFF
--- a/packages/layout/src/Header.less
+++ b/packages/layout/src/Header.less
@@ -5,4 +5,5 @@
 .@{pro-layout-fixed-header-prefix-cls} {
   z-index: 9;
   width: 100%;
+  transition: width 0.3s;
 }


### PR DESCRIPTION
如果固定了 Header，侧边栏从折叠状态打开的时候，Header 宽度动画有问题