### PR TITLE
fix(table): LightFilter dosn't render if options={false}

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -470,7 +470,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     if (toolBarRender === false) {
       return null;
     }
-    if (options === false && !headerTitle && !toolBarRender && !toolbar) {
+    if (options === false && !headerTitle && !toolBarRender && !toolbar && !isLightFilter) {
       return null;
     }
     /** 根据表单类型的不同决定是否生成 toolbarProps */


### PR DESCRIPTION
修复当Pro-table 设置search={{filterType:'light'}} options={false}且未设置headerTitle及toolbar时搜索表单不渲染的问题