### PR TITLE
feat(layout): SettingDrawer support disableUrlParams

### DIFF
--- a/packages/layout/src/components/SettingDrawer/index.tsx
+++ b/packages/layout/src/components/SettingDrawer/index.tsx
@@ -59,6 +59,7 @@ export type SettingDrawerProps = {
   onCollapseChange?: (collapse: boolean) => void;
   onSettingChange?: (settings: MergerSettingsType<ProSettings>) => void;
   pathname?: string;
+  disableUrlParams?: boolean;
 };
 
 export type SettingDrawerState = {
@@ -331,6 +332,7 @@ const SettingDrawer: React.FC<SettingDrawerProps> = (props) => {
     onSettingChange,
     prefixCls = 'ant-pro',
     pathname = window.location.pathname,
+    disableUrlParams = false,
   } = props;
   const firstRender = useRef<boolean>(true);
 
@@ -431,13 +433,14 @@ const SettingDrawer: React.FC<SettingDrawerProps> = (props) => {
   useEffect(() => {
     /** 如果不是浏览器 都没有必要做了 */
     if (!isBrowser()) return;
+    if (disableUrlParams) return;
     if (firstRender.current) {
       firstRender.current = false;
       return;
     }
     const diffParams = getDifferentSetting({ ...urlParams, ...settingState });
     setUrlParams(diffParams);
-  }, [setUrlParams, settingState, urlParams, pathname]);
+  }, [setUrlParams, settingState, urlParams, pathname, disableUrlParams]);
   const baseClassName = `${prefixCls}-setting`;
   return (
     <Drawer

--- a/packages/layout/src/demos/base.tsx
+++ b/packages/layout/src/demos/base.tsx
@@ -136,6 +136,7 @@ export default () => {
         getContainer={() => document.getElementById('test-pro-layout')}
         settings={settings}
         onSettingChange={(changeSetting) => setSetting(changeSetting)}
+        disableUrlParams
       />
     </div>
   );

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -152,6 +152,7 @@ PageContainer 配置 `ghost` 可以将页头切换为透明模式。
 | settings | layout 的设置 | [`Settings`](#Settings) \| [`Settings`](#Settings) | - |
 | onSettingChange | [`Settings`](#Settings) 发生更改事件 | `(settings: [`Settings`](#Settings) ) => void` | - |
 | hideHintAlert | 删除下方的提示信息 | `boolean` | - |
+| disableUrlParams | 禁止同步设置到查询参数 | `boolean` | `false` |
 
 ### PageLoading
 


### PR DESCRIPTION
本来打算写测试用例的，但是现在配置了


```json
testURL: 'http://localhost?navTheme=realDark&layout=mix&primaryColor=daybreak&splitMenus=false&fixedHeader=true'
```

尝试了在用例里重置 URL `window.location.href = 'http://localhost'`，报错：

```shell
Error: Not implemented: navigation (except hash changes)
```

一番折腾后发现应该用不着 mock 整个 navigation，mock `useUrlSearchParams` 用到的 [API](https://github.com/rudyhuynh/use-url-search-params/blob/master/src/mockWindow.js) 应该就行了，如果需要的话我再补齐测试用例。