### PR TITLE
fix(select): 修复 Select 默认的 filterOption 没有忽略大小写

### DIFF
--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -274,8 +274,8 @@ export const useFieldFetchData = (
       : options?.filter((item) => {
           if (!keyWords) return true;
           if (
-            item?.label?.toString().includes(keyWords) ||
-            item.value.toString().includes(keyWords)
+            item?.label?.toString().toLowerCase().includes(keyWords.toLowerCase()) ||
+            item.value.toString().toLowerCase().includes(keyWords.toLowerCase())
           ) {
             return true;
           }


### PR DESCRIPTION
Select 组件默认筛选没有忽略大小写