### PR TITLE
docs(compiler): add some docs for PageContainer basic demo and docs

### DIFF
--- a/packages/layout/src/components/PageContainer/demos/basic.tsx
+++ b/packages/layout/src/components/PageContainer/demos/basic.tsx
@@ -52,12 +52,18 @@ export default () => (
       {
         tab: '基本信息',
         key: 'base',
+        closable: false,
       },
       {
         tab: '详细信息',
         key: 'info',
       },
     ]}
+    tabProps={{
+      type: 'editable-card',
+      hideAdd: true,
+      onEdit: (e, action) => console.log(e, action),
+    }}
     footer={[
       <Button key="3">重置</Button>,
       <Button key="2" type="primary">

--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -81,6 +81,7 @@ PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和
 | affixProps | 固钉的配置，与 antd 完全相同 | `AffixProps` | - |
 | footer | 悬浮在底部的操作栏，传入一个数组，会自动加空格 | `ReactNode[]` | - |
 | waterMarkProps | 配置水印, Layout 会透传给 PageContainer，但是以 PageContainer 的配置优先 | [WaterMarkProps](/components/water-mark) | - |
+| tabProps | [Tabs 的相关属性](https://ant.design/components/tabs-cn/#Tabs),只有卡片样式的页签支持新增和关闭选项。使用 closable={false} 禁止关闭。 | `TabsProps` |  |
 
 > fixedHeader 使用了 antd 的 Affix 实现，默认监听 body，如果你的滚动条不在 body 上需要人肉[设置](https://ant.design/components/affix-cn/)一下。
 

--- a/tests/layout/__snapshots__/demo.test.ts.snap
+++ b/tests/layout/__snapshots__/demo.test.ts.snap
@@ -131,7 +131,7 @@ exports[`layout demos 📸 renders ./packages/layout/src/components/PageContaine
         class="ant-page-header-footer"
       >
         <div
-          class="ant-tabs ant-tabs-top ant-pro-page-container-tabs"
+          class="ant-tabs ant-tabs-top ant-tabs-editable ant-tabs-card ant-tabs-editable-card ant-pro-page-container-tabs"
         >
           <div
             class="ant-tabs-nav"
@@ -159,7 +159,7 @@ exports[`layout demos 📸 renders ./packages/layout/src/components/PageContaine
                   </div>
                 </div>
                 <div
-                  class="ant-tabs-tab"
+                  class="ant-tabs-tab ant-tabs-tab-with-remove"
                 >
                   <div
                     aria-controls="rc-tabs-test-panel-info"
@@ -171,6 +171,32 @@ exports[`layout demos 📸 renders ./packages/layout/src/components/PageContaine
                   >
                     详细信息
                   </div>
+                  <button
+                    aria-label="remove"
+                    class="ant-tabs-tab-remove"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      aria-label="close"
+                      class="anticon anticon-close"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="close"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M563.8 512l262.5-312.9c4.4-5.2.7-13.1-6.1-13.1h-79.8c-4.7 0-9.2 2.1-12.3 5.7L511.6 449.8 295.1 191.7c-3-3.6-7.5-5.7-12.3-5.7H203c-6.8 0-10.5 7.9-6.1 13.1L459.4 512 196.9 824.9A7.95 7.95 0 00203 838h79.8c4.7 0 9.2-2.1 12.3-5.7l216.5-258.1 216.5 258.1c3 3.6 7.5 5.7 12.3 5.7h79.8c6.8 0 10.5-7.9 6.1-13.1L563.8 512z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
                 </div>
                 <div
                   class="ant-tabs-ink-bar ant-tabs-ink-bar-animated"


### PR DESCRIPTION
mofiy PageContainer basic demo and docs。 add  `editable-card`

``` tsx
    tabList={[
      {
        tab: '基本信息',
        key: 'base',
        closable: false,
      },
      {
        tab: '详细信息',
        key: 'info',
      },
    ]}
    tabProps={{
      type: 'editable-card',
      hideAdd: true,
      onEdit: (e, action) => console.log(e, action),
    }}
```

 tabProps | [Tabs 的相关属性](https://ant.design/components/tabs-cn/#Tabs),只有卡片样式的页签支持新增和关闭选项。使用 closable={false} 禁止关闭。
