### PR TITLE
docs: add modalForm reset demos.

### DIFF
--- a/packages/form/src/components/ModalForm/demos/modal-form-reset.tsx
+++ b/packages/form/src/components/ModalForm/demos/modal-form-reset.tsx
@@ -1,5 +1,6 @@
-﻿import React from 'react';
+import React, { useRef, useState } from 'react';
 import { Button, message, Space } from 'antd';
+import type { FormInstance } from 'antd';
 import { ModalForm, ProFormText } from '@ant-design/pro-form';
 
 const waitTime = (time: number = 100) => {
@@ -11,80 +12,71 @@ const waitTime = (time: number = 100) => {
 };
 
 export default () => {
+  const formRef = useRef<FormInstance>();
+  const [modalVisible, setModalVisible] = useState<boolean>(false);
+
   return (
     <Space>
       <ModalForm
         title="新建表单"
-        trigger={<Button type="primary">自己定义 footer 的按钮</Button>}
+        formRef={formRef}
+        visible={modalVisible}
+        trigger={
+          <Button
+            type="primary"
+            onClick={() => {
+              setModalVisible(true);
+            }}
+          >
+            通过 formRef 重置
+          </Button>
+        }
+        onVisibleChange={setModalVisible}
+        submitter={{
+          searchConfig: {
+            resetText: '重置',
+          },
+          resetButtonProps: {
+            onClick: () => {
+              formRef.current?.resetFields();
+              //   setModalVisible(false);
+            },
+          },
+        }}
+        onFinish={async (values) => {
+          await waitTime(2000);
+          console.log(values);
+          message.success('提交成功');
+          return true;
+        }}
+      >
+        <ProFormText
+          width="md"
+          name="name"
+          label="签约客户名称"
+          tooltip="最长为 24 位"
+          placeholder="请输入名称"
+        />
+
+        <ProFormText width="md" name="company" label="我方公司名称" placeholder="请输入名称" />
+      </ModalForm>
+      <ModalForm
+        title="新建表单"
+        formRef={formRef}
+        trigger={<Button type="primary">通过自定义 footer 按钮重置</Button>}
         submitter={{
           render: (props, defaultDoms) => {
             return [
               ...defaultDoms,
               <Button
-                key="ok"
+                key="extra-reset"
                 onClick={() => {
-                  props.submit();
+                  props.reset();
                 }}
               >
-                ok
+                重置
               </Button>,
             ];
-          },
-        }}
-        onFinish={async (values) => {
-          await waitTime(2000);
-          console.log(values);
-          message.success('提交成功');
-          return true;
-        }}
-      >
-        <ProFormText
-          width="md"
-          name="name"
-          label="签约客户名称"
-          tooltip="最长为 24 位"
-          placeholder="请输入名称"
-        />
-
-        <ProFormText width="md" name="company" label="我方公司名称" placeholder="请输入名称" />
-      </ModalForm>
-      <ModalForm
-        title="新建表单"
-        trigger={<Button type="primary">自定义文字</Button>}
-        submitter={{
-          searchConfig: {
-            submitText: '确认',
-            resetText: '取消',
-          },
-        }}
-        onFinish={async (values) => {
-          await waitTime(2000);
-          console.log(values);
-          message.success('提交成功');
-          return true;
-        }}
-      >
-        <ProFormText
-          width="md"
-          name="name"
-          label="签约客户名称"
-          tooltip="最长为 24 位"
-          placeholder="请输入名称"
-        />
-
-        <ProFormText width="md" name="company" label="我方公司名称" placeholder="请输入名称" />
-      </ModalForm>
-      <ModalForm
-        title="新建表单"
-        trigger={<Button type="primary">隐藏或修改按钮样式</Button>}
-        submitter={{
-          resetButtonProps: {
-            type: 'dashed',
-          },
-          submitButtonProps: {
-            style: {
-              display: 'none',
-            },
           },
         }}
         onFinish={async (values) => {

--- a/packages/form/src/components/ModalForm/index.en-US.md
+++ b/packages/form/src/components/ModalForm/index.en-US.md
@@ -15,15 +15,23 @@ ModalForm and DrawerForm both provide triggers to reduce state usage, if you nee
 
 ## Modal Forms
 
-<code src="./demos/modal-form.tsx" background="#f5f5f5" height="32px"/>
+<code src="./demos/modal-form.tsx" background="#f5f5f5" height="32px" title="Modal Forms"/>
 
 ## Drawer Forms
 
-<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="32px"/>
+<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="32px" title="Drawer Forms"/>
+
+## Custom Modal Forms' Button
+
+<code src="./demos/modal-form-submitter.tsx"  background="#f5f5f5" height="32px" title="Custom Modal Forms' Button"/>
 
 ## Use visible and onVisibleChange
 
-<code src="./demos/visible-on-visible-change.tsx"  background="#f5f5f5" height="32px"/>
+<code src="./demos/visible-on-visible-change.tsx"  background="#f5f5f5" height="32px" title="Use visible and onVisibleChange"/>
+
+## Reset Form
+
+<code src="./demos/modal-form-reset.tsx"  background="#f5f5f5" height="32px" title="Reset Form"/>
 
 ## API
 

--- a/packages/form/src/components/ModalForm/index.md
+++ b/packages/form/src/components/ModalForm/index.md
@@ -22,13 +22,17 @@ ModalForm 和 DrawerForm 都提供了 trigger 来减少 state 的使用，如果
 
 <code src="./demos/drawer-form.tsx"  background="#f5f5f5" height="32px" title="Drawer 表单" />
 
-## 自定义 Drawer 表单按钮
+## 自定义 Modal 表单按钮
 
-<code src="./demos/modal-form-submitter.tsx"  background="#f5f5f5" height="32px" title="自定义 Drawer 表单按钮"/>
+<code src="./demos/modal-form-submitter.tsx"  background="#f5f5f5" height="32px" title="自定义 Modal 表单按钮"/>
 
 ## 使用 visible 和 onVisibleChange
 
 <code src="./demos/visible-on-visible-change.tsx"  background="#f5f5f5" height="32px" title="使用 visible 和 onVisibleChange"/>
+
+## 重置表单
+
+<code src="./demos/modal-form-reset.tsx"  background="#f5f5f5" height="32px" title="重置表单"/>
 
 ## API
 

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -8071,7 +8071,7 @@ Array [
         class="ant-modal-root"
       >
         <div
-          aria-labelledby="rcDialogTitle3"
+          aria-labelledby="rcDialogTitle5"
           class="ant-modal-wrap"
           role="dialog"
           style="display: none;"
@@ -8114,6 +8114,38 @@ Array [
 ]
 `;
 
+exports[`form demos 📸 renders ./packages/form/src/components/ModalForm/demos/modal-form-reset.tsx correctly 1`] = `
+<div
+  class="ant-space ant-space-horizontal ant-space-align-center"
+>
+  <div
+    class="ant-space-item"
+    style="margin-right: 8px;"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        通过 formRef 重置
+      </span>
+    </button>
+  </div>
+  <div
+    class="ant-space-item"
+  >
+    <button
+      class="ant-btn ant-btn-primary"
+      type="button"
+    >
+      <span>
+        通过自定义 footer 按钮重置
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`form demos 📸 renders ./packages/form/src/components/ModalForm/demos/modal-form-submitter.tsx correctly 1`] = `
 <div
   class="ant-space ant-space-horizontal ant-space-align-center"
@@ -8127,7 +8159,7 @@ exports[`form demos 📸 renders ./packages/form/src/components/ModalForm/demos/
       type="button"
     >
       <span>
-        自己定义footer的按钮
+        自己定义 footer 的按钮
       </span>
     </button>
   </div>
@@ -8248,7 +8280,7 @@ Array [
         class="ant-modal-root"
       >
         <div
-          aria-labelledby="rcDialogTitle4"
+          aria-labelledby="rcDialogTitle6"
           class="ant-modal-wrap"
           role="dialog"
           style="display: none;"


### PR DESCRIPTION
1. 添加了 重置 表单的 Demo
2. `自定义 Drawer 表单按钮` 标题修改为 `自定义 Modal 表单按钮`，因为例子用的 Modal Form，保持下统一
3. `自定义 Modal 表单按钮`这个 Demo 中的`自定义footer的按钮`，和另外几个例子中 英文单词带空格保持下统一
4. 英文版的文档中没有引入`自定义 Modal 表单按钮`的 Demo，补充了一下，顺便都加上了 `title`