### PR TITLE
feat(table): search form support className

### DIFF
--- a/packages/field/src/components/ColorPicker/index.tsx
+++ b/packages/field/src/components/ColorPicker/index.tsx
@@ -2,7 +2,8 @@
 import { SketchPicker } from 'react-color';
 import React, { useContext } from 'react';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
-import { ConfigProvider, PopoverProps } from 'antd';
+import type { PopoverProps } from 'antd';
+import { ConfigProvider } from 'antd';
 import { Popover } from 'antd';
 import type { ProFieldFC } from '../../index';
 

--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
 import React, {
   useState,
   useImperativeHandle,

--- a/packages/form/src/layouts/QueryFilter/index.tsx
+++ b/packages/form/src/layouts/QueryFilter/index.tsx
@@ -86,6 +86,7 @@ export type BaseQueryFilterProps = Omit<ActionsProps, 'submitter' | 'setCollapse
   defaultColsNumber?: number;
   labelWidth?: number | 'auto';
   split?: boolean;
+  className?: string;
   /** 配置列数 */
   span?: SpanConfig;
 

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,8 +416,10 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-          [searchConfig.className]: searchConfig !== false && searchConfig?.className,
-        }        
+          ...(searchConfig !== false && searchConfig?.className
+            ? { [searchConfig.className]: searchConfig?.className }
+            : {}),
+        }
       )}
     >
       <Competent

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,8 +416,7 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-          [searchConfig?.className]:
-            searchConfig !== false && searchConfig?.className,
+          [searchConfig?.className]: searchConfig !== false && searchConfig?.className,
         }
       )}
     >

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -417,7 +417,7 @@ const FormRender = <T, U = any>({
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
           [(searchConfig as { className: string })?.className]:
-          searchConfig !== false && searchConfig?.className,
+            searchConfig !== false && searchConfig?.className,
         }
       )}
     >

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,9 +416,8 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-          ...(searchConfig !== false && searchConfig?.className
-            ? { [searchConfig.className]: searchConfig?.className }
-            : {}),
+          [searchConfig !== false && searchConfig?.className ? searchConfig?.className : '']:
+            searchConfig !== false && searchConfig?.className,
         }
       )}
     >

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,7 +416,7 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-          [searchConfig !== false && searchConfig?.className ? searchConfig?.className : '']:
+          [searchConfig?.className]:
             searchConfig !== false && searchConfig?.className,
         }
       )}

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,8 +416,8 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-        },
-        [searchConfig.className]: searchConfig !== false && searchConfig?.className ,
+          [searchConfig.className]: searchConfig !== false && searchConfig?.className,
+        }        
       )}
     >
       <Competent

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -416,7 +416,8 @@ const FormRender = <T, U = any>({
           [formClassName]: isForm,
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
-          [searchConfig?.className]: searchConfig !== false && searchConfig?.className,
+          [(searchConfig as { className: string })?.className]:
+          searchConfig !== false && searchConfig?.className,
         }
       )}
     >

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -410,11 +410,15 @@ const FormRender = <T, U = any>({
   );
   return (
     <div
-      className={classNames(className, {
-        [formClassName]: isForm,
-        [getPrefixCls(`pro-table-search-${competentName}`)]: true,
-        [`${getPrefixCls('card')}-bordered`]: !!bordered,
-      })}
+      className={classNames(
+        className,
+        {
+          [formClassName]: isForm,
+          [getPrefixCls(`pro-table-search-${competentName}`)]: true,
+          [`${getPrefixCls('card')}-bordered`]: !!bordered,
+        },
+        searchConfig !== false && searchConfig?.className ? searchConfig.className : '',
+      )}
     >
       <Competent
         {...loadingProps}

--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -417,7 +417,7 @@ const FormRender = <T, U = any>({
           [getPrefixCls(`pro-table-search-${competentName}`)]: true,
           [`${getPrefixCls('card')}-bordered`]: !!bordered,
         },
-        searchConfig !== false && searchConfig?.className ? searchConfig.className : '',
+        [searchConfig.className]: searchConfig !== false && searchConfig?.className ,
       )}
     >
       <Competent

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -303,6 +303,7 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 | submitText | the text of the submit button | `string` | submit |
 | labelWidth | The width of the label | `'number'` \| `'auto'` | 80 |
 | span | Configure the number of columns in the query form | `'number'` \| [`'ColConfig'`](#ColConfig) | defaultColConfig |
+| className | The className of the search form | `string` | - |
 | collapseRender | render of the collapse button | `(collapsed: boolean,showCollapseButton?: boolean,) => ReactNode` | - |
 | defaultCollapsed | whether to collapse by default | `boolean` | true |
 | collapsed | collapsed or not | `boolean` | - |

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -310,6 +310,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 | submitText | 提交按钮的文本 | `string` | 提交 |
 | labelWidth | 标签的宽度 | `'number'` \| `'auto'` | 80 |
 | span | 配置查询表单的列数 | `'number'` \| [`'ColConfig'`](#ColConfig) | defaultColConfig |
+| className | 封装的搜索 Form 的 className | `string` | - |
 | collapseRender | 收起按钮的 render | `(collapsed: boolean,showCollapseButton?: boolean,) => ReactNode` | - |
 | defaultCollapsed | 默认是否收起 | `boolean` | true |
 | collapsed | 是否收起 | `boolean` | - |


### PR DESCRIPTION
## Example

```diff
 <ProTable<TableListItem, Record<string, any>, 'link' | 'tags'>
+    search={{
+        className="shadow-md rounded-lg",
+    }}
     columns={columns}
     request={() => {
         return Promise.resolve({
            total: 200,
            data: tableListDataSource,
            success: true,
         });
     }}
     rowKey="key"
     headerTitle="自定义 valueType"
 />
```

🤚 **Don't want to use less.**
```less
.xxxx {
  :global .ant-pro-table-search {
    border-radius: 8px;
  }
}
```