### PR TITLE
fix(table): omit className in treeData

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -10,6 +10,7 @@ import type { TableColumnType } from 'antd';
 import { Checkbox, Tree, Popover, ConfigProvider, Tooltip } from 'antd';
 import classNames from 'classnames';
 import type { DataNode } from 'antd/lib/tree';
+import omit from 'omit.js';
 
 import type { ColumnsState } from '../../container';
 import Container from '../../container';
@@ -142,7 +143,7 @@ const CheckboxList: React.FC<{
     }
     return {
       key: columnKey,
-      ...rest,
+      ...omit(rest, ['className']),
       selectable: false,
       switcherIcon: () => false,
     };


### PR DESCRIPTION
修复为 column 配置 className 时覆盖了 `.ant-pro-table-column-setting-*` 相关类名