### PR TITLE
refactor: 调整valueEnum的定义方式

### DIFF
--- a/packages/descriptions/src/demos/customization-value-type.tsx
+++ b/packages/descriptions/src/demos/customization-value-type.tsx
@@ -4,12 +4,12 @@ import ProDescriptions from '@ant-design/pro-descriptions';
 import ProProvider from '@ant-design/pro-provider';
 import { Input, Space, Tag } from 'antd';
 
-const valueEnum = {
-  0: 'close',
-  1: 'running',
-  2: 'online',
-  3: 'error',
-};
+enum valueEnum {
+  close,
+  running,
+  online,
+  error,
+}
 
 export type TableListItem = {
   key: number;


### PR DESCRIPTION
修改了demo中对valueEnum的定义方式。利用枚举值的方式，显得会简洁一些。