### PR TITLE
fix: render empty text when 'text === 0'

### DIFF
--- a/packages/field/src/components/Text/index.tsx
+++ b/packages/field/src/components/Text/index.tsx
@@ -23,7 +23,7 @@ const FieldText: ProFieldFC<{
   );
 
   if (mode === 'read') {
-    const dom = text || '-';
+    const dom = text ?? '-';
     if (render) {
       return render(text, { mode, ...fieldProps }, <>{dom}</>);
     }

--- a/packages/field/src/components/TextArea/index.tsx
+++ b/packages/field/src/components/TextArea/index.tsx
@@ -14,7 +14,7 @@ const FieldTextArea: ProFieldFC<{
 }> = ({ text, mode, render, renderFormItem, fieldProps }, ref) => {
   const intl = useIntl();
   if (mode === 'read') {
-    const dom = <span ref={ref}>{text || '-'}</span>;
+    const dom = <span ref={ref}>{text ?? '-'}</span>;
     if (render) {
       return render(text, { mode, ...fieldProps }, dom);
     }


### PR DESCRIPTION
对于 Text 和 TextArea，应该只有 `undefined` 和 `null` 被视为空值，fixed #2240。