### PR TITLE
ProForm ProFormUploadDragger  and ProFormUploadButton add uploadParamName field

### DIFF
--- a/packages/form/src/components/FieldSet/index.md
+++ b/packages/form/src/components/FieldSet/index.md
@@ -263,11 +263,12 @@ ProFormCaptcha 是为了支持中后台中常见的验证码功能开发的组�
 
 与 [upload](https://ant.design/components/upload-cn/) 相同。预设了 Dragger 的样式，其他与 Upload 相同。
 
-| 参数        | 说明             | 类型        | 默认值                           |
-| ----------- | ---------------- | ----------- | -------------------------------- |
-| icon        | Dragger 的图表。 | `ReactNode` | InboxOutlined                    |
-| title       | Dragger 的标题   | `ReactNode` | '单击或拖动文件到此区域进行上传' |
-| description | Dragger 的描述   | `ReactNode` | '支持单次或批量上传'             |
+| 参数            | 说明                 | 类型        | 默认值                           |
+| --------------- | -------------------- | ----------- | -------------------------------- |
+| icon            | Dragger 的图表。     | `ReactNode` | InboxOutlined                    |
+| title           | Dragger 的标题       | `ReactNode` | '单击或拖动文件到此区域进行上传' |
+| description     | Dragger 的描述       | `ReactNode` | '支持单次或批量上传'             |
+| uploadParamName | 发到后台的文件参数名 | `string`    | 'files'                          |
 
 ```tsx | pure
 <ProFormUploadDragger label="Dragger" name="dragger" action="upload.do" />
@@ -277,10 +278,11 @@ ProFormCaptcha 是为了支持中后台中常见的验证码功能开发的组�
 
 与 [upload](https://ant.design/components/upload-cn/) 相同。预设了 Button 的样式，其他与 Upload 相同。
 
-| 参数  | 说明             | 类型        | 默认值         |
-| ----- | ---------------- | ----------- | -------------- |
-| icon  | Dragger 的图表。 | `ReactNode` | UploadOutlined |
-| title | Dragger 的标题   | `ReactNode` | 单击上传       |
+| 参数            | 说明                 | 类型        | 默认值         |
+| --------------- | -------------------- | ----------- | -------------- |
+| icon            | Dragger 的图表。     | `ReactNode` | UploadOutlined |
+| title           | Dragger 的标题       | `ReactNode` | 单击上传       |
+| uploadParamName | 发到后台的文件参数名 | `string`    | 'files'        |
 
 ```tsx | pure
 <ProFormUploadButton label="upload" name="upload" action="upload.do" />

--- a/packages/form/src/components/UploadButton/index.tsx
+++ b/packages/form/src/components/UploadButton/index.tsx
@@ -8,7 +8,7 @@ import createField from '../../BaseForm/createField';
 export type ProFormDraggerProps = ProFormItemProps<UploadProps> & {
   icon?: React.ReactNode;
   title?: React.ReactNode;
-  name?: UploadProps['name'];
+  uploadParamName?: UploadProps['uploadParamName'];
   listType?: UploadProps['listType'];
   action?: UploadProps['action'];
   accept?: UploadProps['accept'];
@@ -27,7 +27,8 @@ export type ProFormDraggerProps = ProFormItemProps<UploadProps> & {
 const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerProps> = (
   {
     fieldProps,
-    name,
+    //新增 uploadParamName 自定义字段，用来自定义上传接口字段。防止 name ['config','file'] 方式产生冲突
+    uploadParamName,
     action,
     accept,
     listType,
@@ -51,7 +52,7 @@ const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerPro
       accept={accept}
       ref={ref}
       //'fileList' 改成和 ant.design 文档中 Update 组件 默认 file字段一样
-      name={name || 'file'}
+      name={uploadParamName || 'files'}
       listType={listType || 'picture'}
       fileList={value}
       {...fieldProps}

--- a/packages/form/src/components/UploadButton/index.tsx
+++ b/packages/form/src/components/UploadButton/index.tsx
@@ -8,7 +8,7 @@ import createField from '../../BaseForm/createField';
 export type ProFormDraggerProps = ProFormItemProps<UploadProps> & {
   icon?: React.ReactNode;
   title?: React.ReactNode;
-  name?: Recat.UploadProps['name'];
+  name?: UploadProps['name'];
   listType?: UploadProps['listType'];
   action?: UploadProps['action'];
   accept?: UploadProps['accept'];
@@ -27,6 +27,7 @@ export type ProFormDraggerProps = ProFormItemProps<UploadProps> & {
 const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerProps> = (
   {
     fieldProps,
+    name,
     action,
     accept,
     listType,
@@ -49,7 +50,8 @@ const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerPro
       action={action}
       accept={accept}
       ref={ref}
-      name={name || 'fileList'}
+      //'fileList' 改成和 ant.design 文档中 Update 组件 默认 file字段一样
+      name={name || 'file'}
       listType={listType || 'picture'}
       fileList={value}
       {...fieldProps}

--- a/packages/form/src/components/UploadButton/index.tsx
+++ b/packages/form/src/components/UploadButton/index.tsx
@@ -8,6 +8,7 @@ import createField from '../../BaseForm/createField';
 export type ProFormDraggerProps = ProFormItemProps<UploadProps> & {
   icon?: React.ReactNode;
   title?: React.ReactNode;
+  name?: Recat.UploadProps['name'];
   listType?: UploadProps['listType'];
   action?: UploadProps['action'];
   accept?: UploadProps['accept'];
@@ -48,7 +49,7 @@ const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerPro
       action={action}
       accept={accept}
       ref={ref}
-      name="fileList"
+      name={name || 'fileList'}
       listType={listType || 'picture'}
       fileList={value}
       {...fieldProps}

--- a/packages/form/src/components/UploadDragger/index.tsx
+++ b/packages/form/src/components/UploadDragger/index.tsx
@@ -8,6 +8,7 @@ import createField from '../../BaseForm/createField';
 export type ProFormDraggerProps = ProFormItemProps<DraggerProps> & {
   icon?: React.ReactNode;
   title?: React.ReactNode;
+  uploadParamName?: UploadProps['uploadParamName'];
   action?: UploadProps['action'];
   accept?: UploadProps['accept'];
   description?: React.ReactNode;
@@ -27,6 +28,8 @@ const ProFormUploadDragger: React.FC<ProFormDraggerProps> = React.forwardRef(
     {
       fieldProps,
       title = '单击或拖动文件到此区域进行上传',
+      //新增 uploadParamName 自定义字段，用来自定义上传接口字段。防止 name ['config','file'] 方式产生冲突
+      uploadParamName,
       icon = <InboxOutlined />,
       description = '支持单次或批量上传',
       action,
@@ -48,7 +51,7 @@ const ProFormUploadDragger: React.FC<ProFormDraggerProps> = React.forwardRef(
       <Upload.Dragger
         // @ts-ignore
         ref={ref}
-        name="files"
+        name={uploadParamName || 'files'}
         action={action}
         accept={accept}
         fileList={value}

--- a/packages/form/src/layouts/StepsForm/index.less
+++ b/packages/form/src/layouts/StepsForm/index.less
@@ -21,7 +21,7 @@
     &-active {
       display: block;
     }
-    
+
     > form {
       max-width: 100%;
     }


### PR DESCRIPTION
新增uploadParamName 用于自定义后台上传接口字段。
解决以name = {['config','file']} 形式也将导致无法上传。