### PR TITLE
fix(utils): 优化 inline-error-form-item 的 popover 展示逻辑

### DIFF
--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -113,7 +113,7 @@ const Highlight: React.FC<{
   label: string;
   words: string[];
 }> = ({ label, words }) => {
-  const reg = new RegExp(words.join('|'), 'g');
+  const reg = new RegExp(words.map((w) => w.replace(/\\/g, '\\\\')).join('|'), 'g');
   const token = label.replace(reg, '#@$&#');
   const elements = token.split('#').map((x) =>
     x[0] === '@'

--- a/packages/utils/src/components/InlineErrorFormItem/index.tsx
+++ b/packages/utils/src/components/InlineErrorFormItem/index.tsx
@@ -2,7 +2,7 @@
 import { Form, Popover, Progress, Space } from 'antd';
 import type { FormItemProps, PopoverProps, ProgressProps } from 'antd';
 import { CheckCircleFilled, CloseCircleFilled, LoadingOutlined } from '@ant-design/icons';
-import type { Rule, NamePath } from 'rc-field-form/lib/interface';
+import type { Rule, NamePath, RuleObject } from 'rc-field-form/lib/interface';
 
 const RED = '#ff4d4f';
 const YELLOW = '#faad14';
@@ -43,9 +43,17 @@ const CircleRender = () => {
   );
 };
 
-const getIcon = (fieldError: string[], value: any, rule: Rule, isTouched: boolean) => {
+const getIcon = (
+  fieldError: string[],
+  rule: Rule,
+  isTouched: boolean,
+  requiredChecked: boolean,
+) => {
   if (!isTouched) {
     return <CircleRender></CircleRender>;
+  }
+  if (!requiredChecked) {
+    return <CloseCircleFilled style={{ color: COLORS.RED }} />;
   }
   if (fieldError.includes((rule as any).message)) {
     return <CloseCircleFilled style={{ color: COLORS.RED }} />;
@@ -66,6 +74,9 @@ const Content: React.FC<{
     Math.min(100, ((rules.length - fieldError.length) / rules.length) * 100),
   );
   const isSingleRule = rules.length === 1;
+  const requiredRule = rules.filter((_) => (_ as RuleObject).required)[0] as RuleObject;
+  const hasRequired = !!requiredRule;
+  const requiredChecked = hasRequired && !fieldError.includes(requiredRule?.message as string);
   return (
     <div style={isSingleRule ? {} : { padding: '6px 8px 12px 8px' }}>
       {(progressProps === undefined || progressProps) && (
@@ -91,7 +102,7 @@ const Content: React.FC<{
               {isValidating ? (
                 <LoadingOutlined style={{ color: COLORS.PRIMARY }} />
               ) : (
-                getIcon(fieldError, value, rule, isTouched)
+                getIcon(fieldError, rule, isTouched, hasRequired ? requiredChecked : true)
               )}
               <span style={{ color: 'rgba(0,0,0,0.65)' }}>{(rule as any).message}</span>
             </Space>
@@ -129,6 +140,7 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
   progressProps,
   ...rest
 }) => {
+  let prevIsError = false;
   return (
     <Form.Item shouldUpdate={true} noStyle>
       {(form) => {
@@ -136,12 +148,15 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
         const value = form.getFieldValue(name);
         const isValidating = form.isFieldValidating(name);
         const isTouched = form.isFieldTouched(name);
+        if (!isValidating) {
+          prevIsError = !!fieldError.length;
+        }
         return (
           <Form.Item
             style={FIX_INLINE_STYLE}
             preserve={false}
             name={name}
-            validateFirst="parallel"
+            validateFirst={false}
             rules={rules}
             // @ts-ignore
             _internalItemRender={{
@@ -163,6 +178,7 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
                   <Popover
                     trigger={popoverProps?.trigger || 'focus'}
                     placement={popoverProps?.placement}
+                    visible={isValidating ? prevIsError : !!fieldError.length}
                     content={
                       <Content
                         fieldError={fieldError}

--- a/packages/utils/src/components/InlineErrorFormItem/index.tsx
+++ b/packages/utils/src/components/InlineErrorFormItem/index.tsx
@@ -11,10 +11,10 @@ const PRIMARY = '#1890ff';
 const COLORS = { RED, YELLOW, GREEN, PRIMARY };
 
 const getStrokeColor = (percent: number) => {
-  if (percent < 30) {
+  if (percent < 50) {
     return COLORS.RED;
   }
-  if (percent < 60) {
+  if (percent < 100) {
     return COLORS.YELLOW;
   }
   return COLORS.GREEN;
@@ -140,7 +140,8 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
   progressProps,
   ...rest
 }) => {
-  let prevIsError = false;
+  let isPrevError = true;
+  let isDoneFirstValidate = false;
   return (
     <Form.Item shouldUpdate={true} noStyle>
       {(form) => {
@@ -149,7 +150,11 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
         const isValidating = form.isFieldValidating(name);
         const isTouched = form.isFieldTouched(name);
         if (!isValidating) {
-          prevIsError = !!fieldError.length;
+          if (isDoneFirstValidate) {
+            isPrevError = !!fieldError.length;
+          }
+        } else {
+          isDoneFirstValidate = true;
         }
         return (
           <Form.Item
@@ -178,7 +183,10 @@ const InlineErrorFormItem: React.FC<InternalProps> = ({
                   <Popover
                     trigger={popoverProps?.trigger || 'focus'}
                     placement={popoverProps?.placement}
-                    visible={isValidating ? prevIsError : !!fieldError.length}
+                    visible={
+                      // eslint-disable-next-line no-nested-ternary
+                      isTouched ? (isValidating ? isPrevError : !!fieldError.length) : undefined
+                    }
                     content={
                       <Content
                         fieldError={fieldError}

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -266,7 +266,9 @@ describe('utils', () => {
       html.find('Input#test').simulate('focus');
     });
     await waitForComponentToPaint(html, 100);
-    expect(html.find('div.ant-popover').exists()).toBeFalsy();
+    expect(html.find('div.ant-popover').exists()).toBeTruthy();
+    expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(0);
+    expect(html.find('.ant-popover .anticon.anticon-close-circle').length).toEqual(0);
 
     act(() => {
       html.find('Input#test').simulate('change', {

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -266,14 +266,7 @@ describe('utils', () => {
       html.find('Input#test').simulate('focus');
     });
     await waitForComponentToPaint(html, 100);
-    expect(html.find('div.ant-popover').exists()).toBeTruthy();
-    const li = html.find('div.ant-popover ul li');
-    expect(li.length).toEqual(4);
-    expect(li.at(0).find('.ant-space-item span').text()).toEqual(ruleMessage.required);
-    expect(li.at(1).find('.ant-space-item span').text()).toEqual(ruleMessage.min);
-    expect(li.at(2).find('.ant-space-item span').text()).toEqual(ruleMessage.numberRequired);
-    expect(li.at(3).find('.ant-space-item span').text()).toEqual(ruleMessage.alphaRequired);
-    expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(0);
+    expect(html.find('div.ant-popover').exists()).toBeFalsy();
 
     act(() => {
       html.find('Input#test').simulate('change', {
@@ -283,72 +276,43 @@ describe('utils', () => {
       });
     });
     await waitForComponentToPaint(html, 1000);
+
+    const li = html.find('div.ant-popover .ant-popover-inner-content ul li');
+    expect(li.length).toEqual(4);
+    expect(li.at(0).find('.ant-space-item span').at(1).text()).toEqual(ruleMessage.required);
+    expect(li.at(1).find('.ant-space-item span').at(1).text()).toEqual(ruleMessage.min);
+    expect(li.at(2).find('.ant-space-item span').at(1).text()).toEqual(ruleMessage.numberRequired);
+    expect(li.at(3).find('.ant-space-item span').at(1).text()).toEqual(ruleMessage.alphaRequired);
     expect(
       html
         .find('div.ant-popover .ant-progress-bg')
         .at(0)
         .getDOMNode()
         .getAttribute('style')
-        ?.indexOf('width: 75%'),
+        ?.indexOf('width: 50%'),
     ).toBeGreaterThanOrEqual(0);
-    expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(3);
+    expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(2);
 
-    // act(() => {
-    //   html.find('Input#test').simulate('change', {
-    //     target: {
-    //       value: 'aaaabbbbcccc',
-    //     },
-    //   });
-    // });
-    // await waitForComponentToPaint(html, 100);
-    // console.log(
-    //   html.find('div.ant-popover .ant-progress-bg').at(0).getDOMNode().getAttribute('style'),
-    // );
-    // expect(
-    //   html
-    //     .find('div.ant-popover .ant-progress-bg')
-    //     .at(0)
-    //     .getDOMNode()
-    //     .getAttribute('style')
-    //     ?.indexOf('width: 75%'),
-    // ).toBeGreaterThanOrEqual(0);
-    // expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(3);
+    act(() => {
+      html.find('Input#test').simulate('change', {
+        target: {
+          value: '12345678901AB',
+        },
+      });
+    });
+    await waitForComponentToPaint(html, 1000);
+    expect(html.find('div.ant-popover.ant-popover-hidden').exists()).toBeTruthy();
 
-    // act(() => {
-    //   html.find('Input#test').simulate('change', {
-    //     target: {
-    //       value: 'aaaabbbbcccc1',
-    //     },
-    //   });
-    // });
-    // await waitForComponentToPaint(html, 100);
-    // expect(
-    //   html
-    //     .find('div.ant-popover .ant-progress-bg')
-    //     .at(0)
-    //     .getDOMNode()
-    //     .getAttribute('style')
-    //     ?.indexOf('width: 100%'),
-    // ).toBeGreaterThanOrEqual(0);
-    // expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(4);
-
-    // act(() => {
-    //   html.find('Input#test').simulate('change', {
-    //     target: {
-    //       value: '_',
-    //     },
-    //   });
-    // });
-    // await waitForComponentToPaint(html, 100);
-    // expect(
-    //   html
-    //     .find('div.ant-popover .ant-progress-bg')
-    //     .at(0)
-    //     .getDOMNode()
-    //     .getAttribute('style')
-    //     ?.indexOf('width: 25%'),
-    // ).toBeGreaterThanOrEqual(0);
-    // expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(1);
+    act(() => {
+      html.find('Input#test').simulate('change', {
+        target: {
+          value: '',
+        },
+      });
+    });
+    await waitForComponentToPaint(html, 1000);
+    expect(html.find('div.ant-popover.ant-popover-hidden').exists()).toBeFalsy();
+    expect(html.find('.ant-popover .anticon.anticon-check-circle').length).toEqual(0);
   });
 
   it('📅 InlineErrorFormItem no progress', async () => {
@@ -373,30 +337,12 @@ describe('utils', () => {
     act(() => {
       html.find('Input#test').simulate('focus');
     });
-    await waitForComponentToPaint(html, 100);
-    expect(html.find('div.ant-popover .ant-progress').exists()).toBeFalsy();
-  });
-
-  it('📅 InlineErrorFormItem no progress', async () => {
-    const html = mount(
-      <Form>
-        <InlineErrorFormItem
-          errorType="popover"
-          rules={[
-            {
-              required: true,
-              message: '必填项',
-            },
-          ]}
-          popoverProps={{ trigger: 'focus' }}
-          name="title"
-        >
-          <Input id="test" />
-        </InlineErrorFormItem>
-      </Form>,
-    );
     act(() => {
-      html.find('Input#test').simulate('focus');
+      html.find('Input#test').simulate('change', {
+        target: {
+          value: '1',
+        },
+      });
     });
     await waitForComponentToPaint(html, 100);
     expect(html.find('div.ant-popover .ant-progress').exists()).toBeFalsy();
@@ -426,6 +372,13 @@ describe('utils', () => {
     );
     act(() => {
       html.find('Input#test').simulate('focus');
+    });
+    act(() => {
+      html.find('Input#test').simulate('change', {
+        target: {
+          value: '1',
+        },
+      });
     });
     await waitForComponentToPaint(html, 100);
     expect(html.find('div.ant-popover .ant-progress').exists()).toBeTruthy();


### PR DESCRIPTION
- 现在只有在表单域错误时才会展示popover
- 整理了一下相关测试用例

Closes #2361