### PR TITLE
fix(table): defaultSortOrder and defaultFilteredValue

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -20,7 +20,14 @@ import Container from './container';
 import Toolbar from './components/ToolBar';
 import Alert from './components/Alert';
 import FormRender from './components/Form';
-import { genColumnKey, mergePagination, useActionType, isBordered } from './utils';
+import {
+  genColumnKey,
+  mergePagination,
+  useActionType,
+  isBordered,
+  parseDefaultSort,
+  parseDefaultFilter,
+} from './utils';
 import { genProColumnToColumn } from './utils/genProColumnToColumn';
 
 import './index.less';
@@ -340,34 +347,8 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
 
   /** 设置默认排序和筛选值 */
   useEffect(() => {
-    const resolveDataIndex = (dataIndex: ProColumnType['dataIndex']): string | undefined => {
-      if (Array.isArray(dataIndex)) {
-        return dataIndex.join(',');
-      }
-      return dataIndex?.toString();
-    };
-
-    const defaultProFilter: Record<string, React.ReactText[]> = {};
-    const defaultProSort: Record<string, SortOrder> = {};
-    propsColumns
-      .filter((column) => !!column.filters)
-      .forEach((column) => {
-        const dataIndex = resolveDataIndex(column.dataIndex);
-        if (dataIndex && column.defaultFilteredValue) {
-          defaultProFilter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
-        }
-      });
-    propsColumns
-      .filter((column) => !!column.sorter)
-      .forEach((column) => {
-        const dataIndex = resolveDataIndex(column.dataIndex);
-        if (dataIndex && column.defaultSortOrder) {
-          defaultProSort[dataIndex] = column.defaultSortOrder;
-        }
-      });
-
-    setProFilter(defaultProFilter);
-    setProSort(defaultProSort);
+    setProFilter(parseDefaultFilter(propsColumns));
+    setProSort(parseDefaultSort(propsColumns));
   }, []);
 
   /** 获取 table 的 dom ref */

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -26,6 +26,7 @@ import { genProColumnToColumn } from './utils/genProColumnToColumn';
 import './index.less';
 import type {
   PageInfo,
+  ProColumnType,
   ProTableProps,
   RequestData,
   TableRowSelection,
@@ -336,6 +337,38 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
 
   const [proFilter, setProFilter] = useMountMergeState<Record<string, React.ReactText[]>>({});
   const [proSort, setProSort] = useMountMergeState<Record<string, SortOrder>>({});
+
+  /** 设置默认排序和筛选值 */
+  useEffect(() => {
+    const resolveDataIndex = (dataIndex: ProColumnType['dataIndex']): string | undefined => {
+      if (Array.isArray(dataIndex)) {
+        return dataIndex.join(',');
+      }
+      return dataIndex?.toString();
+    };
+
+    const defaultProFilter: Record<string, React.ReactText[]> = {};
+    const defaultProSort: Record<string, SortOrder> = {};
+    propsColumns
+      .filter((column) => !!column.filters)
+      .forEach((column) => {
+        const dataIndex = resolveDataIndex(column.dataIndex);
+        if (dataIndex && column.defaultFilteredValue) {
+          defaultProFilter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
+        }
+      });
+    propsColumns
+      .filter((column) => !!column.sorter)
+      .forEach((column) => {
+        const dataIndex = resolveDataIndex(column.dataIndex);
+        if (dataIndex && column.defaultSortOrder) {
+          defaultProSort[dataIndex] = column.defaultSortOrder;
+        }
+      });
+
+    setProFilter(defaultProFilter);
+    setProSort(defaultProSort);
+  }, []);
 
   /** 获取 table 的 dom ref */
   const rootRef = useRef<HTMLDivElement>(null);

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -25,8 +25,7 @@ import {
   mergePagination,
   useActionType,
   isBordered,
-  parseDefaultSort,
-  parseDefaultFilter,
+  parseDefaultColumnConfig,
 } from './utils';
 import { genProColumnToColumn } from './utils/genProColumnToColumn';
 
@@ -346,8 +345,9 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
 
   /** 设置默认排序和筛选值 */
   useEffect(() => {
-    setProFilter(parseDefaultFilter(propsColumns));
-    setProSort(parseDefaultSort(propsColumns));
+    const { sort, filter } = parseDefaultColumnConfig(propsColumns);
+    setProFilter(filter);
+    setProSort(sort);
   }, []);
 
   /** 获取 table 的 dom ref */

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -33,7 +33,6 @@ import { genProColumnToColumn } from './utils/genProColumnToColumn';
 import './index.less';
 import type {
   PageInfo,
-  ProColumnType,
   ProTableProps,
   RequestData,
   TableRowSelection,

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -165,32 +165,24 @@ function parseDataIndex(dataIndex: ProColumnType['dataIndex']): string | undefin
   return dataIndex?.toString();
 }
 
-export function parseDefaultSort<T, Value>(
-  columns: ProColumns<T, Value>[],
-): Record<string, SortOrder> {
-  const defaultSort: Record<string, SortOrder> = {};
-  columns
-    .filter((column) => !!column.sorter && !!column.defaultSortOrder)
-    .forEach((column) => {
-      const dataIndex = parseDataIndex(column.dataIndex);
-      if (dataIndex) {
-        defaultSort[dataIndex] = column.defaultSortOrder!;
-      }
-    });
-  return defaultSort;
-}
-
-export function parseDefaultFilter<T, Value>(
-  columns: ProColumns<T, Value>[],
-): Record<string, React.ReactText[]> {
-  const defaultFilter: Record<string, React.ReactText[]> = {};
+export function parseDefaultColumnConfig<T, Value>(columns: ProColumns<T, Value>[]) {
+  const filter: Record<string, React.ReactText[]> = {};
+  const sort: Record<string, SortOrder> = {};
   columns
     .filter((column) => !!column.filters && !!column.defaultFilteredValue)
     .forEach((column) => {
       const dataIndex = parseDataIndex(column.dataIndex);
       if (dataIndex) {
-        defaultFilter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
+        filter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
       }
     });
-  return defaultFilter;
+  columns
+    .filter((column) => !!column.sorter && !!column.defaultSortOrder)
+    .forEach((column) => {
+      const dataIndex = parseDataIndex(column.dataIndex);
+      if (dataIndex) {
+        sort[dataIndex] = column.defaultSortOrder!;
+      }
+    });
+  return { sort, filter };
 }

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -168,21 +168,17 @@ function parseDataIndex(dataIndex: ProColumnType['dataIndex']): string | undefin
 export function parseDefaultColumnConfig<T, Value>(columns: ProColumns<T, Value>[]) {
   const filter: Record<string, React.ReactText[]> = {};
   const sort: Record<string, SortOrder> = {};
-  columns
-    .filter((column) => !!column.filters && !!column.defaultFilteredValue)
-    .forEach((column) => {
-      const dataIndex = parseDataIndex(column.dataIndex);
-      if (dataIndex) {
-        filter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
-      }
-    });
-  columns
-    .filter((column) => !!column.sorter && !!column.defaultSortOrder)
-    .forEach((column) => {
-      const dataIndex = parseDataIndex(column.dataIndex);
-      if (dataIndex) {
-        sort[dataIndex] = column.defaultSortOrder!;
-      }
-    });
+  columns.forEach((column) => {
+    const dataIndex = parseDataIndex(column.dataIndex);
+    if (!dataIndex) {
+      return;
+    }
+    if (column.filters && column.defaultFilteredValue) {
+      filter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
+    }
+    if (column.sorter && column.defaultSortOrder) {
+      sort[dataIndex] = column.defaultSortOrder!;
+    }
+  });
   return { sort, filter };
 }

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -1,9 +1,18 @@
+import React from 'react';
 import type { TablePaginationConfig } from 'antd';
+import { SortOrder } from 'antd/es/table/interface';
 
 import type { UseEditableUtilType } from '@ant-design/pro-utils';
 import type { IntlType } from '@ant-design/pro-provider';
 
-import type { ActionType, Bordered, BorderedType, UseFetchDataAction } from '../typing';
+import type {
+  ActionType,
+  Bordered,
+  BorderedType,
+  ProColumns,
+  ProColumnType,
+  UseFetchDataAction,
+} from '../typing';
 
 /**
  * 检查值是否存在 为了 避开 0 和 false
@@ -148,3 +157,40 @@ export const genColumnKey = (key?: React.ReactText | undefined, index?: number):
   }
   return `${index}`;
 };
+
+function parseDataIndex(dataIndex: ProColumnType['dataIndex']): string | undefined {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.join(',');
+  }
+  return dataIndex?.toString();
+}
+
+export function parseDefaultSort<T, Value>(
+  columns: ProColumns<T, Value>[],
+): Record<string, SortOrder> {
+  const defaultSort: Record<string, SortOrder> = {};
+  columns
+    .filter((column) => !!column.filters && !!column.defaultSortOrder)
+    .forEach((column) => {
+      const dataIndex = parseDataIndex(column.dataIndex);
+      if (dataIndex) {
+        defaultSort[dataIndex] = column.defaultSortOrder!;
+      }
+    });
+  return defaultSort;
+}
+
+export function parseDefaultFilter<T, Value>(
+  columns: ProColumns<T, Value>[],
+): Record<string, React.ReactText[]> {
+  const defaultFilter: Record<string, React.ReactText[]> = {};
+  columns
+    .filter((column) => !!column.filters && !!column.defaultFilteredValue)
+    .forEach((column) => {
+      const dataIndex = parseDataIndex(column.dataIndex);
+      if (dataIndex) {
+        defaultFilter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
+      }
+    });
+  return defaultFilter;
+}

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -158,6 +158,11 @@ export const genColumnKey = (key?: React.ReactText | undefined, index?: number):
   return `${index}`;
 };
 
+/**
+ * 将 ProTable - column - dataIndex 转为字符串形式
+ *
+ * @param dataIndex Column 中的 dataIndex
+ */
 function parseDataIndex(dataIndex: ProColumnType['dataIndex']): string | undefined {
   if (Array.isArray(dataIndex)) {
     return dataIndex.join(',');
@@ -165,17 +170,25 @@ function parseDataIndex(dataIndex: ProColumnType['dataIndex']): string | undefin
   return dataIndex?.toString();
 }
 
+/**
+ * 从 ProColumns 数组中取出默认的排序和筛选数据
+ *
+ * @param columns ProColumns
+ */
 export function parseDefaultColumnConfig<T, Value>(columns: ProColumns<T, Value>[]) {
   const filter: Record<string, React.ReactText[]> = {};
   const sort: Record<string, SortOrder> = {};
   columns.forEach((column) => {
+    // 转换 dataIndex
     const dataIndex = parseDataIndex(column.dataIndex);
     if (!dataIndex) {
       return;
     }
+    // 当 column 启用 filters 功能时，取出默认的筛选值
     if (column.filters && column.defaultFilteredValue) {
       filter[dataIndex] = column.defaultFilteredValue as React.ReactText[];
     }
+    // 当 column 启用 sorter 功能时，取出默认的排序值
     if (column.sorter && column.defaultSortOrder) {
       sort[dataIndex] = column.defaultSortOrder!;
     }

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -170,7 +170,7 @@ export function parseDefaultSort<T, Value>(
 ): Record<string, SortOrder> {
   const defaultSort: Record<string, SortOrder> = {};
   columns
-    .filter((column) => !!column.filters && !!column.defaultSortOrder)
+    .filter((column) => !!column.sorter && !!column.defaultSortOrder)
     .forEach((column) => {
       const dataIndex = parseDataIndex(column.dataIndex);
       if (dataIndex) {

--- a/tests/table/filter.test.tsx
+++ b/tests/table/filter.test.tsx
@@ -99,7 +99,7 @@ describe('BasicTable Search', () => {
               2: { text: '已上线', status: 'Success' },
               3: { text: '异常', status: 'Error' },
             },
-            defaultFilteredValue: [0, 1],
+            defaultFilteredValue: ['0', '1'],
           },
         ]}
         onChange={fn}
@@ -171,7 +171,7 @@ describe('BasicTable Search', () => {
               2: { text: '已上线', status: 'Success' },
               3: { text: '异常', status: 'Error' },
             },
-            defaultFilteredValue: [0, 1],
+            defaultFilteredValue: ['0', '1'],
           },
         ]}
         request={async (_, sort, filter) => {

--- a/tests/table/filter.test.tsx
+++ b/tests/table/filter.test.tsx
@@ -171,7 +171,7 @@ describe('BasicTable Search', () => {
               2: { text: '已上线', status: 'Success' },
               3: { text: '异常', status: 'Error' },
             },
-            defaultFilteredValue: ['0', '1'],
+            defaultFilteredValue: ['0'],
           },
         ]}
         request={async (_, sort, filter) => {
@@ -217,6 +217,32 @@ describe('BasicTable Search', () => {
         .at(0)
         .simulate('click', {
           target: {
+            checked: false,
+          },
+        });
+    });
+
+    await waitForComponentToPaint(html, 500);
+    act(() => {
+      html
+        .find('.ant-table-filter-dropdown-btns .ant-btn.ant-btn-primary.ant-btn-sm')
+        .simulate('click');
+    });
+
+    await waitForComponentToPaint(html, 200);
+    act(() => {
+      html.find('span.ant-table-filter-trigger').simulate('click');
+    });
+
+    await waitForComponentToPaint(html, 800);
+    act(() => {
+      html.find('.ant-table-filter-dropdown').debug();
+      html.find('span.ant-table-filter-trigger').simulate('click');
+      html
+        .find('.ant-table-filter-dropdown .ant-dropdown-menu-item')
+        .at(0)
+        .simulate('click', {
+          target: {
             checked: true,
           },
         });
@@ -230,7 +256,7 @@ describe('BasicTable Search', () => {
     });
 
     await waitForComponentToPaint(html, 500);
-    expect(fn).toBeCalledTimes(1);
+    expect(fn).toBeCalledTimes(2);
   });
 
   it('🎏 order multiple test', async () => {

--- a/tests/table/filter.test.tsx
+++ b/tests/table/filter.test.tsx
@@ -99,6 +99,7 @@ describe('BasicTable Search', () => {
               2: { text: '已上线', status: 'Success' },
               3: { text: '异常', status: 'Error' },
             },
+            defaultFilteredValue: [0, 1],
           },
         ]}
         onChange={fn}
@@ -170,6 +171,7 @@ describe('BasicTable Search', () => {
               2: { text: '已上线', status: 'Success' },
               3: { text: '异常', status: 'Error' },
             },
+            defaultFilteredValue: [0, 1],
           },
         ]}
         request={async (_, sort, filter) => {
@@ -245,6 +247,7 @@ describe('BasicTable Search', () => {
               compare: (a, b) => a.money - b.money,
               multiple: 3,
             },
+            defaultSortOrder: 'descend',
           },
           {
             title: 'money',
@@ -254,6 +257,7 @@ describe('BasicTable Search', () => {
               compare: (a, b) => a.money - b.money,
               multiple: 3,
             },
+            defaultSortOrder: 'ascend',
           },
           {
             title: '状态',
@@ -306,6 +310,7 @@ describe('BasicTable Search', () => {
             key: 'name',
             dataIndex: 'name',
             sorter: (a, b) => a.money - b.money,
+            defaultSortOrder: 'descend',
           },
           {
             title: 'money',


### PR DESCRIPTION
修复 ProTable 的默认排序和默认筛选值功能（#1179），用了一种似乎比较笨的方法，即 `useEffect(() => { ... }, [])` 中解析 `proColumns` 内的 default 数据，再调用 `setProSort` 和 `setProFilter`

测试发现功能可用，可作为临时的解决方案，但不知是否合理。。。

（本菜鸟想不出啥好的解决方案，希望各位大大能做后续优化）