### PR TITLE
fix(form): ignore case when highlighting options

### DIFF
--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -113,7 +113,7 @@ const Highlight: React.FC<{
   label: string;
   words: string[];
 }> = ({ label, words }) => {
-  const reg = new RegExp(words.map((w) => w.replace(/\\/g, '\\\\')).join('|'), 'g');
+  const reg = new RegExp(words.map((w) => w.replace(/\\/g, '\\\\')).join('|'), 'gi');
   const token = label.replace(reg, '#@$&#');
   const elements = token.split('#').map((x) =>
     x[0] === '@'


### PR DESCRIPTION
Select 搜索时会高亮匹配的文本，搜索时是不区分大小写的，但是高亮却会区分大小写，导致不一致。
修改前：
![image](https://user-images.githubusercontent.com/21698836/113541934-c6e04c00-9615-11eb-83bd-acf93b7c94a1.png)
修改后：
![image](https://user-images.githubusercontent.com/21698836/113541952-d069b400-9615-11eb-828a-f4ec4ad0c1cd.png)

