### PR TITLE
设置 Select 的 optionLabelProp 和 optionFilterProp 的默认值为 label

### DIFF
--- a/packages/field/src/components/Select/SearchSelect/index.tsx
+++ b/packages/field/src/components/Select/SearchSelect/index.tsx
@@ -83,6 +83,8 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     onChange,
     searchOnFocus = false,
     resetAfterSelect = false,
+    optionFilterProp = 'label',
+    optionLabelProp = 'label',
     className,
     disabled,
     options,
@@ -156,6 +158,8 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
       allowClear
       disabled={disabled}
       mode={mode}
+      optionFilterProp={optionFilterProp}
+      optionLabelProp={optionLabelProp}
       {...restProps}
       onSearch={
         restProps?.showSearch


### PR DESCRIPTION
1. 使用 Select 的都是用 options 和 valueEnum 来配置选项的，antd 默认是根据 value 搜索的，但是真实场景中绝大部分情况下都是根据 label 来搜索的，所以将 optionFilterProp 设置为 label
2. Select 对匹配项做了高亮处理，所以回填到输入框的值也是高亮的，将 optionFilterProp 设置为 label 可以解决这个问题，而且我觉得也是比较合理的