### PR TITLE
fix(field): fix index column align center

### DIFF
--- a/packages/field/src/components/IndexColumn/index.less
+++ b/packages/field/src/components/IndexColumn/index.less
@@ -3,7 +3,7 @@
 @pro-field-index-prefix-cls: ~'@{ant-prefix}-pro-field-index-column';
 
 .@{pro-field-index-prefix-cls} {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 18px;


### PR DESCRIPTION
Fixed index and  indexBorder column setting center invalid.
```diff
{
    title: 'index',
    dataIndex: 'index',
+   valueType: 'indexBorder',
+   align: 'center'
}
```