### PR TITLE
just fixed broken table in markdown file

### DIFF
--- a/packages/form/src/components/QueryFilter/index.en-US.md
+++ b/packages/form/src/components/QueryFilter/index.en-US.md
@@ -66,7 +66,7 @@ Note that the values of the breakpoints are the size of the form container and n
 ##### Rules for default layout
 
 | container-width breakpoint | single-row display form single-column count (including action area) | default layout |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- |
 | `≧ 1352px` | 4 columns | `horizontal` |
 | `≧ 1062px` | 3 columns | `horizontal` |
 | `≧ 701px && < 1063px` | 3 columns | `horizontal` | `≧ 701px && < 1063px` | 3 columns |

--- a/packages/form/src/form.en-US.md
+++ b/packages/form/src/form.en-US.md
@@ -105,7 +105,7 @@ ProForm is a repackaging of antd Form, if you want to customize form elements, P
 > antd's Form api View [here](https://ant.design/components/form-cn/)
 
 | Parameters | Description | Type | Default |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | onFinish | Callback event after form is submitted and data validation is successful, same as antd 4 `Form` component API | `(values)=>Promise<void>` | - |
 | onReset | Callback for clicking the reset button | `(e)=>void` | - |
 | submitter | Submitter button-related configuration | `boolean` \| `SubmitterProps` | `true` |

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -380,7 +380,7 @@ ref.current.cancelEditable(rowKey);
 > Requesting remote data is more complicated, see [here](/components/field#RemoteData) for details.
 
 | Properties | Description | Type | Default |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | title | is basically the same as in antd, but supports passing in a method | `ReactNode \| ((config: ProColumnType<T>, type: ProTableTypes) => ReactNode)` | - - |
 | tooltip | will show an icon after the title, and hover to prompt for some information | string | - |
 | renderText | similar to render for table, but must return string, if you just want to transform the enumeration, you can use [valueEnum](#valueEnum) | `(text: any,record: T,index: number, action: UseFetchDataAction<T>) => string` | - | render |
@@ -409,7 +409,7 @@ ProTable wraps some common value types to reduce repetitive `render` operations,
 The following values are now supported
 
 | type | description | example |
-| --- | --- | --- | --- |
+| --- | --- | --- |
 | money | Converts the value to an amount | ¥10,000.26 |
 | date | date | 2019-11-16 |
 | dateRange | dateRange | dateRange | 2019-11-16 2019-11-18 |


### PR DESCRIPTION
just fixed broken table in markdown file

**AS-IS**
| Parameters | Description | Type | Default |
| --- | --- | --- | --- | --- |
| onFinish | Callback event after form is submitted and data validation is successful, same as antd 4 `Form` component API | `(values)=>Promise<void>` | - |
| onReset | Callback for clicking the reset button | `(e)=>void` | - |
| submitter | Submitter button-related configuration | `boolean` \| `SubmitterProps` | `true` |
| dateFormatter | AutoFormat data, mainly moment forms, supports string and number modes | `string\| number \|false` | string |
| syncToUrl | sync parameters to url,url only supports string, better read [documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) before using | `true` \| `(values,type)=>values` | - |
| omitNil | ProForm automatically clears null and undefined data, if you have agreed that nil means something, set to false to disable this feature | `boolean` | true |
| string | [(...)](https://ant.design/components/form-cn/) | support other antd `Form` component parameters besides `wrapperCol` \| `labelCol` \| `layout` | - | - |

**TO-BE**
| Parameters | Description | Type | Default |
| --- | --- | --- | --- |
| onFinish | Callback event after form is submitted and data validation is successful, same as antd 4 `Form` component API | `(values)=>Promise<void>` | - |
| onReset | Callback for clicking the reset button | `(e)=>void` | - |
| submitter | Submitter button-related configuration | `boolean` \| `SubmitterProps` | `true` |
| dateFormatter | AutoFormat data, mainly moment forms, supports string and number modes | `string\| number \|false` | string |
| syncToUrl | sync parameters to url,url only supports string, better read [documentation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) before using | `true` \| `(values,type)=>values` | - |
| omitNil | ProForm automatically clears null and undefined data, if you have agreed that nil means something, set to false to disable this feature | `boolean` | true |
| string | [(...)](https://ant.design/components/form-cn/) | support other antd `Form` component parameters besides `wrapperCol` \| `labelCol` \| `layout` | - | - |

**fixed list**
- packages/form/src/components/QueryFilter/index.en-US.md
- packages/form/src/form.en-US.md
- packages/table/src/table.en-US.md