### PR TITLE
chore: update peerDependencies

### DIFF
--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/descriptions/package.json
+++ b/packages/descriptions/package.json
@@ -41,7 +41,8 @@
     "use-json-comparison": "^1.0.5"
   },
   "peerDependencies": {
-    "antd": "4.x"
+    "antd": "4.x",
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -46,6 +46,6 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -46,7 +46,8 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -51,8 +51,7 @@
   },
   "peerDependencies": {
     "antd": "^4.x",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -45,7 +45,7 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -48,7 +48,8 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -42,7 +42,8 @@
   },
   "peerDependencies": {
     "antd": "4.x",
-    "react": "^16.x"
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
1. 重新整理了一下 peerDependencies，现在各个包依赖的 react 版本时 16.x，如果用户安装的是 17.x，就会报下面的警告：
![image](https://user-images.githubusercontent.com/21698836/115143259-cfef0580-a078-11eb-8a86-9c9c80e32376.png)
更改后兼容 17.x，同时也和 ant-design 保持一致。

2. pro-layout 没有使用 react-dom，所以去掉了，pro-form、pro-table、pro-utils 使用 react-dom，所以加上了 react-dom。