### PR TITLE
fix(form): ispicturecard judgment logic

### DIFF
--- a/packages/form/src/components/UploadButton/index.tsx
+++ b/packages/form/src/components/UploadButton/index.tsx
@@ -46,7 +46,7 @@ const ProFormUploadButton: React.ForwardRefRenderFunction<any, ProFormDraggerPro
   const showUploadButton =
     (max === undefined || !value || value?.length < max) && proFieldProps?.mode !== 'read';
 
-  const isPictureCard = fieldProps?.listType === 'picture-card';
+  const isPictureCard = (listType ?? fieldProps?.listType) === 'picture-card';
   return (
     <Upload
       action={action}


### PR DESCRIPTION
Although listtype is provided in proformdraggerprops, if you want to set the hidden button, you need to set listtype in fieldprops additionally. This should be avoided