### PR TITLE
fix(table): fix table reload params

### DIFF
--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -344,7 +344,7 @@ Sometimes we want to manually trigger actions such as reload of a table, we can 
 
 ```tsx | pure
 interface ActionType {
-  reload: (resetPageIndex?: boolean) => void;
+  reload: (resetPageInfo?: { current?: number; pageSize?: number }) => void;
   reloadAndRest: () => void;
   reset: () => void;
   clearSelected?: () => void;

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -350,7 +350,7 @@ export type OptionConfig = {
 
 ```tsx | pure
 interface ActionType {
-  reload: (resetPageIndex?: boolean) => void;
+  reload: (resetPageInfo?: { current?: number; pageSize?: number }) => void;
   reloadAndRest: () => void;
   reset: () => void;
   clearSelected?: () => void;

--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -1,6 +1,6 @@
-import React from 'react';
+import type React from 'react';
 import type { TablePaginationConfig } from 'antd';
-import { SortOrder } from 'antd/es/table/interface';
+import type { SortOrder } from 'antd/es/table/interface';
 
 import type { UseEditableUtilType } from '@ant-design/pro-utils';
 import type { IntlType } from '@ant-design/pro-provider';
@@ -84,12 +84,12 @@ export function useActionType<T>(
   const userAction: ActionType = {
     ...props.editableUtils,
     pageInfo: action.pageInfo,
-    reload: async (resetPageIndex?: boolean) => {
-      // 如果为 true，回到第一页
-      if (resetPageIndex) {
-        await props.onCleanSelected();
+    reload: async (resetPageInfo?) => {
+      props.onCleanSelected();
+      if (resetPageInfo) {
+        await action.setPageInfo(resetPageInfo);
       }
-      action?.reload();
+      await action?.reload();
     },
     reloadAndRest: async () => {
       // reload 之后大概率会切换数据，清空一下选择。

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -121,7 +121,7 @@ export type ProSchemaComponentTypes =
 /** 操作类型 */
 export type ProCoreActionType<T = {}> = {
   /** @name 刷新 */
-  reload: (resetPageIndex?: boolean) => void;
+  reload: (resetPageInfo?: { current?: number; pageSize?: number }) => void;
   /** @name 刷新并清空，只清空页面，不包括表单 */
   reloadAndRest?: () => void;
   /** @name 重置任何输入项，包括表单 */


### PR DESCRIPTION
原来的传 true 无效，代码中只判断了传 true 清空选中，没有实际重置页码。
现在 reload 可以自定义页数，想重置页数可以传 { current: 1 }
场景：当前是第 5 页，我批量删除了这页的全部之后需要请求第四页的数据