### PR TITLE
fix(form): should only clear collapsed fields when clear button in the more dropdown clicked

### DIFF
--- a/packages/form/src/layouts/LightFilter/index.tsx
+++ b/packages/form/src/layouts/LightFilter/index.tsx
@@ -129,10 +129,12 @@ const LightFilterContainer: React.FC<{
                 },
                 onClear: () => {
                   const clearValues = {};
-                  Object.keys(moreValues).forEach((key) => {
-                    clearValues[key] = undefined;
+                  collapseItems.forEach((child: any) => {
+                    const { name } = child.props;
+                    clearValues[name] = undefined;
                   });
-                  setMoreValues(clearValues);
+
+                  onValuesChange(clearValues);
                 },
               }}
             >


### PR DESCRIPTION
- 更多筛选里面的清除按钮，应只清除更多筛选里面的表单项。
- 清除按钮点击后，立即触发一次 onChange 回调

![image](https://user-images.githubusercontent.com/3023524/118240883-172cb280-b4ce-11eb-9d04-72d69195fc47.png)
