### PR TITLE
chore: 增加组件 props 导出

### DIFF
--- a/packages/form/src/components/ColorPicker/index.tsx
+++ b/packages/form/src/components/ColorPicker/index.tsx
@@ -10,7 +10,7 @@ type ColorPickerProps = SketchPickerProps & {
   onChange?: (color: string) => void;
 };
 
-type ProFormColorPickerProps = ProFormItemProps<ColorPickerProps> & {
+export type ProFormColorPickerProps = ProFormItemProps<ColorPickerProps> & {
   popoverProps?: PopoverProps;
   colors?: string[];
 };

--- a/packages/form/src/components/Digit/index.tsx
+++ b/packages/form/src/components/Digit/index.tsx
@@ -4,7 +4,7 @@ import ProField from '@ant-design/pro-field';
 import type { ProFormItemProps } from '../../interface';
 import createField from '../../BaseForm/createField';
 
-type ProFormDigitProps = ProFormItemProps<InputNumberProps> & {
+export type ProFormDigitProps = ProFormItemProps<InputNumberProps> & {
   min?: InputNumberProps['min'];
   max?: InputNumberProps['max'];
 };


### PR DESCRIPTION
我想在 Color 组件和 Digit 组件基础上做一些封装，发现他们的  Props  都没有导出，于是修复。