### PR TITLE
fix(form):  fix autoClearSearchValue not work

### DIFF
--- a/packages/field/src/components/Select/SearchSelect/index.tsx
+++ b/packages/field/src/components/Select/SearchSelect/index.tsx
@@ -81,7 +81,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     onSearch,
     onFocus,
     onChange,
-    autoClearSearchValue = true,
+    autoClearSearchValue,
     searchOnFocus = false,
     resetAfterSelect = false,
     optionFilterProp = 'label',
@@ -201,7 +201,11 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
         onChange?.(mergeValue, optionList, ...rest);
 
         // 将搜索框置空 和 antd 行为保持一致
-        if (autoClearSearchValue) setSearchValue(undefined);
+        if (restProps?.showSearch && autoClearSearchValue) {
+          fetchData('');
+          onSearch?.('');
+          setSearchValue('');
+        }
         // 将搜索结果置空，重新搜索
         if (resetAfterSelect) resetData();
       }}

--- a/packages/field/src/components/Select/SearchSelect/index.tsx
+++ b/packages/field/src/components/Select/SearchSelect/index.tsx
@@ -81,6 +81,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     onSearch,
     onFocus,
     onChange,
+    autoClearSearchValue = true,
     searchOnFocus = false,
     resetAfterSelect = false,
     optionFilterProp = 'label',
@@ -198,6 +199,9 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
         // 合并值
         const mergeValue = getMergeValue(value, optionList) as any;
         onChange?.(mergeValue, optionList, ...rest);
+
+        // 将搜索框置空 和 antd 行为保持一致
+        if (autoClearSearchValue) setSearchValue(undefined);
         // 将搜索结果置空，重新搜索
         if (resetAfterSelect) resetData();
       }}


### PR DESCRIPTION
支持 autoClearSearchValue ，是否在选中项后清空搜索框，只在 mode 为 multiple 或 tags 时有效
让其保持与antd的行为一致