### PR TITLE
feat(layout): 给 menuItemRender 添加参数

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -50,6 +50,7 @@ export type BaseMenuProps = {
         onClick: () => void;
       },
       defaultDom: React.ReactNode,
+      menuProps: BaseMenuProps,
     ) => React.ReactNode
   >;
   postMenuData?: (menusData?: MenuDataItem[]) => MenuDataItem[];
@@ -195,7 +196,7 @@ class MenuUtil {
         replace: itemPath === location.pathname,
         onClick: () => onCollapse && onCollapse(true),
       };
-      return menuItemRender(renderItemProps, defaultItem);
+      return menuItemRender(renderItemProps, defaultItem, this.props);
     }
     return defaultItem;
   };

--- a/packages/layout/src/layout.en-US.md
+++ b/packages/layout/src/layout.en-US.md
@@ -167,7 +167,7 @@ PageContainer configuration `ghost` can switch the page header to transparent mo
 | pageTitleRender | The render method for custom page titles | `(props: BasicLayoutProps) => ReactNode` | - |
 | menuRender | The render method for custom menus | `(props: HeaderViewProps) => ReactNode` | - |
 | postMenuData | View the menu data before displaying it, changes will not trigger a re-render | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
-| menuItemRender | The render method for custom menu items | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
+| menuItemRender | The render method for custom menu items | [`(itemProps: MenuDataItem, defaultDom: React.ReactNode, props: BaseMenuProps) => ReactNode`](/components/layout/#menudataitem) | - |
 | subMenuItemRender | Customize the render method with submenu items | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
 | menuDataRender | The render method of menuData, used to customize menuData | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
 | breadcrumbRender | customize the data for breadcrumbs | `(route)=>route` | - |

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -134,7 +134,7 @@ PageContainer 配置 `ghost` 可以将页头切换为透明模式。
 | pageTitleRender | 自定义页面标题的显示方法 | `(props: BasicLayoutProps) => string` | - |
 | menuRender | 自定义菜单的 render 方法 | `(props: HeaderViewProps) => ReactNode` | - |
 | postMenuData | 在显示前对菜单数据进行查看，修改不会触发重新渲染 | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
-| menuItemRender | 自定义菜单项的 render 方法 | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
+| menuItemRender | 自定义菜单项的 render 方法 | [`(itemProps: MenuDataItem, defaultDom: React.ReactNode, props: BasicLayoutProps) => ReactNode`](/components/layout/#menudataitem) | - |
 | subMenuItemRender | 自定义拥有子菜单菜单项的 render 方法 | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
 | menuDataRender | menuData 的 render 方法，用来自定义 menuData | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
 | breadcrumbRender | 自定义面包屑的数据 | `(route)=>route` | - |

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -134,7 +134,7 @@ PageContainer 配置 `ghost` 可以将页头切换为透明模式。
 | pageTitleRender | 自定义页面标题的显示方法 | `(props: BasicLayoutProps) => string` | - |
 | menuRender | 自定义菜单的 render 方法 | `(props: HeaderViewProps) => ReactNode` | - |
 | postMenuData | 在显示前对菜单数据进行查看，修改不会触发重新渲染 | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
-| menuItemRender | 自定义菜单项的 render 方法 | [`(itemProps: MenuDataItem, defaultDom: React.ReactNode, props: BasicLayoutProps) => ReactNode`](/components/layout/#menudataitem) | - |
+| menuItemRender | 自定义菜单项的 render 方法 | [`(itemProps: MenuDataItem, defaultDom: React.ReactNode, props: BaseMenuProps) => ReactNode`](/components/layout/#menudataitem) | - |
 | subMenuItemRender | 自定义拥有子菜单菜单项的 render 方法 | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
 | menuDataRender | menuData 的 render 方法，用来自定义 menuData | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
 | breadcrumbRender | 自定义面包屑的数据 | `(route)=>route` | - |


### PR DESCRIPTION
背景：
默认生成的菜单不会处理带参数的path，需通过 menuItemRender 进行自定义。处理参数需要用到 route 和 location，期望通过 props进行获取。