### PR TITLE
fix(table): fix table align with tooltip

### DIFF
--- a/packages/utils/src/components/LabelIconTip/index.less
+++ b/packages/utils/src/components/LabelIconTip/index.less
@@ -3,7 +3,7 @@
 @pro-core-label-tip: ~'@{ant-prefix}-pro-core-label-tip';
 
 .@{pro-core-label-tip} {
-  display: flex;
+  display: inline-flex;
   align-items: center;
 
   &-icon {


### PR DESCRIPTION
修复 column 配置了 tooltip 时，align 无效的问题