### PR TITLE
feat(package/layout): 开放 collapsedWidth

### DIFF
--- a/packages/layout/src/BasicLayout.tsx
+++ b/packages/layout/src/BasicLayout.tsx
@@ -225,10 +225,11 @@ export type BasicLayoutContext = { [K in 'location']: BasicLayoutProps[K] } & {
 const getPaddingLeft = (
   hasLeftPadding: boolean,
   collapsed: boolean | undefined,
+  collapsedWidth: number,
   siderWidth: number,
 ): number | undefined => {
   if (hasLeftPadding) {
-    return collapsed ? 48 : siderWidth;
+    return collapsed ? collapsedWidth : siderWidth;
   }
   return 0;
 };
@@ -248,6 +249,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
     defaultCollapsed,
     style,
     disableContentMargin,
+    collapsedWidth = 48,
     siderWidth = 208,
     menu,
     isChildrenLayout: propsIsChildrenLayout,
@@ -484,7 +486,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
   });
 
   /** 计算 slider 的宽度 */
-  const leftSiderWidth = getPaddingLeft(!!hasLeftPadding, collapsed, siderWidth);
+  const leftSiderWidth = getPaddingLeft(!!hasLeftPadding, collapsed, collapsedWidth, siderWidth);
 
   // siderMenuDom 为空的时候，不需要 padding
   const genLayoutStyle: CSSProperties = {

--- a/packages/layout/src/Header.tsx
+++ b/packages/layout/src/Header.tsx
@@ -23,6 +23,7 @@ export type HeaderViewProps = GlobalHeaderProps & {
     (logo: React.ReactNode, title: React.ReactNode, props: HeaderViewProps) => React.ReactNode
   >;
   headerContentRender?: WithFalse<(props: HeaderViewProps) => React.ReactNode>;
+  collapsedWidth: number;
   siderWidth?: number;
   hasSiderMenu?: boolean;
 };
@@ -67,6 +68,7 @@ class HeaderView extends Component<HeaderViewProps & PrivateSiderMenuProps, Head
       style,
       navTheme,
       collapsed,
+      collapsedWidth = 48,
       siderWidth,
       hasSiderMenu,
       isMobile,
@@ -88,7 +90,7 @@ class HeaderView extends Component<HeaderViewProps & PrivateSiderMenuProps, Head
     /** 计算侧边栏的宽度，不然导致左边的样式会出问题 */
     const width =
       layout !== 'mix' && needSettingWidth
-        ? `calc(100% - ${collapsed ? 48 : siderWidth}px)`
+        ? `calc(100% - ${collapsed ? collapsedWidth : siderWidth}px)`
         : '100%';
 
     const right = needFixedHeader ? 0 : undefined;

--- a/packages/layout/src/components/SiderMenu/SiderMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/SiderMenu.tsx
@@ -54,6 +54,7 @@ export const defaultRenderLogoAndTitle = (
 
 export type SiderMenuProps = {
   logo?: React.ReactNode;
+  collapsedWidth: number;
   siderWidth?: number;
   menuHeaderRender?: WithFalse<
     (logo: React.ReactNode, title: React.ReactNode, props?: SiderMenuProps) => React.ReactNode
@@ -89,6 +90,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
     menuFooterRender,
     onCollapse,
     theme,
+    collapsedWidth = 48,
     siderWidth,
     isMobile,
     onMenuHeaderClick,
@@ -134,11 +136,11 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
       {fixSiderbar && (
         <div
           style={{
-            width: collapsed ? 48 : siderWidth,
+            width: collapsed ? collapsedWidth : siderWidth,
             overflow: 'hidden',
-            flex: `0 0 ${collapsed ? 48 : siderWidth}px`,
-            maxWidth: collapsed ? 48 : siderWidth,
-            minWidth: collapsed ? 48 : siderWidth,
+            flex: `0 0 ${collapsed ? collapsedWidth : siderWidth}px`,
+            maxWidth: collapsed ? collapsedWidth : siderWidth,
+            minWidth: collapsed ? collapsedWidth : siderWidth,
             transition: `background-color 0.3s, min-width 0.3s, max-width 0.3s cubic-bezier(0.645, 0.045, 0.355, 1)`,
             ...style,
           }}
@@ -153,7 +155,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
           if (isMobile) return;
           onCollapse?.(collapse);
         }}
-        collapsedWidth={48}
+        collapsedWidth={collapsedWidth}
         style={{
           overflow: 'hidden',
           paddingTop: layout === 'mix' && !isMobile ? headerHeight : undefined,


### PR DESCRIPTION
1. 基础component siderMenu 增加collapsedWidth属性, 替换所有硬编码的48；
2. baseLayout getPaddingLeft 使用collapsedWidth；
3. header 接收collapsedWidth属性；
4. 其他 css可通过覆盖修改；