### PR TITLE
feat(table): 增加在ProTable中的ProColumns中fieldProps支持的属性类型描述

### DIFF
--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -223,9 +223,12 @@ export type ProSchema<
           entity: Entity;
         },
       ) => Record<string, any>)
-    | Record<string, any> & {
-      placeholder: string;
-    };
+    | Record<string, any>
+    | {
+        placeholder?: string;
+        maxLength?: number;
+        [key: string]: any;
+      };
 
   /** @name 自定义的 formItemProps */
   formItemProps?:

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -223,7 +223,9 @@ export type ProSchema<
           entity: Entity;
         },
       ) => Record<string, any>)
-    | Record<string, any>;
+    | Record<string, any> & {
+      placeholder: string;
+    };
 
   /** @name 自定义的 formItemProps */
   formItemProps?:


### PR DESCRIPTION
问题：
在ProTable->ProColumns中的fieldProps属性支持多个input支持的属性，但缺失类型描述，导致开发时IDE无法智能提示，降低效率。

问题解决：
增加相关属性类型描述