### PR TITLE
fix(descriptions): RequestData 类型优化

### DIFF
--- a/packages/descriptions/src/useFetchData.tsx
+++ b/packages/descriptions/src/useFetchData.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from 'react';
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 
-export type RequestData = {
-  data: any;
+export type RequestData<T = any> = {
+  data?: T;
   success?: boolean;
   [key: string]: any;
-};
+} & Record<string, any>;
 export type UseFetchDataAction<T extends RequestData> = {
   dataSource: T['data'] | T;
   setDataSource: (value: T['data'] | T) => void;

--- a/packages/table/src/typing.ts
+++ b/packages/table/src/typing.ts
@@ -22,7 +22,7 @@ import type { DensitySize } from './components/ToolBar/DensityIcon';
 import type { ColumnsState, useContainer } from './container';
 import type { SearchConfig, TableFormItem } from './components/Form/FormRender';
 import type { LabelTooltipType } from 'antd/lib/form/FormItemLabel';
-import { SizeType } from 'antd/lib/config-provider/SizeContext';
+import type { SizeType } from 'antd/lib/config-provider/SizeContext';
 
 export type PageInfo = {
   pageSize: number;


### PR DESCRIPTION
接口返回中有可能不包括 `data`，同时又没自定义 requestInterceptors 时，`data` 应和 ProTable 中的逻辑一致：非必需属性。