### PR TITLE
fix(layout): 解决侧边栏菜单折叠按钮切换之后，defaultOpenAll失效

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -315,6 +315,9 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         newKeys = Array.from(new Set([...matchMenuKeys, ...(openKeys || [])]));
       }
       setOpenKeys(newKeys);
+    } else if (menu?.ignoreFlatMenu && defaultOpenAll) {
+      // 忽略用户手动折叠过的菜单状态，折叠按钮切换之后也可实现默认展开所有菜单
+      setOpenKeys(getOpenKeysFromMenuData(menuData));
     } else if (flatMenuKeys.length > 0) setDefaultOpenAll(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/layout/src/defaultSettings.ts
+++ b/packages/layout/src/defaultSettings.ts
@@ -29,7 +29,7 @@ export type PureSettings = {
   menu?: {
     locale?: boolean;
     defaultOpenAll?: boolean;
-    ignoreFlatMenu: boolean; // 是否忽略用户手动折叠过的菜单状态，如选择忽略，折叠按钮切换之后也可实现展开所有菜单
+    ignoreFlatMenu?: boolean; // 是否忽略用户手动折叠过的菜单状态，如选择忽略，折叠按钮切换之后也可实现展开所有菜单
     loading?: boolean;
     onLoadingChange?: (loading?: boolean) => void;
     params?: Record<string, any>;

--- a/packages/layout/src/defaultSettings.ts
+++ b/packages/layout/src/defaultSettings.ts
@@ -29,6 +29,7 @@ export type PureSettings = {
   menu?: {
     locale?: boolean;
     defaultOpenAll?: boolean;
+    ignoreFlatMenu: boolean; // 是否忽略用户手动折叠过的菜单状态，如选择忽略，折叠按钮切换之后也可实现展开所有菜单
     loading?: boolean;
     onLoadingChange?: (loading?: boolean) => void;
     params?: Record<string, any>;

--- a/packages/layout/src/demos/AlwaysDefaultOpenAllMenu.tsx
+++ b/packages/layout/src/demos/AlwaysDefaultOpenAllMenu.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import ProLayout, { PageContainer } from '@ant-design/pro-layout';
+
+export default () => (
+  <div
+    style={{
+      height: '100vh',
+    }}
+  >
+    <ProLayout
+      location={{
+        pathname: '/data_hui/data_hui2',
+      }}
+      route={{
+        routes: [
+          {
+            path: '/home',
+            name: '首页',
+            locale: 'menu.home',
+            children: [
+              {
+                path: '/home/overview',
+                name: '概述',
+                hideInMenu: true,
+                locale: 'menu.home.overview',
+              },
+              {
+                path: '/home/search',
+                name: '搜索',
+                hideInMenu: true,
+                locale: 'menu.home.search',
+              },
+            ],
+          },
+          {
+            path: '/data_hui',
+            name: '汇总数据',
+            locale: 'menu.data_hui',
+            children: [
+              {
+                collapsed: true,
+                menuName: '域买家维度交易',
+                name: '域买家维度交易',
+                children: [
+                  {
+                    id: 2,
+                    name: '月表',
+                    path: '/data_hui2',
+                  },
+                  {
+                    name: '日表',
+                    path: '/data_hui3?tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                  },
+                ],
+              },
+              {
+                name: '维度交易',
+                path: '/',
+                children: [
+                  {
+                    name: '月表',
+                    path: '/data_hui4',
+                  },
+                  {
+                    name: '日表',
+                    key: 'tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                    path: '/data_hui5',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }}
+      menu={{ defaultOpenAll: true, ignoreFlatMenu: true }}
+    >
+      <PageContainer content="欢迎使用">
+        <div>Hello World</div>
+      </PageContainer>
+    </ProLayout>
+  </div>
+);

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -61,7 +61,13 @@ ProLayout 默认不提供页脚，要是和 Pro 官网相同的样式，需要�
 
 ### 默认打开所有菜单
 
+menu 配置 `defaultOpenAll` 可以默认打开所有菜单
+
 <code src="./demos/DefaultOpenAllMenu.tsx" iframe="500px" title="默认打开所有菜单" />
+
+折叠按钮反复切换后`defaultOpenAll`将失效，menu 配置 `ignoreFlatMenu` 可以忽略手动折叠过的菜单，实现总是默认打开所有菜单
+
+<code src="./demos/AlwaysDefaultOpenAllMenu.tsx" iframe="500px" title="总是默认打开所有菜单" />
 
 ### 使用 IconFont
 
@@ -156,6 +162,7 @@ menu 中支持了部分常用的 menu 配置， 可以帮助我们更好的管�
 | --- | --- | --- | --- |
 | locale | menu 是否使用国际化，还需要 formatMessage 的配合。 | `boolean` | `true` |
 | defaultOpenAll | 默认打开所有的菜单项，要注意只有 layout 挂载之前生效，异步加载菜单是不支持的 | `boolean` | `false` |
+| ignoreFlatMenu | 是否忽略手动折叠过的菜单状态，结合 defaultOpenAll 可实现折叠按钮切换后，同样可以展开所有子菜单 | `boolean` | `false` |
 | type | 菜单的类型 | `sub` \| `group` | `group` |
 | autoClose | 选中菜单是否自动关闭菜单 | `boolean` | `true` |
 | loading | 菜单是否正在加载中 | `boolean` | `false` |

--- a/tests/layout/defaultSettings.ts
+++ b/tests/layout/defaultSettings.ts
@@ -32,7 +32,7 @@ export type PureSettings = {
   fixedHeader: boolean;
   /** Sticky siderbar */
   fixSiderbar: boolean;
-  menu: { locale?: boolean; defaultOpenAll?: boolean };
+  menu: { locale?: boolean; defaultOpenAll?: boolean; ignoreFlatMenu?: boolean };
   title: string;
   // Your custom iconfont Symbol script Url
   // eg：//at.alicdn.com/t/font_1039637_btcrd5co4w.js

--- a/tests/layout/index.test.tsx
+++ b/tests/layout/index.test.tsx
@@ -1134,4 +1134,193 @@ describe('BasicLayout', () => {
     await waitForComponentToPaint(html, 100);
     expect(fn).toBeCalledTimes(3);
   });
+
+  it('🥩 BasicLayout support menu.defaultOpenAll', async () => {
+    const Demo = () => {
+      const [pathname, setPathname] = useState('/admin/sub-page1');
+      return (
+        <BasicLayout
+          menu={{
+            defaultOpenAll: true,
+          }}
+          location={{ pathname }}
+          menuItemRender={(item, dom) => (
+            <a
+              onClick={() => {
+                item.onClick();
+                setPathname(item.path || '/welcome');
+              }}
+            >
+              {dom}
+            </a>
+          )}
+          menuDataRender={() => [
+            {
+              path: '/home',
+              name: '首页',
+              locale: 'menu.home',
+              children: [
+                {
+                  path: '/home/overview',
+                  name: '概述',
+                  hideInMenu: true,
+                  locale: 'menu.home.overview',
+                },
+                {
+                  path: '/home/search',
+                  name: '搜索',
+                  hideInMenu: true,
+                  locale: 'menu.home.search',
+                },
+              ],
+            },
+            {
+              path: '/data_hui',
+              name: '汇总数据',
+              locale: 'menu.data_hui',
+              children: [
+                {
+                  collapsed: true,
+                  menuName: '域买家维度交易',
+                  name: '域买家维度交易',
+                  children: [
+                    {
+                      id: 2,
+                      name: '月表',
+                      path: '/data_hui2',
+                    },
+                    {
+                      name: '日表',
+                      path: '/data_hui3?tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                    },
+                  ],
+                },
+                {
+                  name: '维度交易',
+                  path: '/',
+                  children: [
+                    {
+                      name: '月表',
+                      path: '/data_hui4',
+                    },
+                    {
+                      name: '日表',
+                      key: 'tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                      path: '/data_hui5',
+                    },
+                  ],
+                },
+              ],
+            },
+          ]}
+        />
+      );
+    };
+    const html = mount(<Demo />);
+    await waitForComponentToPaint(html);
+
+    expect(html.find('li.ant-menu-submenu').length).toBe(3);
+    expect(html.find('li.ant-menu-submenu-open').length).toBe(3);
+  });
+
+  it('🥩 BasicLayout support menu.ignoreFlatMenu', async () => {
+    const Demo = () => {
+      const [pathname, setPathname] = useState('/admin/sub-page1');
+      return (
+        <BasicLayout
+          menu={{
+            defaultOpenAll: true,
+            ignoreFlatMenu: true,
+          }}
+          location={{ pathname }}
+          menuItemRender={(item, dom) => (
+            <a
+              onClick={() => {
+                item.onClick();
+                setPathname(item.path || '/welcome');
+              }}
+            >
+              {dom}
+            </a>
+          )}
+          menuDataRender={() => [
+            {
+              path: '/home',
+              name: '首页',
+              locale: 'menu.home',
+              children: [
+                {
+                  path: '/home/overview',
+                  name: '概述',
+                  hideInMenu: true,
+                  locale: 'menu.home.overview',
+                },
+                {
+                  path: '/home/search',
+                  name: '搜索',
+                  hideInMenu: true,
+                  locale: 'menu.home.search',
+                },
+              ],
+            },
+            {
+              path: '/data_hui',
+              name: '汇总数据',
+              locale: 'menu.data_hui',
+              children: [
+                {
+                  collapsed: true,
+                  menuName: '域买家维度交易',
+                  name: '域买家维度交易',
+                  children: [
+                    {
+                      id: 2,
+                      name: '月表',
+                      path: '/data_hui2',
+                    },
+                    {
+                      name: '日表',
+                      path: '/data_hui3?tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                    },
+                  ],
+                },
+                {
+                  name: '维度交易',
+                  path: '/',
+                  children: [
+                    {
+                      name: '月表',
+                      path: '/data_hui4',
+                    },
+                    {
+                      name: '日表',
+                      key: 'tableName=adm_rk_cr_tb_trv_byr_ds&tableSchema=alifin_odps_birisk',
+                      path: '/data_hui5',
+                    },
+                  ],
+                },
+              ],
+            },
+          ]}
+        />
+      );
+    };
+    const html = mount(<Demo />);
+    await waitForComponentToPaint(html);
+
+    expect(html.find('li.ant-menu-submenu').length).toBe(3);
+    expect(html.find('li.ant-menu-submenu-open').length).toBe(3);
+
+    act(() => {
+      html.find('li.ant-pro-sider-collapsed-button').simulate('click');
+    });
+    await waitForComponentToPaint(html, 100);
+    expect(html.find('li.ant-menu-submenu-open').length).toBe(0);
+
+    act(() => {
+      html.find('li.ant-pro-sider-collapsed-button').simulate('click');
+    });
+    await waitForComponentToPaint(html, 100);
+    expect(html.find('li.ant-menu-submenu-open').length).toBe(3);
+  });
 });


### PR DESCRIPTION
* 解决ProLayout侧边栏菜单折叠按钮切换之后，会收起所有子菜单，此时defaultOpenAll相当于失效了，菜单较多时，用户需要手动一个个展开很不方便
* 在保持默认行为不变的情况下，增加ignoreFlatMenu配置，控制defaultOpenAll折叠后继续生效