### PR TITLE
fix(form): fix incorrect formRef in demo code

### DIFF
--- a/packages/form/src/components/ModalForm/demos/modal-form-reset.tsx
+++ b/packages/form/src/components/ModalForm/demos/modal-form-reset.tsx
@@ -39,7 +39,7 @@ export default () => {
           },
           resetButtonProps: {
             onClick: () => {
-              formRef.current?.resetFields();
+              restFormRef.current?.resetFields();
               //   setModalVisible(false);
             },
           },


### PR DESCRIPTION
the first ModalForm use incorrect formRef to cause reset form failed.