### PR TITLE
fix(ProLayout): headerContentRender example function.

### DIFF
--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -117,7 +117,7 @@ return (props) => (
   <ProLayout
     {...props}
     // 将面包屑显示在顶部
-    headerContentRender={) => {
+    headerContentRender={() => {
       return <ProBreadcrumb/>;
     }}
   />


### PR DESCRIPTION
fix(ProLayout): headerContentRender example function.
- 问题页面链接(该页面最底部位置)：https://procomponents.ant.design/components/page-container/#api
- 问题页面位置：PageContainer - 页容器 --> ProBreadcrumb -->  示例代码
- 问题描述：箭头函数少了一个左括号