### PR TITLE
feat: DragSortTable is sort base on rowKey now

### DIFF
--- a/packages/table/src/components/DragSortTable/index.tsx
+++ b/packages/table/src/components/DragSortTable/index.tsx
@@ -24,6 +24,7 @@ const DragHandle = handleCreator(
 
 function DragSortTable<T, U extends ParamsType>(props: DragTableProps<T, U>) {
   const {
+    rowKey,
     dragSortKey,
     dragSortHandlerRender,
     onDragSortEnd,
@@ -44,6 +45,7 @@ function DragSortTable<T, U extends ParamsType>(props: DragTableProps<T, U>) {
     dragSortKey,
     onDragSortEnd,
     components: props.components,
+    rowKey,
   });
 
   // 重写列配置的render,并在卸载时恢复原始render
@@ -72,6 +74,7 @@ function DragSortTable<T, U extends ParamsType>(props: DragTableProps<T, U>) {
   return handleColumn ? (
     <ProTable
       {...otherProps}
+      rowKey={rowKey}
       dataSource={oriDs}
       components={components}
       columns={columns}
@@ -81,6 +84,7 @@ function DragSortTable<T, U extends ParamsType>(props: DragTableProps<T, U>) {
     /* istanbul ignore next */
     <ProTable
       {...otherProps}
+      rowKey={rowKey}
       dataSource={oriDs}
       columns={columns}
       onDataSourceChange={onDataSourceChange}

--- a/packages/table/src/demos/drag-sort-table.tsx
+++ b/packages/table/src/demos/drag-sort-table.tsx
@@ -48,21 +48,21 @@ const columns2: ProColumns[] = [
 
 const data = [
   {
-    key: '1',
+    key: 'key1',
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
     index: 0,
   },
   {
-    key: '2',
+    key: 'key2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
     index: 1,
   },
   {
-    key: '3',
+    key: 'key3',
     name: 'Joe Black',
     age: 32,
     address: 'Sidney No. 1 Lake Park',
@@ -96,7 +96,7 @@ export default () => {
       <DragSortTable
         headerTitle="拖拽排序(默认把手)"
         columns={columns}
-        rowKey="index"
+        rowKey="key"
         pagination={false}
         dataSource={dataSource1}
         dragSortKey="sort"

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -443,7 +443,7 @@ ref.current.cancelEditable(rowKey);
 | render | 类似 table 的 render，第一个参数变成了 dom,增加了第四个参数 action | `(text: ReactNode,record: T,index: number,action: UseFetchDataAction<T>) => ReactNode \| ReactNode[]` | - |
 | renderFormItem | 渲染查询表单的输入组件 | `(item,{ type, defaultRender, formItemProps, fieldProps, ...rest },form) => ReactNode` | - |
 | search | 配置列的搜索相关，false 为隐藏 | `false` \| `{ transform: (value: any) => any }` | true |
-| search.transform | 转化值的 key, 一般用于事件区间的转化 | `(value: any) => any` | - |
+| search.transform | 转化值的 key, 一般用于时间区间的转化 | `(value: any) => any` | - |
 | [editable](/components/editable-table) | 在编辑表格中是否可编辑的，函数的参数和 table 的 render 一样 | `false` \| `(text: any, record: T,index: number) => boolean` | true |
 | colSize | 一个表单项占用的格子数量, `占比= colSize*span`，`colSize` 默认为 1 ，`span` 为 8，`span`是`form={{span:8}}` 全局设置的 | `number` | - |
 | hideInSearch | 在查询表单中不展示此项 | `boolean` | - |

--- a/packages/table/src/utils/useDragSort.tsx
+++ b/packages/table/src/utils/useDragSort.tsx
@@ -9,6 +9,7 @@ export interface UseDragSortOptions<T> {
   onDragSortEnd?: (newDataSource: T[]) => Promise<void> | void;
   dragSortKey?: string;
   components?: TableComponents<T>;
+  rowKey: any;
 }
 export function useDragSort<T>(props: UseDragSortOptions<T>) {
   const { data = [], onDragSortEnd, dragSortKey } = props;
@@ -44,7 +45,10 @@ export function useDragSort<T>(props: UseDragSortOptions<T>) {
   const DraggableBodyRow = (p: any) => {
     const { className: DraggableBodyRowClassName, style: DraggableBodyRowStyle, ...restProps } = p;
     // function findIndex base on Table rowKey props and should always be a right array index
-    const index = data.findIndex((x: any) => x.index === restProps['data-row-key']);
+    console.log(restProps);
+    const index = data.findIndex(
+      (x: any) => x[props.rowKey ?? 'index'] === restProps['data-row-key'],
+    );
     return <SortableItem index={index} {...restProps} />;
   };
 

--- a/tests/table/__snapshots__/demo.test.ts.snap
+++ b/tests/table/__snapshots__/demo.test.ts.snap
@@ -23306,7 +23306,7 @@ Array [
                         class="ant-table-tbody"
                       >
                         <tr
-                          data-row-key="0"
+                          data-row-key="key1"
                         >
                           <td
                             class="ant-table-cell"
@@ -23354,7 +23354,7 @@ Array [
                           </td>
                         </tr>
                         <tr
-                          data-row-key="1"
+                          data-row-key="key2"
                         >
                           <td
                             class="ant-table-cell"
@@ -23402,7 +23402,7 @@ Array [
                           </td>
                         </tr>
                         <tr
-                          data-row-key="2"
+                          data-row-key="key3"
                         >
                           <td
                             class="ant-table-cell"


### PR DESCRIPTION
Dragsorttable should be sorted based on the rowkey attribute as the unique value. If it is based on index, the data source has to add this attribute before passing in data, which will be very cumbersome。

DragSortTable 应该是基于rowKey属性作为唯一值进行排序的，如果基于index，那么数据源不得不在传入数据之前添加该属性，这样会显得很繁琐。