### PR TITLE
PageLoading组件Spin改为垂直居中显示

### DIFF
--- a/packages/layout/src/components/PageLoading/index.tsx
+++ b/packages/layout/src/components/PageLoading/index.tsx
@@ -10,7 +10,7 @@ const PageLoading: React.FC<SpinProps & any> = ({
   retry,
   ...reset
 }) => (
-  <div style={{ paddingTop: 100, textAlign: 'center' }}>
+  <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
     <Spin size="large" {...reset} />
   </div>
 );


### PR DESCRIPTION
PageLoading组件Spin改为垂直居中显示，因为绝大多数产品的loading是垂直居中显示。