### PR TITLE
🐛 fix(card): Divider disappeared in Firefox

### DIFF
--- a/packages/card/src/components/Divider/index.less
+++ b/packages/card/src/components/Divider/index.less
@@ -5,6 +5,7 @@
 .@{pro-card-prefix-cls} {
   // 分隔线
   &-divider {
+    flex: none;
     width: @border-width-base;
     margin: @card-padding-base @margin-xs;
     background-color: @border-color-split;


### PR DESCRIPTION
close #3783