### PR TITLE
locale(compiler) 🌐 : Add internationalisation in LoginForm component.

### DIFF
--- a/packages/form/src/layouts/LoginForm/index.tsx
+++ b/packages/form/src/layouts/LoginForm/index.tsx
@@ -2,6 +2,7 @@ import { ConfigProvider } from 'antd';
 import React, { useContext, useMemo } from 'react';
 import type { ProFormProps } from '../ProForm';
 import ProForm from '../ProForm';
+import { useIntl } from '@ant-design/pro-provider';
 
 import './index.less';
 
@@ -16,9 +17,11 @@ export type LoginFormProps<T> = {
 function LoginForm<T = Record<string, any>>(props: Partial<LoginFormProps<T>>) {
   const { logo, message, title, subTitle, actions, children, ...proFormProps } = props;
 
+  const intl = useIntl();
+
   const submitter = {
     searchConfig: {
-      submitText: '登录',
+      submitText: intl.getMessage('loginForm.submitText', '登录'),
     },
     render: (_, dom) => dom.pop(),
     submitButtonProps: {

--- a/packages/provider/src/locale/ar_EG.tsx
+++ b/packages/provider/src/locale/ar_EG.tsx
@@ -52,4 +52,7 @@ export default {
     next: 'التالي',
     prev: 'السابق',
   },
+  loginForm: {
+    submitText: 'تسجيل الدخول',
+  },
 };

--- a/packages/provider/src/locale/de_DE.tsx
+++ b/packages/provider/src/locale/de_DE.tsx
@@ -53,4 +53,7 @@ export default {
     prev: 'Zurück',
     submit: 'Abschließen',
   },
+  loginForm: {
+    submitText: 'Anmelden',
+  },
 };

--- a/packages/provider/src/locale/en_GB.tsx
+++ b/packages/provider/src/locale/en_GB.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Previous',
     submit: 'Finish',
   },
+  loginForm: {
+    submitText: 'Login',
+  },
   editableTable: {
     action: {
       save: 'Save',

--- a/packages/provider/src/locale/en_US.tsx
+++ b/packages/provider/src/locale/en_US.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Previous',
     submit: 'Finish',
   },
+  loginForm: {
+    submitText: 'Login',
+  },
   editableTable: {
     action: {
       save: 'Save',

--- a/packages/provider/src/locale/es_ES.tsx
+++ b/packages/provider/src/locale/es_ES.tsx
@@ -45,4 +45,7 @@ export default {
     prev: 'Anterior',
     submit: 'Finalizar',
   },
+  loginForm: {
+    submitText: 'Entrar',
+  },
 };

--- a/packages/provider/src/locale/fa_IR.tsx
+++ b/packages/provider/src/locale/fa_IR.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'قبلی',
     submit: 'اتمام',
   },
+  loginForm: {
+    submitText: 'ورود',
+  },
   editableTable: {
     action: {
       save: 'ذخیره',

--- a/packages/provider/src/locale/fr_FR.tsx
+++ b/packages/provider/src/locale/fr_FR.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Précédente',
     submit: 'Finaliser',
   },
+  loginForm: {
+    submitText: 'Se connecter',
+  },
   editableTable: {
     action: {
       save: 'Sauvegarder',

--- a/packages/provider/src/locale/id_ID.tsx
+++ b/packages/provider/src/locale/id_ID.tsx
@@ -53,4 +53,7 @@ export default {
     prev: 'Sebelumnya',
     submit: 'Selesai',
   },
+  loginForm: {
+    submitText: 'Login',
+  },
 };

--- a/packages/provider/src/locale/it_IT.tsx
+++ b/packages/provider/src/locale/it_IT.tsx
@@ -39,4 +39,7 @@ export default {
     densityMiddle: 'Media',
     densitySmall: 'Compatta',
   },
+  loginForm: {
+    submitText: 'Accedi',
+  },
 };

--- a/packages/provider/src/locale/ja_JP.tsx
+++ b/packages/provider/src/locale/ja_JP.tsx
@@ -44,4 +44,7 @@ export default {
     pre: '前へ',
     submit: '送信',
   },
+  loginForm: {
+    submitText: 'ログイン',
+  },
 };

--- a/packages/provider/src/locale/ko_KR.tsx
+++ b/packages/provider/src/locale/ko_KR.tsx
@@ -53,6 +53,9 @@ export default {
     prev: '이전',
     submit: '종료',
   },
+  loginForm: {
+    submitText: '로그인',
+  },
   editableTable: {
     action: {
       save: '저장',

--- a/packages/provider/src/locale/ms_MY.tsx
+++ b/packages/provider/src/locale/ms_MY.tsx
@@ -40,4 +40,7 @@ export default {
     densityMiddle: 'Tengah',
     densitySmall: 'Kecil',
   },
+  loginForm: {
+    submitText: 'Log Masuk',
+  },
 };

--- a/packages/provider/src/locale/pl_PL.tsx
+++ b/packages/provider/src/locale/pl_PL.tsx
@@ -53,4 +53,7 @@ export default {
     prev: 'Zurück',
     submit: 'Abschließen',
   },
+  loginForm: {
+    submitText: 'Zaloguj się',
+  },
 };

--- a/packages/provider/src/locale/pt_BR.tsx
+++ b/packages/provider/src/locale/pt_BR.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Anterior',
     submit: 'Enviar',
   },
+  loginForm: {
+    submitText: 'Entrar',
+  },
   editableTable: {
     action: {
       save: 'Salvar',

--- a/packages/provider/src/locale/ru_RU.tsx
+++ b/packages/provider/src/locale/ru_RU.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Предыдущий',
     submit: 'Завершить',
   },
+  loginForm: {
+    submitText: 'Вход',
+  },
   editableTable: {
     action: {
       save: 'Сохранить',

--- a/packages/provider/src/locale/sr_RS.tsx
+++ b/packages/provider/src/locale/sr_RS.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Nazad',
     submit: 'Gotovo',
   },
+  loginForm: {
+    submitText: 'Prijavi se',
+  },
   editableTable: {
     action: {
       save: 'Sačuvaj',

--- a/packages/provider/src/locale/tr_TR.tsx
+++ b/packages/provider/src/locale/tr_TR.tsx
@@ -53,6 +53,9 @@ export default {
     prev: 'Önceki',
     submit: 'Gönder',
   },
+  loginForm: {
+    submitText: 'Giriş Yap',
+  },
   editableTable: {
     action: {
       save: 'Kaydet',

--- a/packages/provider/src/locale/vi_VN.tsx
+++ b/packages/provider/src/locale/vi_VN.tsx
@@ -40,4 +40,7 @@ export default {
     densityMiddle: 'Trung bình',
     densitySmall: 'Chật',
   },
+  loginForm: {
+    submitText: 'Đăng nhập',
+  },
 };

--- a/packages/provider/src/locale/zh_CN.tsx
+++ b/packages/provider/src/locale/zh_CN.tsx
@@ -59,4 +59,7 @@ export default {
     open: '打开',
     close: '关闭',
   },
+  loginForm: {
+    submitText: '登录',
+  },
 };

--- a/packages/provider/src/locale/zh_TW.tsx
+++ b/packages/provider/src/locale/zh_TW.tsx
@@ -59,4 +59,7 @@ export default {
     open: '打開',
     close: '關閉',
   },
+  loginForm: {
+    submitText: '登入',
+  },
 };


### PR DESCRIPTION
## Problem
Currently, when this component is used, the Login button is hard coded in Chinese. When users of other locales use this, they will still have a Chinese login button, which is not correct behavior.

## Solution
By adding `useIntl`, we can allow the button to work in any language provided the key exists in the localisation file. A prop could be passed, but this would break the API. Therefore, if the localisation key is not found, we will default to keeping '登录'.

Closes #3785 