### PR TITLE
fix(form): 完善 StepsForm 的 useCallback 依赖，修复可能导致的打包丢失依赖问题

### DIFF
--- a/packages/form/src/layouts/StepsForm/index.tsx
+++ b/packages/form/src/layouts/StepsForm/index.tsx
@@ -141,13 +141,13 @@ function StepsForm<T = Record<string, any>>(
       formDataRef.current.set(name, formData);
       // 如果是最后一步
       if (step === formMapRef.current.size - 1 || formMapRef.current.size === 0) {
-        if (!props.onFinish) {
+        if (!onFinish) {
           return;
         }
         setLoading(true);
         const values: any = merge({}, ...Array.from(formDataRef.current.values()));
         try {
-          const success = await props.onFinish(values);
+          const success = await onFinish(values);
           if (success) {
             setStep(0);
             formArrayRef.current.forEach((form) => form.current?.resetFields());
@@ -161,7 +161,7 @@ function StepsForm<T = Record<string, any>>(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [props, step],
+    [step, formMapRef, onFinish],
   );
 
   const stepsDom = (

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -17681,6 +17681,134 @@ exports[`form demos 📸 renders ./packages/form/src/components/SchemaForm/demos
 </form>
 `;
 
+exports[`form demos 📸 renders ./packages/form/src/components/SchemaForm/demos/dependency.tsx correctly 1`] = `
+<form
+  autocomplete="off"
+  class="ant-form ant-form-vertical"
+>
+  <input
+    style="display: none;"
+    type="text"
+  />
+  <div
+    class="ant-row ant-form-item"
+  >
+    <div
+      class="ant-col ant-form-item-label"
+    >
+      <label
+        class="ant-form-item-required"
+        for="type"
+        title="优惠方式"
+      >
+        优惠方式
+      </label>
+    </div>
+    <div
+      class="ant-col ant-form-item-control"
+    >
+      <div
+        class="ant-form-item-control-input"
+      >
+        <div
+          class="ant-form-item-control-input-content"
+        >
+          <div
+            class="ant-select ant-pro-filed-search-select pro-field pro-field-m ant-select-single ant-select-allow-clear ant-select-show-arrow"
+            style="min-width: 100px;"
+          >
+            <div
+              class="ant-select-selector"
+            >
+              <span
+                class="ant-select-selection-search"
+              >
+                <input
+                  aria-activedescendant="type_list_0"
+                  aria-autocomplete="list"
+                  aria-controls="type_list"
+                  aria-haspopup="listbox"
+                  aria-owns="type_list"
+                  autocomplete="off"
+                  class="ant-select-selection-search-input"
+                  id="type"
+                  readonly=""
+                  role="combobox"
+                  style="opacity: 0;"
+                  type="search"
+                  unselectable="on"
+                  value=""
+                />
+              </span>
+              <span
+                class="ant-select-selection-placeholder"
+              >
+                请选择
+              </span>
+            </div>
+            <span
+              aria-hidden="true"
+              class="ant-select-arrow"
+              style="user-select: none;"
+              unselectable="on"
+            >
+              <span
+                aria-label="down"
+                class="anticon anticon-down ant-select-suffix"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="down"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="ant-space ant-space-horizontal ant-space-align-center"
+  >
+    <div
+      class="ant-space-item"
+      style="margin-right: 8px;"
+    >
+      <button
+        class="ant-btn ant-btn-primary"
+        type="button"
+      >
+        <span>
+          提 交
+        </span>
+      </button>
+    </div>
+    <div
+      class="ant-space-item"
+    >
+      <button
+        class="ant-btn"
+        type="button"
+      >
+        <span>
+          重 置
+        </span>
+      </button>
+    </div>
+  </div>
+</form>
+`;
+
 exports[`form demos 📸 renders ./packages/form/src/components/SchemaForm/demos/embed.tsx correctly 1`] = `
 <form
   autocomplete="off"


### PR DESCRIPTION
在我们项目中出现 onFinish 回调里始终只能拿到初始 state 的 bug，经排查发现是 useCallback 打包后丢失了 props 依赖，导致组件拿到的只是首个 onFinish，猜测是打包工具某一环的策略导致的。
_不过 props 也不应该成为直接依赖，否则和写不写应该都一样吧，另一个项目却没此问题 。_
### 源码
![image](https://user-images.githubusercontent.com/24448924/139661059-ec7f0221-e872-46cf-a16b-500085a4ec6f.png)
### 正常打包
![image](https://user-images.githubusercontent.com/24448924/139661149-eb342a81-ca3c-4939-9584-c75c5eeb7503.png)

### 异常打包
![image](https://user-images.githubusercontent.com/24448924/139661170-68ff6fac-9583-4b63-bff6-eaeba55c72d0.png)
