### PR TITLE
fix(table): 取消编辑行后表单未能全部重置

### DIFF
--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -361,7 +361,9 @@ const CancelEditableAction: React.FC<ActionRenderConfig<any> & { row: any }> = (
         const record = isMapEditor ? set({}, namePath, fields) : fields;
         const res = await onCancel?.(recordKey, record, row, newLineConfig);
         cancelEditable(recordKey);
-        form.setFieldsValue(row);
+        form.setFieldsValue({
+          [recordKey as React.Key]: row,
+        });
         return res;
       }}
     >


### PR DESCRIPTION
## 场景
**初始**
![image](https://user-images.githubusercontent.com/48742371/141036987-7471216d-3b28-4364-b17a-6f37270975cd.png)
**编辑中**
![image](https://user-images.githubusercontent.com/48742371/141037107-78d6b6f6-6a0f-4c4d-b025-4abea5ecb214.png)
**取消编辑，再次点开编辑**
![image](https://user-images.githubusercontent.com/48742371/141037260-5b362e07-e352-44bf-bd8d-6bdd77ebb5a7.png)

## 预期
虽然使用者可以主动传入form实例手动重置。但是理想情况，应该组件可以自动表单全部重置，或者全部不重置。现改成可全部重置

