### PR TITLE
feat: pro-layout已支持传入props到breadcrumbProps，但文档中没有体现

### DIFF
--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -154,6 +154,7 @@ PageContainer 配置 `ghost` 可以将页头切换为透明模式。
 | subMenuItemRender | 自定义拥有子菜单菜单项的 render 方法 | [`(itemProps: MenuDataItem) => ReactNode`](/components/layout/#menudataitem) | - |
 | menuDataRender | menuData 的 render 方法，用来自定义 menuData | `(menuData: MenuDataItem[]) => MenuDataItem[]` | - |
 | breadcrumbRender | 自定义面包屑的数据 | `(route)=>route` | - |
+| breadcrumbProps | 传递到 antd Breadcrumb 组件的 props, 参考 (https://ant.design/components/breadcrumb-cn/) | `breadcrumbProps` | undefined |
 | route | 用于生成菜单和面包屑。umi 的 Layout 会自动带有 | [route](#route) | - |
 | disableMobile | 禁止自动切换到移动页面 | `boolean` | false |
 | links | 显示在菜单右下角的快捷操作 | `ReactNode[]` | - |


### PR DESCRIPTION
我在开发过程中，使用到了ProLayout，期望对其中的Breadcrumb组件分隔符做个性化设置，但没有在ProComponents文档中看到类似Ant Design文档中Breadcrumb组件的separator配置项
![image](https://user-images.githubusercontent.com/40264423/142385572-6ff2bfbe-82d0-4467-895b-1c30c55fb6e7.png)
经过查看，BasicLayout.d.ts中已经存在了对Breadcrumb组件的breadcrumbProps设置，但文档中没有体现出来

