### PR TITLE
fix:docs: en-US docs for Layout section

### DIFF
--- a/packages/layout/src/layout.en-US.md
+++ b/packages/layout/src/layout.en-US.md
@@ -129,7 +129,7 @@ PageContainer configuration `ghost` can switch the page header to transparent mo
 > All methods suffixed with `Render` can be made not to render by passing `false`.
 
 | Parameters | Description | Type | Default |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- |
 | title | The title of the top-left corner of the layout | `ReactNode` | `'Ant Design Pro'` |
 | logo | url to the top-left corner of layout's logo | `ReactNode` \| `()=> ReactNode` | - |
 | pure | Whether to remove all self-contained interfaces | `boolean` | - |
@@ -223,7 +223,7 @@ GridContent encapsulates the [equal-width](https://preview.pro.ant.design/dashbo
 
 Generate menuData and breadcrumb based on router information.
 
-``js | pure import { getMenuData } from '@ant-design/pro-layout';
+```js | pure import { getMenuData } from '@ant-design/pro-layout';
 
 const { breadcrumb, menuData } = getMenuData(routes, menu, formatMessage, menuDataRender);
 
@@ -240,7 +240,7 @@ const { breadcrumb, menuData } = getMenuData(routes, menu, formatMessage, menuDa
 
 getPageTitle encapsulates the logic of the title generated on the menuData.
 
-``` js | pure
+```js | pure
 import { getPageTitle } from '@ant-design/pro-layout';
 
 const title = getPageTitle({
@@ -390,7 +390,7 @@ const Page = () => (
 
 ProLayout provides some api to remove areas that are not needed by the user. Some configurations are also provided in SettingDrawer to set them.
 
-! [setting-drawer-render](https://gw.alipayobjects.com/zos/antfincdn/mCXDkK2pJ0/60298863-F5A5-4af2-923A-13EF912DB0E1.png)
+![setting-drawer-render](https://gw.alipayobjects.com/zos/antfincdn/mCXDkK2pJ0/60298863-F5A5-4af2-923A-13EF912DB0E1.png)
 
 - `headerRender` can customize the top bar
 - `footerRender` can customize the footer
@@ -414,7 +414,7 @@ The width of the menu is not customizable because it involves animation and huge
 
 Auto-cut menu is an exclusive ability of `mix` mode to place the first level of the menu into the top bar. We can set `splitMenus=true` to turn it on, and for a good experience it's best to set a redirect for each level of the menu, which will prevent switching to a white screen page.
 
-! [cutMenu](https://gw.alipayobjects.com/zos/antfincdn/H9hDMcrUh1/5438EB45-27F8-4B4F-8740-54F7BE55075C.png)
+![cutMenu](https://gw.alipayobjects.com/zos/antfincdn/H9hDMcrUh1/5438EB45-27F8-4B4F-8740-54F7BE55075C.png)
 
 ### Customizing menus
 


### PR DESCRIPTION
- En-US docs for Layout has some issues.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/11713395/143482043-d55d5327-2446-4b11-826b-015a4e0f3ca9.png)|![image](https://user-images.githubusercontent.com/11713395/143483720-97e523b3-ccaf-4236-89b3-a01744bbd978.png)|
|![image](https://user-images.githubusercontent.com/11713395/143482094-306c28b0-dbba-4964-84ad-338076257806.png)|![image](https://user-images.githubusercontent.com/11713395/143483933-1a019667-65c2-49f1-896b-d80c27210481.png)|
|![image](https://user-images.githubusercontent.com/11713395/143483623-12195845-2f51-4af4-992b-18e18092d52a.png)|![image](https://user-images.githubusercontent.com/11713395/143484018-2c7c9a46-2fc1-469a-924a-2e5863dab5e7.png)|
|![image](https://user-images.githubusercontent.com/11713395/143483650-a79b9db1-626c-4e30-b9fa-bb090aeaba39.png)|![image](https://user-images.githubusercontent.com/11713395/143484109-b274bb88-9b4b-4445-be8b-c70eabcdd7f3.png)|

