### PR TITLE
docs: correct nav path for playground

### DIFF
--- a/docs/playground/curd.playground.md
+++ b/docs/playground/curd.playground.md
@@ -2,7 +2,7 @@
 title: CRUD
 nav:
   title: Playground
-  path: /playground/
+  path: /playground
 group:
   path: /
 ---

--- a/docs/playground/pro-descriptions.playground.md
+++ b/docs/playground/pro-descriptions.playground.md
@@ -2,7 +2,7 @@
 title: ProDescriptions
 nav:
   title: Playground
-  path: /playground/
+  path: /playground
 group:
   path: /
 ---

--- a/docs/playground/pro-form.playground.md
+++ b/docs/playground/pro-form.playground.md
@@ -2,7 +2,7 @@
 title: ProForm
 nav:
   title: Playground
-  path: /playground/
+  path: /playground
 group:
   path: /
 ---

--- a/docs/playground/pro-layout.playground.md
+++ b/docs/playground/pro-layout.playground.md
@@ -2,7 +2,7 @@
 title: ProLayout
 nav:
   title: Playground
-  path: /playground/
+  path: /playground
 group:
   path: /
 ---

--- a/docs/playground/pro-table.playground.md
+++ b/docs/playground/pro-table.playground.md
@@ -2,7 +2,7 @@
 title: ProTable
 nav:
   title: Playground
-  path: /playground/
+  path: /playground
 group:
   path: /
 ---


### PR DESCRIPTION
## Description

Fix the following error when building docs with ssr mode:

```bash
Error: Prevent writing to file that only differs in casing or query string from already written file.
This will lead to a race-condition and corrupted files on case-insensitive file systems
```