### PR TITLE
feat: disable default error boundary

### DIFF
--- a/packages/layout/src/WrapContent.tsx
+++ b/packages/layout/src/WrapContent.tsx
@@ -16,11 +16,17 @@ const WrapContent: React.FC<{
   const ErrorComponent = props.ErrorBoundary || ErrorBoundary;
   return (
     <ConfigProviderWrap autoClearCache>
-      <ErrorComponent>
+      {props.ErrorBoundary === false ? (
         <Layout.Content className={className} style={style}>
           {children}
         </Layout.Content>
-      </ErrorComponent>
+      ) : (
+        <ErrorComponent>
+          <Layout.Content className={className} style={style}>
+            {children}
+          </Layout.Content>
+        </ErrorComponent>
+      )}
     </ConfigProviderWrap>
   );
 };

--- a/packages/layout/src/demos/top-breadcrumb.tsx
+++ b/packages/layout/src/demos/top-breadcrumb.tsx
@@ -12,6 +12,7 @@ export default () => (
       location={{
         pathname: '/admin/process/edit/123',
       }}
+      ErrorBoundary={false}
       headerContentRender={() => <ProBreadcrumb />}
       breadcrumbRender={(routers = []) => [
         {

--- a/packages/layout/src/layout.en-US.md
+++ b/packages/layout/src/layout.en-US.md
@@ -173,6 +173,7 @@ PageContainer configuration `ghost` can switch the page header to transparent mo
 | breadcrumbRender | customize the data for breadcrumbs | `(route)=>route` | - |
 | route | Used to generate menus and breadcrumbs. umi's Layout will automatically have | [route](#route) | - |
 | disableMobile | disable automatic switching to mobile pages | `boolean` | false |
+| ErrorBoundary | Comes with error handling function to prevent blank screen. `ErrorBoundary=false` turn off default ErrorBoundary | `ReactNode` | default ErrorBoundary |
 | links | Show shortcut actions in the lower right corner of the menu | `ReactNode[]` | - |
 | menuProps | The props passed to the antd menu component, see (https://ant.design/components/menu/) | `MenuProps` | undefined |
 | waterMarkProps | Configure watermark, watermark is a function of PageContainer, layout is only transparently transmitted to PageContainer | [WaterMarkProps](/components/water-mark) | - |

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -157,6 +157,7 @@ PageContainer 配置 `ghost` 可以将页头切换为透明模式。
 | breadcrumbProps | 传递到 antd Breadcrumb 组件的 props, 参考 (https://ant.design/components/breadcrumb-cn/) | `breadcrumbProps` | undefined |
 | route | 用于生成菜单和面包屑。umi 的 Layout 会自动带有 | [route](#route) | - |
 | disableMobile | 禁止自动切换到移动页面 | `boolean` | false |
+| ErrorBoundary | 自带了错误处理功能，防止白屏，`ErrorBoundary=false` 关闭默认错误边界 | `ReactNode` | 内置 ErrorBoundary |
 | links | 显示在菜单右下角的快捷操作 | `ReactNode[]` | - |
 | menuProps | 传递到 antd menu 组件的 props, 参考 (https://ant.design/components/menu-cn/) | `MenuProps` | undefined |
 | waterMarkProps | 配置水印，水印是 PageContainer 的功能，layout 只是透传给 PageContainer | [WaterMarkProps](/components/water-mark) | - |


### PR DESCRIPTION
给一个时机关闭默认错误边界，现在有一个使用 [sentry](https://docs.sentry.io/platforms/javascript/guides/react/components/errorboundary/) 的场景，sentry 错误边界作为父组件存在，error event 会被默认错误边界拦截

```jsx
import React from "react";
import * as Sentry from "@sentry/react";

<Sentry.ErrorBoundary fallback={<p>An error has occurred</p>}>
  <ProLayout />
</Sentry.ErrorBoundary>;
```