### PR TITLE
fix(table): Table在column带有request情况下，搜索栏的表单由于没有设置proFieldKey导致在页面初始化会…

### DIFF
--- a/packages/table/src/components/Form/FormRender.tsx
+++ b/packages/table/src/components/Form/FormRender.tsx
@@ -155,11 +155,15 @@ const FormRender = <T, U = any>({
           (['textarea', 'jsonCode', 'code'].includes(item?.valueType) && type === 'table')
             ? 'text'
             : (item?.valueType as 'text');
+        const columnKey = item?.key || item?.dataIndex?.toString();
         return {
           ...item,
           width: undefined,
           ...(item.search ? item.search : {}),
           valueType: finalValueType,
+          proFieldProps: {
+            proFieldKey: columnKey ? `table-field-${columnKey}` : undefined,
+          },
         };
       });
   }, [columns, type]);

--- a/tests/table/valueEnum.test.tsx
+++ b/tests/table/valueEnum.test.tsx
@@ -148,9 +148,6 @@ describe('Table valueEnum', () => {
     );
     await waitForComponentToPaint(html, 1200);
 
-    expect(request).toBeCalledWith({
-      status: 2,
-      key: '1',
-    });
+    expect(request).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Table在column带设置了request情况下，在第一次进入页面时候会发出两个request。