### PR TITLE
fix(form): DateRangePicker in LightFilter format is always set to YYYY-MM-DD

### DIFF
--- a/packages/form/src/components/DateRangePicker/index.tsx
+++ b/packages/form/src/components/DateRangePicker/index.tsx
@@ -24,7 +24,8 @@ const ProFormDateRangePicker: React.FC<ProFormFieldItemProps<RangePickerProps>> 
         proFieldProps={proFieldProps}
         filedConfig={{
           valueType,
-          lightFilterLabelFormatter: (value) => dateArrayFormatter(value, 'YYYY-MM-DD'),
+          lightFilterLabelFormatter: (value) =>
+            dateArrayFormatter(value, fieldProps?.format || 'YYYY-MM-DD'),
         }}
         {...rest}
       />


### PR DESCRIPTION
close #4093