### PR TITLE
fix(form): 重新给LightFilter内的表单项指定属性不生效🐛[BUG] #4366

### DIFF
--- a/packages/form/src/layouts/LightFilter/index.tsx
+++ b/packages/form/src/layouts/LightFilter/index.tsx
@@ -83,7 +83,7 @@ const LightFilterContainer: React.FC<{
       outsideItems: outsideItemsArr,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.items.length]);
+  }, [props.items]);
 
   const collapseLabelRender = () => {
     if (collapseLabel) {


### PR DESCRIPTION
Fixes #4366