### PR TITLE
fix: ProTable documentation typo 

### DIFF
--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -307,7 +307,7 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 | --- | --- | --- | --- |
 | defaultValue | The default value of the column status, only for the first time | `record <string, columnState>;` |
 | value | Column status, support controlled mode | `Record <string, columnState>;` |
-| onChange | Column status After changing | `(Value: Record <string, columnSstate>) => Viod` |
+| onChange | Column status After changing | `(value: Record <string, columnSstate>) => void` |
 | PersistenceKey | The key of the persistence column is used to determine if it is the same table | `string \| Number` |
 | PersistenceType | The type of persistence column, localStorage is also existing after closing the browser, sessionStorage closes the browser will be lost | `localstorage \| sessionStorage` |
 

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -305,9 +305,9 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| defaultValue | The default value of the column status, only for the first time | `record <string, columnState>;` |
-| value | Column status, support controlled mode | `Record <string, ColumnState>;` |
-| onChange | Column status After changing | `(value: Record <string, ColumnSstate>) => void` |
+| defaultValue | The default value of the column status, only for the first time | `record <string, ColumnsState>;` |
+| value | Column status, support controlled mode | `Record <string, ColumnsState>;` |
+| onChange | Column status After changing | `(value: Record <string, ColumnsState>) => void` |
 | PersistenceKey | The key of the persistence column is used to determine if it is the same table | `string \| Number` |
 | PersistenceType | The type of persistence column, localStorage is also existing after closing the browser, sessionStorage closes the browser will be lost | `localstorage \| sessionStorage` |
 

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -305,7 +305,7 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| defaultValue | The default value of the column status, only for the first time | `record <string, ColumnsState>;` |
+| defaultValue | The default value of the column status, only for the first time | `Record <string, ColumnsState>;` |
 | value | Column status, support controlled mode | `Record <string, ColumnsState>;` |
 | onChange | Column status After changing | `(value: Record <string, ColumnsState>) => void` |
 | PersistenceKey | The key of the persistence column is used to determine if it is the same table | `string \| Number` |

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -306,8 +306,8 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
 | defaultValue | The default value of the column status, only for the first time | `record <string, columnState>;` |
-| value | Column status, support controlled mode | `Record <string, columnState>;` |
-| onChange | Column status After changing | `(value: Record <string, columnSstate>) => void` |
+| value | Column status, support controlled mode | `Record <string, ColumnState>;` |
+| onChange | Column status After changing | `(value: Record <string, ColumnSstate>) => void` |
 | PersistenceKey | The key of the persistence column is used to determine if it is the same table | `string \| Number` |
 | PersistenceType | The type of persistence column, localStorage is also existing after closing the browser, sessionStorage closes the browser will be lost | `localstorage \| sessionStorage` |
 

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -361,7 +361,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 | --- | --- | --- | --- |
 | defaultValue | 列状态的默认值，只有初次生效 | `Record<string, ColumnsState>;` | - |
 | value | 列状态的值，支持受控模式 | `Record<string, ColumnsState>;` | - |
-| onChange | 列状态的值发生改变之后触发 | `(value:Record<string, ColumnsState>)=>viod` | - |
+| onChange | 列状态的值发生改变之后触发 | `(value:Record<string, ColumnsState>)=>void` | - |
 | persistenceKey | 持久化列的 key，用于判断是否是同一个 table | `string \| number` | - |
 | persistenceType | 持久化列的类类型， localStorage 设置在关闭浏览器后也是存在的，sessionStorage 关闭浏览器后会丢失 | `localStorage \| sessionStorage` | - |
 


### PR DESCRIPTION
ProTable component documentation typo

![image](https://user-images.githubusercontent.com/8070933/147710762-81face54-f2e4-474b-a1d2-efbb2b0a175e.png)
