### PR TITLE
fix(form): render option failed while key is number 0.

### DIFF
--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -423,11 +423,11 @@ const FieldSelect: ProFieldFC<FieldSelectProps> = (props, ref) => {
   }));
 
   if (mode === 'read') {
-    const optionsValueEnum: ProSchemaValueEnumObj = options?.length
-      ? options?.reduce((pre: any, cur) => {
-          return { ...pre, [cur.value || '']: cur.label };
-        }, {})
-      : undefined;
+    const optionsValueEnumMap: ProSchemaValueEnumMap = new Map();
+    options?.forEach((opt) => {
+      optionsValueEnumMap.set(opt.value ?? '', opt.label);
+    });
+
     // 如果有 label 直接就用 label
     // @ts-ignore
     if (rest.text?.label) {
@@ -439,7 +439,7 @@ const FieldSelect: ProFieldFC<FieldSelectProps> = (props, ref) => {
       <>
         {proFieldParsingText(
           rest.text,
-          ObjToMap(valueEnum || optionsValueEnum) as unknown as ProSchemaValueEnumObj,
+          ObjToMap(valueEnum || optionsValueEnumMap) as unknown as ProSchemaValueEnumObj,
         )}
       </>
     );


### PR DESCRIPTION
fix field select issue that number 0 as option value not render its label while options from request method. BTW, save value as map key to avoid number type convert to string as object key. 