### PR TITLE
fix(table): fix the param resetPageIndex is invalid in ProTable's method reload.

### DIFF
--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -87,7 +87,9 @@ export function useActionType<T>(
     reload: async (resetPageIndex?: boolean) => {
       // 如果为 true，回到第一页
       if (resetPageIndex) {
-        await props.onCleanSelected();
+        await action.setPageInfo({
+          current: 1,
+        });
       }
       action?.reload();
     },


### PR DESCRIPTION
修复 ProTable 的 reload 方法在传入 resetPageIndex 参数时无效的问题。