### PR TITLE
fix(form): ModalForm and DrawerForm lost default closing-animarion-ef…

### DIFF
--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -87,7 +87,9 @@ export function useActionType<T>(
     reload: async (resetPageIndex?: boolean) => {
       // 如果为 true，回到第一页
       if (resetPageIndex) {
-        await props.onCleanSelected();
+        await action.setPageInfo({
+          current: 1,
+        });
       }
       action?.reload();
     },


### PR DESCRIPTION
ModalForm and DrawerForm lost default closing-animarion-effect when deploying custom visible and destroyOnClose==true.
fixes  #4405
ModalForm 和 DrawerForm 在 destroyOnClose==true 时，关闭后解除了对BaseForm的渲染，所以自然没有了关闭的动画效果。