### PR TITLE
fix(form): 🐛 DrawerForm cannot get form instance by formRef

### DIFF
--- a/packages/form/src/components/ModalForm/demos/drawer-form.tsx
+++ b/packages/form/src/components/ModalForm/demos/drawer-form.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useEffect, useRef } from 'react';
+﻿import React, { useRef } from 'react';
 import { Button, message } from 'antd';
 import type { ProFormInstance } from '@ant-design/pro-form';
 import ProForm, {

--- a/packages/form/src/components/ModalForm/demos/drawer-form.tsx
+++ b/packages/form/src/components/ModalForm/demos/drawer-form.tsx
@@ -20,8 +20,6 @@ const waitTime = (time: number = 100) => {
 export default () => {
   const formRef = useRef<ProFormInstance>();
 
-  console.log('formRef: ', formRef);
-
   return (
     <DrawerForm<{
       name: string;

--- a/packages/form/src/components/ModalForm/demos/drawer-form.tsx
+++ b/packages/form/src/components/ModalForm/demos/drawer-form.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useRef } from 'react';
+﻿import React, { useEffect, useRef } from 'react';
 import { Button, message } from 'antd';
 import type { ProFormInstance } from '@ant-design/pro-form';
 import ProForm, {
@@ -19,6 +19,9 @@ const waitTime = (time: number = 100) => {
 
 export default () => {
   const formRef = useRef<ProFormInstance>();
+
+  console.log('formRef: ', formRef);
+
   return (
     <DrawerForm<{
       name: string;

--- a/packages/form/src/layouts/DrawerForm/index.tsx
+++ b/packages/form/src/layouts/DrawerForm/index.tsx
@@ -158,7 +158,8 @@ function DrawerForm<T = Record<string, any>>({
     [],
   );
 
-  useImperativeHandle(rest.formRef, () => formRef.current);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useImperativeHandle(rest.formRef, () => formRef.current, [shouldRenderFormItems]);
 
   const formDom = (
     <div onClick={(e) => e.stopPropagation()}>

--- a/tests/form/drawerForm.test.tsx
+++ b/tests/form/drawerForm.test.tsx
@@ -764,4 +764,32 @@ describe('DrawerForm', () => {
     expect(html.baseElement.querySelector('form')).toBeFalsy();
     html.unmount();
   });
+
+  it('📦 drawerForm get formRef when destroyOnClose', async () => {
+    const ref = React.createRef<any>();
+
+    const html = mount(
+      <DrawerForm
+        formRef={ref}
+        drawerProps={{
+          destroyOnClose: true,
+        }}
+        trigger={
+          <Button id="new" type="primary">
+            新建
+          </Button>
+        }
+      >
+        <ProFormText name="name" />
+      </DrawerForm>,
+    );
+
+    waitForComponentToPaint(html, 200);
+    expect(ref.current).toBeFalsy();
+    act(() => {
+      html.find('button#new').simulate('click');
+    });
+    waitForComponentToPaint(html, 200);
+    expect(ref.current).toBeTruthy();
+  });
 });


### PR DESCRIPTION
fixes: #4418

DrawerForm中设置destroyOnClose=true时，无法获取表单实例，因为visible === false不渲染表单