### PR TITLE
fix(form): SchemaForm dependency add warning message

### DIFF
--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -44,7 +44,8 @@
     "rc-resize-observer": "^1.1.0",
     "rc-util": "^5.0.6",
     "use-json-comparison": "^1.0.5",
-    "use-media-antd-query": "^1.0.6"
+    "use-media-antd-query": "^1.0.6",
+    "warning": "^4.0.3"
   },
   "peerDependencies": {
     "antd": "4.x",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -44,8 +44,7 @@
     "rc-resize-observer": "^1.1.0",
     "rc-util": "^5.0.6",
     "use-json-comparison": "^1.0.5",
-    "use-media-antd-query": "^1.0.6",
-    "warning": "^4.0.3"
+    "use-media-antd-query": "^1.0.6"
   },
   "peerDependencies": {
     "antd": "4.x",

--- a/packages/form/src/components/SchemaForm/index.tsx
+++ b/packages/form/src/components/SchemaForm/index.tsx
@@ -25,6 +25,7 @@ import ProForm, { DrawerForm, ModalForm, QueryFilter, LightFilter, StepsForm } f
 import type { ProFormFieldProps } from '../Field';
 import ProFormList from '../List';
 import type { NamePath } from 'antd/lib/form/interface';
+import warning from 'warning';
 
 export type ExtraProColumnType = {
   tooltip?: React.ReactNode;
@@ -277,6 +278,17 @@ function BetaSchemaForm<T, ValueType = 'text'>(props: FormSchema<T, ValueType>) 
 
           /** ProFormDependency */
           if (item.valueType === 'dependency') {
+            warning(
+              Array.isArray(item.fieldProps?.name),
+              'SchemaForm: fieldProps.name should be NamePath[] when valueType is "dependency"',
+            );
+            warning(
+              typeof item.columns === 'function',
+              'SchemaForm: columns should be a function when valueType is "dependency"',
+            );
+
+            if (!Array.isArray(item.fieldProps?.name)) return null;
+
             return (
               <ProFormDependency {...item.fieldProps} key={key}>
                 {(values: any) => {

--- a/packages/form/src/components/SchemaForm/index.tsx
+++ b/packages/form/src/components/SchemaForm/index.tsx
@@ -25,7 +25,7 @@ import ProForm, { DrawerForm, ModalForm, QueryFilter, LightFilter, StepsForm } f
 import type { ProFormFieldProps } from '../Field';
 import ProFormList from '../List';
 import type { NamePath } from 'antd/lib/form/interface';
-import warning from 'warning';
+import { noteOnce } from 'rc-util/lib/warning';
 
 export type ExtraProColumnType = {
   tooltip?: React.ReactNode;
@@ -278,11 +278,11 @@ function BetaSchemaForm<T, ValueType = 'text'>(props: FormSchema<T, ValueType>) 
 
           /** ProFormDependency */
           if (item.valueType === 'dependency') {
-            warning(
+            noteOnce(
               Array.isArray(item.fieldProps?.name),
               'SchemaForm: fieldProps.name should be NamePath[] when valueType is "dependency"',
             );
-            warning(
+            noteOnce(
               typeof item.columns === 'function',
               'SchemaForm: columns should be a function when valueType is "dependency"',
             );


### PR DESCRIPTION
在`SchemaForm`中使用`dependency`如果忘记设置/不设置正确`fieldProps.name`会直接crash。
这边添加warning且不展示没有设置name的组件