### PR TITLE
fix(form):  readonly form will not render the latest value

### DIFF
--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -371,7 +371,7 @@ export type ProFieldPropsType = {
 } & RenderProps;
 
 const ProField: React.ForwardRefRenderFunction<any, ProFieldPropsType> = (
-  { text, valueType = 'text', onChange, renderFormItem, value, ...rest },
+  { text, valueType = 'text', mode = 'read', onChange, renderFormItem, value, readonly, ...rest },
   ref: any,
 ) => {
   const intl = useIntl();
@@ -386,15 +386,16 @@ const ProField: React.ForwardRefRenderFunction<any, ProFieldPropsType> = (
       onChange?.(...restParams);
     },
   };
+
   return (
     <React.Fragment>
       {defaultRenderText(
-        text ?? fieldProps?.value ?? '',
+        mode === 'edit' ? fieldProps?.value ?? text ?? '' : text ?? fieldProps?.value ?? '',
         valueType || 'text',
         {
           ref,
           ...rest,
-          mode: rest.mode || 'read',
+          mode: readonly ? 'read' : mode,
           renderFormItem: renderFormItem
             ? (...restProps) => {
                 const newDom = renderFormItem(...restProps);

--- a/packages/form/src/BaseForm/createField.tsx
+++ b/packages/form/src/BaseForm/createField.tsx
@@ -182,7 +182,8 @@ function createField<P extends ProFormFieldItemProps = any>(
           })}
           proFieldProps={omitUndefined({
             // @ts-ignore
-            mode: readonly ? 'read' : rest?.mode,
+            mode: rest?.mode,
+            readonly,
             params: rest.params,
             proFieldKey: proFieldKey,
             ...proFieldProps,

--- a/packages/form/src/components/UploadDragger/index.tsx
+++ b/packages/form/src/components/UploadDragger/index.tsx
@@ -43,7 +43,9 @@ const ProFormUploadDragger: React.FC<ProFormDraggerProps> = React.forwardRef(
     const baseClassName = context.getPrefixCls('upload');
     // 如果配置了 max ，并且 超过了文件列表的大小，就不展示按钮
     const showUploadButton =
-      (max === undefined || !value || value?.length < max) && proFieldProps?.mode !== 'read';
+      (max === undefined || !value || value?.length < max) &&
+      proFieldProps?.mode !== 'read' &&
+      proFieldProps?.readonly !== true;
     return (
       <Upload.Dragger
         // @ts-ignore

--- a/packages/provider/src/index.tsx
+++ b/packages/provider/src/index.tsx
@@ -70,6 +70,7 @@ export type ProFieldFCMode = 'read' | 'edit' | 'update';
 /** Render 第二个参数，里面包含了一些常用的参数 */
 export type ProFieldFCRenderProps = {
   mode?: ProFieldFCMode;
+  readonly?: boolean;
   placeholder?: string | string[];
   value?: any;
   onChange?: (...rest: any[]) => void;

--- a/packages/table/src/components/EditableTable/demos/basic.tsx
+++ b/packages/table/src/components/EditableTable/demos/basic.tsx
@@ -66,7 +66,7 @@ export default () => {
       width: '15%',
     },
     {
-      title: '活动名称',
+      title: '活动名称二',
       dataIndex: 'readonly',
       tooltip: '只读，使用form.getFieldValue可以获取到值',
       formItemProps: (form, { rowIndex }) => {

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -336,4 +336,5 @@ export interface ProFieldProps {
   /** 这个属性可以设置useSwr的key */
   proFieldKey?: string;
   render?: any;
+  readonly?: boolean;
 }

--- a/tests/field/field.test.tsx
+++ b/tests/field/field.test.tsx
@@ -1147,6 +1147,28 @@ describe('Field', () => {
     expect(html.text()).toBe('-');
   });
 
+  it(`🐴 readonly and mode is edit use fieldProps.value`, async () => {
+    const html = mount(
+      <Field
+        text={10000}
+        mode="edit"
+        readonly
+        fieldProps={{
+          value: 2000,
+        }}
+      />,
+    );
+    await waitForComponentToPaint(200);
+    expect(html.text()).toBe('2000');
+    html.setProps({
+      fieldProps: {
+        value: 20000,
+      },
+    });
+    await waitForComponentToPaint(200);
+    expect(html.text()).toBe('20000');
+  });
+
   it('🐴 select request debounceTime', async () => {
     const requestFn = jest.fn();
     const html = mount(

--- a/tests/table/__snapshots__/demo.test.ts.snap
+++ b/tests/table/__snapshots__/demo.test.ts.snap
@@ -2004,7 +2004,7 @@ exports[`table demos 📸 renders ./packages/table/src/components/EditableTable/
                               <div
                                 class="ant-pro-core-label-tip-title"
                               >
-                                活动名称
+                                活动名称二
                               </div>
                               <span
                                 class="ant-pro-core-label-tip-icon"


### PR DESCRIPTION
fix: #4487

当设置readonly为true时

### mode === read
保持原来的逻辑

### mode === edit
优先从fieldProps?.value获取值，保证在只读的表单操作里依然能展示最新的值

现实现方式调整了判断readonly===true设置mode=true的位置