### PR TITLE
chore(card): remove useless frontmatter from demos

### DIFF
--- a/packages/card/src/components/CheckCard/demos/avatar.tsx
+++ b/packages/card/src/components/CheckCard/demos/avatar.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 250d5cd3 title: 自定义头像 */
+/**
+ * title: 自定义头像
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/basic.tsx
+++ b/packages/card/src/components/CheckCard/demos/basic.tsx
@@ -1,4 +1,6 @@
-/** Uuid: d502a5cf title: 基本使用 */
+/**
+ * title: 基本使用
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/compose.tsx
+++ b/packages/card/src/components/CheckCard/demos/compose.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 2c9c6174 title: 组合样式 */
+/**
+ * title: 组合样式
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/custom.tsx
+++ b/packages/card/src/components/CheckCard/demos/custom.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 4d4d1bdf title: 自定义尺寸 */
+/**
+ * title: 自定义尺寸
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/defaultChecked.tsx
+++ b/packages/card/src/components/CheckCard/demos/defaultChecked.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 47390657 title: 默认选中 */
+/**
+ * title: 默认选中
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/description.tsx
+++ b/packages/card/src/components/CheckCard/demos/description.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 15886807 title: 自定义描述 */
+/**
+ * title: 自定义描述
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/disabled.tsx
+++ b/packages/card/src/components/CheckCard/demos/disabled.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 0cdbe369 title: 选项不可用 */
+/**
+ * title: 选项不可用
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/extra.tsx
+++ b/packages/card/src/components/CheckCard/demos/extra.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 1d7b8f42 title: 操作栏 */
+/**
+ * title: 操作栏
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/form.tsx
+++ b/packages/card/src/components/CheckCard/demos/form.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 5277507c title: 表单中使用 */
+/**
+ * title: 表单中使用
+ */
 
 /* eslint-disable no-console */
 import React from 'react';

--- a/packages/card/src/components/CheckCard/demos/grid.tsx
+++ b/packages/card/src/components/CheckCard/demos/grid.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 0dba888a title: 布局 */
+/**
+ * title: 布局
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/group.tsx
+++ b/packages/card/src/components/CheckCard/demos/group.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 483166e2 title: 选项列表 */
+/**
+ * title: 选项列表
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/image.tsx
+++ b/packages/card/src/components/CheckCard/demos/image.tsx
@@ -1,4 +1,6 @@
-/** Uuid: b7df90e4 title: 纯图片选项 */
+/**
+ * title: 纯图片选项
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/list.tsx
+++ b/packages/card/src/components/CheckCard/demos/list.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 69aec291 title: 应用列表示例 */
+/**
+ * title: 应用列表示例
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/loading.tsx
+++ b/packages/card/src/components/CheckCard/demos/loading.tsx
@@ -1,4 +1,6 @@
-/** Uuid: c94c25fc title: 组件 Loading */
+/**
+ * title: 组件 Loading
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/multiple.tsx
+++ b/packages/card/src/components/CheckCard/demos/multiple.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 9c5425b1 title: 多选模式 */
+/**
+ * title: 多选模式
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/single.tsx
+++ b/packages/card/src/components/CheckCard/demos/single.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 900875c6 title: 单选模式 */
+/**
+ * title: 单选模式
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';

--- a/packages/card/src/components/CheckCard/demos/size.tsx
+++ b/packages/card/src/components/CheckCard/demos/size.tsx
@@ -1,4 +1,6 @@
-/** Uuid: 9e6989c0 title: 不同尺寸 */
+/**
+ * title: 不同尺寸
+ */
 
 import React, { useState } from 'react';
 import { Radio } from 'antd';

--- a/packages/card/src/components/CheckCard/demos/title.tsx
+++ b/packages/card/src/components/CheckCard/demos/title.tsx
@@ -1,4 +1,6 @@
-/** Uuid: e9c5486d title: 自定义标题 */
+/**
+ * title: 自定义标题
+ */
 
 import React from 'react';
 import { CheckCard } from '@ant-design/pro-card';


### PR DESCRIPTION
## Description

移除无用的 uuid frontmatter，早期海兔的遗留产物，用不到了；另外发现 pro-components 的 precommit 会强行把注释格式化成 `/** balabala */` 的单行形式，这样会导致 demo 源码中的 frontmatter 失效，这个 PR 先 `--no-verify` 绕过了， @chenshuai2144 看看怎么处理比较好