### PR TITLE
fix(form): dependency transform from Array to Object

### DIFF
--- a/packages/form/src/components/Dependency/index.tsx
+++ b/packages/form/src/components/Dependency/index.tsx
@@ -92,8 +92,7 @@ const ProFormDependency: React.FC<ProFormDependencyProps> = ({
         // ignoreFormListField === false 时，取局部依赖值
         const nameValues = name.reduce((pre, namePath) => {
           const finalNamePath = [formListField.listName, namePath].flat(1);
-          const fieldValue =
-            context.getFieldFormatValue?.(finalNamePath) ?? form.getFieldValue(finalNamePath);
+          const fieldValue = form.getFieldValue(finalNamePath);
           return set(pre, [namePath].flat(1), fieldValue, false);
         }, {});
         return children?.({ ...nameValues }, form as FormInstance<any>);

--- a/packages/form/src/components/Dependency/index.tsx
+++ b/packages/form/src/components/Dependency/index.tsx
@@ -92,7 +92,8 @@ const ProFormDependency: React.FC<ProFormDependencyProps> = ({
         // ignoreFormListField === false 时，取局部依赖值
         const nameValues = name.reduce((pre, namePath) => {
           const finalNamePath = [formListField.listName, namePath].flat(1);
-          const fieldValue = form.getFieldValue(finalNamePath);
+          const fieldValue =
+            context.getFieldFormatValue?.(finalNamePath) ?? form.getFieldValue(finalNamePath);
           return set(pre, [namePath].flat(1), fieldValue, false);
         }, {});
         return children?.({ ...nameValues }, form as FormInstance<any>);

--- a/packages/utils/src/transformKeySubmitValue/index.ts
+++ b/packages/utils/src/transformKeySubmitValue/index.ts
@@ -50,9 +50,14 @@ const transformKeySubmitValue = <T = any>(
   }
 
   if (typeof window === 'undefined') return values;
-  // 如果 value 是 string | null | Blob类型 其中之一，直接返回
+  // 如果 value 是 string | null | Array | Blob类型 其中之一，直接返回
   // 形如 {key: [File, File]} 的表单字段当进行第二次递归时会导致其直接越过 typeof value !== 'object' 这一判断 https://github.com/ant-design/pro-components/issues/2071
-  if (typeof values !== 'object' || isNil(values) || values instanceof Blob) {
+  if (
+    typeof values !== 'object' ||
+    Array.isArray(values) ||
+    isNil(values) ||
+    values instanceof Blob
+  ) {
     return values;
   }
   let finalValues = {} as T;

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -457,6 +457,35 @@ describe('utils', () => {
     expect(html.a.b.name).toBe('qixian_test');
   });
 
+  it('📅 transformKeySubmitValue for array', async () => {
+    const html = transformKeySubmitValue(
+      [
+        {
+          name: 1,
+        },
+        {
+          name: 2,
+        },
+        {
+          f: [1, 2, 4],
+        },
+      ],
+      {
+        1: {
+          name: (e: string) => {
+            return {
+              name: 2,
+              name2: `qixian_${e}`,
+            };
+          },
+        },
+      },
+    );
+
+    //@ts-expect-error
+    expect(html[1].name2).toBe('qixian_2');
+  });
+
   it('📅 transformKeySubmitValue return array', async () => {
     const html = transformKeySubmitValue(
       {


### PR DESCRIPTION
如果监听的内容为数组，比如ProFormCascader组件，监听的内容会从数组转成对象。["A", "B"] -> {0: "A", 1: "B"}