### PR TITLE
fix: ProFormList should show label when  form layout is horizontal

### DIFF
--- a/packages/form/src/components/List/index.less
+++ b/packages/form/src/components/List/index.less
@@ -3,12 +3,20 @@
 
 @pro-table-prefix-cls: ~'@{ant-prefix}-pro-form';
 
+// 只有在垂直模式隐藏label
+.@{ant-prefix}-form:not(.@{ant-prefix}-form-horizontal) {
+  .@{pro-table-prefix-cls}-list {
+    &-item {
+      .@{ant-prefix}-form-item-label {
+        display: none;
+      }
+    }
+  }
+}
+
 .@{pro-table-prefix-cls}-list {
   max-width: 100%;
   &-item {
-    .@{ant-prefix}-form-item-label {
-      display: none;
-    }
     &&-show-label {
       .@{ant-prefix}-form-item-label {
         display: inline-block;


### PR DESCRIPTION
只有Form是垂直模式才隐藏label
修改前
![image](https://user-images.githubusercontent.com/29698222/150496100-018f4ba6-a37a-438f-ad2e-f3878b16ba2d.png)
修改后
![image](https://user-images.githubusercontent.com/29698222/150496119-92c56ec6-d229-4c84-a03a-99b11e528558.png)
