### PR TITLE
fix(form): proformlist style bug

### DIFF
--- a/packages/form/src/components/List/index.less
+++ b/packages/form/src/components/List/index.less
@@ -24,10 +24,6 @@
     }
   }
 
-  &-container {
-    margin-right: 8px;
-  }
-
   &-item {
     &:first-of-type {
       div:first-of-type {
@@ -55,14 +51,11 @@
   }
 
   &-action-icon {
-    margin-right: 8px;
+    margin-left: 8px;
     cursor: pointer;
     transition: color 0.3s ease-in-out;
     &:hover {
       color: @primary-color-hover;
-    }
-    &:last-child {
-      margin-right: 0;
     }
   }
 


### PR DESCRIPTION
当ProForm外层统一设置`<ConfigProvider getPopupContainer={(e)=>e.parentElement()}></ConfigProvider> `，鼠标hover后，多了一个div，导致`&-action-icon:last-child {margin-right: 0;}`失效，出现按钮抖动

![image](https://user-images.githubusercontent.com/29698222/150708788-9676edac-dcca-464f-9bba-2dfeb1fd16d8.png)
