### PR TITLE
fix(form): ModalForm and DrawForm close animation when destroyOnClose

### DIFF
--- a/packages/form/src/layouts/DrawerForm/index.tsx
+++ b/packages/form/src/layouts/DrawerForm/index.tsx
@@ -69,7 +69,9 @@ function DrawerForm<T = Record<string, any>>({
   const [isDestroy, setIsDestroy] = useMergedState<boolean>(!!rest.visible);
 
   useEffect(() => {
-    setIsDestroy(!!rest.visible);
+    if (!!rest.visible) {
+      setIsDestroy(!!rest.visible);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rest.visible]);
 

--- a/packages/form/src/layouts/ModalForm/index.tsx
+++ b/packages/form/src/layouts/ModalForm/index.tsx
@@ -70,7 +70,9 @@ function ModalForm<T = Record<string, any>>({
   const [isDestroy, setIsDestroy] = useState<boolean>(!!rest.visible);
 
   useEffect(() => {
-    setIsDestroy(!!rest.visible);
+    if (!!rest.visible) {
+      setIsDestroy(!!rest.visible);
+    }
   }, [rest.visible]);
 
   const context = useContext(ConfigProvider.ConfigContext);


### PR DESCRIPTION
Closes #4405.