### PR TITLE
fix(form): 解决 EditableProTable 与 FormItem 配合使用时操作按钮无法获取表单实例而报错的问题

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -629,6 +629,12 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     propsActionRef.current = actionRef.current;
   }
 
+  // 当与 FormItem 配合使用时，由于内部不再创建 ProForm，需要用户将外部创建的 formRef 传进来后设置到当前的编辑表格表单中
+  // fix: #4600
+  if (props.formRef) {
+    counter.setEditorTableForm(props.formRef.current!);
+  }
+
   // ---------- 列计算相关 start  -----------------
   const tableColumn = useMemo(() => {
     return genProColumnToColumn<T>({

--- a/packages/table/src/components/EditableTable/demos/form-item.tsx
+++ b/packages/table/src/components/EditableTable/demos/form-item.tsx
@@ -117,6 +117,7 @@ export default () => {
         headerTitle="可编辑表格"
         maxLength={5}
         name="table"
+        formRef={formRef}
         recordCreatorProps={
           position !== 'hidden'
             ? {


### PR DESCRIPTION
fix: #4600 

- 由于在配合 `FormItem` 使用时，`EditableProTable` 内部不再创建表单，此时，我们应该接受外部传入的表单实例作为可编辑表单的表单实例。