### PR TITLE
fix: 修复queryFilter响应式会受span的属性顺序问题

### DIFF
--- a/packages/form/src/layouts/QueryFilter/index.tsx
+++ b/packages/form/src/layouts/QueryFilter/index.tsx
@@ -60,8 +60,13 @@ const getSpanConfig = (
       layout,
     };
   }
+
   const spanConfig = span
-    ? Object.keys(span).map((key) => [CONFIG_SPAN_BREAKPOINTS[key], 24 / span[key], 'horizontal'])
+    ? ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'].map((key) => [
+        CONFIG_SPAN_BREAKPOINTS[key],
+        24 / span[key],
+        'horizontal',
+      ])
     : BREAKPOINTS[layout || 'default'];
 
   const breakPoint = (spanConfig || BREAKPOINTS.default).find(


### PR DESCRIPTION
原有的设计，强依赖了span的属性顺序，如果顺序不对，比如：
`{
xxl: 8,
xs: 1,
  sm: 2,
  md: 3,
  lg: 4,
  xl: 6,
}`
就会一直使用xxl的值