### PR TITLE
fix: ProTable 默认表头可滚动，表格滚动在antd中

### DIFF
--- a/packages/table/src/components/ListToolBar/index.less
+++ b/packages/table/src/components/ListToolBar/index.less
@@ -4,6 +4,7 @@
 @pro-list-toolbar: ~'@{ant-prefix}-pro-table-list-toolbar';
 
 .@{pro-list-toolbar} {
+  overflow-x: auto;
   line-height: 1;
 
   &-container {


### PR DESCRIPTION
相关issue：
https://github.com/ant-design/ant-design/issues/34210
https://github.com/ant-design/pro-components/issues/4728