### PR TITLE
fix(WaterMark): fix css margin collapse issue in some cases

### DIFF
--- a/packages/layout/src/components/WaterMark/index.tsx
+++ b/packages/layout/src/components/WaterMark/index.tsx
@@ -158,6 +158,7 @@ const WaterMark: React.FC<WaterMarkProps> = (props) => {
     <div
       style={{
         position: 'relative',
+        overflow: 'hidden',
         ...style,
       }}
       className={wrapperCls}


### PR DESCRIPTION
说明：

antd-pro 项目 simple 模板中，提供了以下路由配置：

```ts
{
    path: '/admin',
    component: './Admin',
    routes: [
      {
          path: '/admin/sub-page',
          component: './Welcome',
      },
}
```

为了让子路由的 Welcome 组件展示出来，需要在 Admin 组件中，手动渲染 props.children。此时，就有了以下结构：

```tsx
<PageHeaderWrapper>
    {props.children}
    <Card>...</Card>
</PageHeaderWrapper>
```

这种情况下，Welcome 组件中的 `ant-pro-layout-watermark-wrapper` 元素的布局，会受到 CSS Margin 塌陷的影响