### PR TITLE
fix(PageContainer): fix the logic of `WaterMark` props

### DIFF
--- a/packages/layout/src/components/PageContainer/index.tsx
+++ b/packages/layout/src/components/PageContainer/index.tsx
@@ -329,7 +329,11 @@ const PageContainer: React.FC<PageContainerProps> = (props) => {
     // 只要loadingDom非空我们就渲染loadingDom,否则渲染内容
     const dom = loadingDom || content;
     if (props.waterMarkProps || value.waterMarkProps) {
-      return <WaterMark {...(props.waterMarkProps || value.waterMarkProps)}>{dom}</WaterMark>;
+      const waterMarkProps = {
+        ...value.waterMarkProps,
+        ...props.waterMarkProps,
+      };
+      return <WaterMark {...waterMarkProps}>{dom}</WaterMark>;
     }
     return dom;
   }, [props.waterMarkProps, value.waterMarkProps, loadingDom, content]);


### PR DESCRIPTION
说明：

1. 合并 ProLayout 和 PageContainer 的 waterMarkProps，已达到复用某些 props 的目的，~~而不是直接用 PageContainer 替换 ProLayout 的 waterMarkProps~~
2. 优先级：PageContainer > ProLayout