### PR TITLE
feat(ProTable): improve the `clearSelected` type of `ActionType`

### DIFF
--- a/packages/table/src/components/EditableTable/index.en-US.md
+++ b/packages/table/src/components/EditableTable/index.en-US.md
@@ -209,7 +209,7 @@ render: (text, record, _, action) => [
   <a
     key="editable"
     onClick={() => {
-      action?.startEditable? (record.id);
+      action?.startEditable?.(record.id);
     }}
   >
     Edit

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -415,7 +415,7 @@ interface ActionType {
   reload: (resetPageIndex?: boolean) => void;
   reloadAndRest: () => void;
   reset: () => void;
-  clearSelected?: () => void;
+  clearSelected: () => void;
   startEditable: (rowKey: Key) => boolean;
   cancelEditable: (rowKey: Key) => boolean;
 }

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -95,7 +95,7 @@ export type ProCoreActionType<T = {}> = {
   /** @name 重置任何输入项，包括表单 */
   reset?: () => void;
   /** @name 清空选择 */
-  clearSelected?: () => void;
+  clearSelected: () => void;
   /** @name p页面的信息都在里面 */
   pageInfo?: PageInfo;
 } & Omit<

--- a/tests/table/index.test.tsx
+++ b/tests/table/index.test.tsx
@@ -562,7 +562,7 @@ describe('BasicTable', () => {
     await waitForComponentToPaint(html, 1200);
 
     act(() => {
-      actionRef.current?.clearSelected?.();
+      actionRef.current?.clearSelected();
     });
     await waitForComponentToPaint(html);
     expect(fn).toBeCalled();


### PR DESCRIPTION
说明：

通过 ref 调用 ProTable 的 clearSelected 方法，需要：`actionRef.current?.clearSelected?.()`

内置方法 `clearSelected` 应该是一定存在的吧？
如果是，TS 类型中直接去调用可选，这样用起来会更简洁一些（ => `actionRef.current?.clearSelected()`）。