### PR TITLE
feat(form): improve type and support external override type

### DIFF
--- a/packages/form/src/components/SchemaForm/demos/customization-value-type.tsx
+++ b/packages/form/src/components/SchemaForm/demos/customization-value-type.tsx
@@ -4,6 +4,15 @@ import { BetaSchemaForm } from '@ant-design/pro-form';
 import ProProvider from '@ant-design/pro-provider';
 import { Input, Space, Tag } from 'antd';
 
+declare module '@ant-design/pro-utils' {
+  interface ProFieldValueTypeWithFieldProps {
+    tags: Record<string, any>;
+    link: {
+      customField: string;
+    };
+  }
+}
+
 const valueEnum = {
   0: 'close',
   1: 'running',
@@ -74,7 +83,7 @@ const TagList: React.FC<{
   );
 };
 
-const columns: ProFormColumnsType<TableListItem, 'link' | 'tags'>[] = [
+const columns: ProFormColumnsType<TableListItem>[] = [
   {
     title: '标签',
     valueType: 'group',
@@ -141,7 +150,7 @@ export default () => {
         },
       }}
     >
-      <BetaSchemaForm<TableListItem, 'link' | 'tags'>
+      <BetaSchemaForm<TableListItem>
         initialValues={{
           key: 1,
           name: `TradeCode 1`,

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -39,6 +39,7 @@ import useLatest from './hooks/useLatest';
 /** Type */
 import type {
   ProSchema,
+  ProFieldValueTypeWithFieldProps,
   ProSchemaValueEnumMap,
   ProSchemaValueEnumObj,
   ProSchemaComponentTypes,
@@ -79,6 +80,7 @@ export type {
   SearchConvertKeyFn,
   RequestOptionsType,
   ProSchema,
+  ProFieldValueTypeWithFieldProps,
   ProSchemaValueType,
   ProCoreActionType,
   ProSchemaComponentTypes,

--- a/packages/utils/src/types/index.ts
+++ b/packages/utils/src/types/index.ts
@@ -19,161 +19,52 @@ import type {
 import type { RangePickerProps } from 'antd/lib/date-picker';
 import type { PasswordProps, TextAreaProps } from 'antd/lib/input';
 import type { SketchPickerProps } from 'react-color';
-import type { ProFieldValueObjectType, ProSchema } from '../typing';
+import type { ProFieldRequestData, ProSchema } from '../typing';
 
-type FieldPropsCommonType = Record<string, any>;
-
-export type ProFieldValueTypeWithFieldProps =
-  | {
-      valueType: 'text';
-      fieldProps: InputProps;
-    }
-  | {
-      valueType: 'password';
-      fieldProps: PasswordProps;
-    }
-  | {
-      valueType: 'money';
-      fieldProps: FieldPropsCommonType;
-    }
-  | {
-      valueType: 'textarea';
-      fieldProps: TextAreaProps;
-    }
-  | {
-      valueType: 'option';
-      fieldProps: FieldPropsCommonType;
-    }
-  | {
-      valueType: 'date';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'dateWeek';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'dateMonth';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'dateQuarter';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'dateYear';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'dateRange';
-      fieldProps: RangePickerProps;
-    }
-  | {
-      valueType: 'dateTimeRange';
-      fieldProps: RangePickerProps;
-    }
-  | {
-      valueType: 'dateTime';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'time';
-      fieldProps: TimeRangePickerProps;
-    }
-  | {
-      valueType: 'timeRange';
-      fieldProps: TimeRangePickerProps;
-    }
-  | {
-      valueType: 'select';
-      fieldProps: SelectProps;
-    }
-  | {
-      valueType: 'checkbox';
-      fieldProps: CheckboxProps;
-    }
-  | {
-      valueType: 'rate';
-      fieldProps: RateProps;
-    }
-  | {
-      valueType: 'radio';
-      fieldProps: RadioProps;
-    }
-  | {
-      valueType: 'radioButton';
-      fieldProps: RadioProps;
-    }
-  | {
-      valueType: 'index';
-      fieldProps: FieldPropsCommonType;
-    }
-  | {
-      valueType: 'indexBorder';
-      fieldProps: FieldPropsCommonType;
-    }
-  | {
-      valueType: 'progress';
-      fieldProps: ProgressProps;
-    }
-  | {
-      valueType: 'percent';
-      fieldProps: InputNumberProps;
-    }
-  | {
-      valueType: 'digit';
-      fieldProps: InputNumberProps;
-    }
-  | {
-      valueType: 'digitRange';
-      fieldProps: InputNumberProps;
-    }
-  | {
-      valueType: 'second';
-      fieldProps: InputNumberProps;
-    }
-  | {
-      valueType: 'code';
-      fieldProps: InputProps | TextAreaProps;
-    }
-  | {
-      valueType: 'jsonCode';
-      fieldProps: InputProps | TextAreaProps;
-    }
-  | {
-      valueType: 'avatar';
-      fieldProps: AvatarProps;
-    }
-  | {
-      valueType: 'switch';
-      fieldProps: SwitchProps;
-    }
-  | {
-      valueType: 'fromNow';
-      fieldProps: DatePickerProps;
-    }
-  | {
-      valueType: 'image';
-      fieldProps: ImageProps | InputProps;
-    }
-  | {
-      valueType: 'cascader';
-      fieldProps: CascaderProps<any>;
-    }
-  | {
-      valueType: 'treeSelect';
-      fieldProps: TreeSelectProps;
-    }
-  | {
-      valueType: 'color';
-      fieldProps: SketchPickerProps & {
-        value?: string;
-        popoverProps?: PopoverProps;
-        mode?: 'read' | 'edit';
-        onChange?: (color: string) => void;
-        colors?: string[];
-      };
-    };
+export interface ProFieldValueTypeWithFieldProps {
+  text: InputProps;
+  password: PasswordProps;
+  money: Record<string, any>;
+  index: Record<string, any>;
+  indexBorder: Record<string, any>;
+  option: Record<string, any>;
+  textarea: TextAreaProps;
+  date: DatePickerProps;
+  dateWeek: DatePickerProps;
+  dateMonth: DatePickerProps;
+  dateQuarter: DatePickerProps;
+  dateYear: DatePickerProps;
+  dateTime: DatePickerProps;
+  fromNow: DatePickerProps;
+  dateRange: RangePickerProps;
+  dateTimeRange: RangePickerProps;
+  time: TimeRangePickerProps;
+  timeRange: TimeRangePickerProps;
+  select: SelectProps;
+  checkbox: CheckboxProps;
+  rate: RateProps;
+  radio: RadioProps;
+  radioButton: RadioProps;
+  progress: ProgressProps;
+  percent: InputNumberProps;
+  digit: InputNumberProps;
+  digitRange: InputNumberProps;
+  second: InputNumberProps;
+  code: InputProps | TextAreaProps;
+  jsonCode: InputProps | TextAreaProps;
+  avatar: AvatarProps;
+  switch: SwitchProps;
+  image: ImageProps | InputProps;
+  cascader: CascaderProps<any>;
+  treeSelect: TreeSelectProps;
+  color: SketchPickerProps & {
+    value?: string;
+    popoverProps?: PopoverProps;
+    mode?: 'read' | 'edit';
+    onChange?: (color: string) => void;
+    colors?: string[];
+  };
+}
 
 /**
  * @param textarea 文本框
@@ -203,7 +94,7 @@ export type ProFieldValueTypeWithFieldProps =
  * @param color 颜色选择器
  * @param color 颜色选择器
  */
-export type ProFieldValueType = ProFieldValueTypeWithFieldProps['valueType'];
+export type ProFieldValueType = Extract<keyof ProFieldValueTypeWithFieldProps, any>;
 
 type FieldPropsTypeBase<Entity, ComponentsType, ExtraProps, FieldPropsType> =
   | ((
@@ -219,50 +110,45 @@ type FieldPropsTypeBase<Entity, ComponentsType, ExtraProps, FieldPropsType> =
   | FieldPropsType
   | Record<string, any>;
 
-type PickFieldPropsByValueType<Type> = [ProFieldValueTypeWithFieldProps] extends [infer Item]
-  ? Item extends { valueType: any; fieldProps: any }
-    ? Type extends Item['valueType']
-      ? Item['fieldProps']
-      : never
-    : never
+export type ProFieldValueObject<Type> = Type extends 'progress' | 'money' | 'percent' | 'image'
+  ? {
+      type: Type;
+      status?: 'normal' | 'active' | 'success' | 'exception' | undefined;
+      locale?: string;
+      /** Percent */
+      showSymbol?: ((value: any) => boolean) | boolean;
+      showColor?: boolean;
+      precision?: number;
+      moneySymbol?: boolean;
+      request?: ProFieldRequestData;
+      /** Image */
+      width?: number;
+    }
   : never;
 
-type GetValueType<T> = T extends { type: infer Type } ? Type : T;
-
-type ValueTypeWithFieldPropsBase<Entity, ComponentsType, ExtraProps, ValueType> = {
-  valueType?: ValueType extends (...args: any) => any ? never : ValueType;
+type ValueTypeWithFieldPropsBase<Entity, ComponentsType, ExtraProps, Type> = {
+  valueType?:
+    | Type
+    | ProFieldValueObject<Type>
+    | ((entity: Entity, type: ComponentsType) => Type | ProFieldValueObject<Type>);
   fieldProps?: FieldPropsTypeBase<
     Entity,
     ComponentsType,
     ExtraProps,
-    PickFieldPropsByValueType<GetValueType<ValueType>>
+    ProFieldValueTypeWithFieldProps[ProFieldValueType]
   >;
 };
 
-type ValueTypeWithFieldPropsBaseFunction<Entity, ComponentsType, ExtraProps, ValueType> = {
-  valueType?: (entity: Entity, type: ComponentsType) => ValueType;
-  fieldProps?: FieldPropsTypeBase<
-    Entity,
-    ComponentsType,
-    ExtraProps,
-    PickFieldPropsByValueType<GetValueType<ValueType>>
-  >;
-};
-
-type UnionSameValueType<ValueType> = [ValueType] extends [infer Type]
+type UnionSameValueType<Type> = Type extends any
   ? Type extends ProFieldValueType
     ? never
     : Type
-  : ValueType;
+  : never;
 
 export type ValueTypeWithFieldProps<Entity, ComponentsType, ExtraProps, ValueType> =
-  | ValueTypeWithFieldPropsBase<Entity, ComponentsType, ExtraProps, ProFieldValueObjectType>
-  | ValueTypeWithFieldPropsBase<Entity, ComponentsType, ExtraProps, ProFieldValueType | undefined>
-  | ValueTypeWithFieldPropsBase<Entity, ComponentsType, ExtraProps, UnionSameValueType<ValueType>>
-  | ValueTypeWithFieldPropsBaseFunction<Entity, ComponentsType, ExtraProps, ProFieldValueType>
-  | ValueTypeWithFieldPropsBaseFunction<
-      Entity,
-      ComponentsType,
-      ExtraProps,
-      ProFieldValueObjectType
-    >;
+  ValueTypeWithFieldPropsBase<
+    Entity,
+    ComponentsType,
+    ExtraProps,
+    ProFieldValueType | UnionSameValueType<ValueType> | undefined
+  >;

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -4,7 +4,11 @@ import type { LabelTooltipType } from 'antd/lib/form/FormItemLabel';
 import type { NamePath } from 'antd/lib/form/interface';
 import type { Moment } from 'moment';
 import type { ReactNode } from 'react';
-import type { ProFieldValueType, ValueTypeWithFieldProps } from './types';
+import type {
+  ProFieldValueType,
+  ProFieldValueTypeWithFieldProps,
+  ValueTypeWithFieldProps,
+} from './types';
 import type { UseEditableUtilType } from './useEditableArray';
 
 export type PageInfo = {
@@ -13,7 +17,7 @@ export type PageInfo = {
   current: number;
 };
 
-export { ProFieldValueType } from './types';
+export type { ProFieldValueType, ProFieldValueTypeWithFieldProps };
 
 export type RequestOptionsType = {
   label?: React.ReactNode;
@@ -70,7 +74,6 @@ export type SearchTransformKeyFn = (
   field: string,
   object: any,
 ) => string | Record<string, any>;
-
 export type SearchConvertKeyFn = (value: any, field: NamePath) => string | Record<string, any>;
 
 export type ProTableEditableFnType<T> = (_: any, record: T, index: number) => boolean;


### PR DESCRIPTION
改进类型提示，支持外部使用如下代码添加新的valueType支持，用于用户使用valueTypeMap导致类型不匹配等问题

```typescript
declare module '@ant-design/pro-utils' {
  interface ProFieldValueTypeWithFieldProps {
    newType: Record<string, any>
  }
}
```