### PR TITLE
UI(layout): 完善 GlobalHeader RTL 支持

### DIFF
--- a/packages/layout/src/components/GlobalHeader/index.less
+++ b/packages/layout/src/components/GlobalHeader/index.less
@@ -53,7 +53,6 @@
       }
       h1 {
         height: 32px;
-        margin: 0 0 0 8px;
         margin: 0 0 0 12px;
         color: @primary-color;
         font-weight: 600;

--- a/packages/layout/src/components/GlobalHeader/index.less
+++ b/packages/layout/src/components/GlobalHeader/index.less
@@ -62,6 +62,14 @@
     }
   }
 
+  &-logo-rtl {
+    a {
+      h1 {
+        margin: 0 12px 0 0;
+      }
+    }
+  }
+
   &-menu {
     .anticon {
       margin-right: 8px;

--- a/packages/layout/src/components/GlobalHeader/index.tsx
+++ b/packages/layout/src/components/GlobalHeader/index.tsx
@@ -1,5 +1,5 @@
 import './index.less';
-import React from 'react';
+import React, { useContext } from 'react';
 import classNames from 'classnames';
 
 import type { HeaderViewProps } from '../../Header';
@@ -14,6 +14,7 @@ import TopNavHeader from '../TopNavHeader';
 import type { MenuDataItem } from '../../index';
 import type { WithFalse } from '../../typings';
 import { clearMenuItem } from '../../utils/utils';
+import { ConfigProvider } from 'antd';
 
 export type GlobalHeaderProps = {
   collapsed?: boolean;
@@ -67,6 +68,7 @@ const GlobalHeader: React.FC<GlobalHeaderProps & PrivateSiderMenuProps> = (props
     menuData,
     prefixCls,
   } = props;
+  const { direction } = useContext(ConfigProvider.ConfigContext);
   const baseClassName = `${prefixCls}-global-header`;
   const className = classNames(propClassName, baseClassName, {
     [`${baseClassName}-layout-${layout}`]: layout && headerTheme === 'dark',
@@ -90,8 +92,12 @@ const GlobalHeader: React.FC<GlobalHeaderProps & PrivateSiderMenuProps> = (props
     );
   }
 
+  const logoClassNames = classNames(`${baseClassName}-logo`, {
+    [`${baseClassName}-logo-rtl`]: direction === 'rtl',
+  });
+
   const logoDom = (
-    <span className={`${baseClassName}-logo`} key="logo">
+    <span className={logoClassNames} key="logo">
       <a>{defaultRenderLogo(logo)}</a>
     </span>
   );
@@ -113,7 +119,7 @@ const GlobalHeader: React.FC<GlobalHeaderProps & PrivateSiderMenuProps> = (props
       )}
       {layout === 'mix' && !isMobile && (
         <>
-          <div className={`${baseClassName}-logo`} onClick={onMenuHeaderClick}>
+          <div className={logoClassNames} onClick={onMenuHeaderClick}>
             {defaultRenderLogoAndTitle({ ...props, collapsed: false }, 'headerTitleRender')}
           </div>
         </>


### PR DESCRIPTION
修复 logo 部分 RTL 时的 margin 间隙

![image](https://user-images.githubusercontent.com/28819315/157670595-cc166a4c-6425-4c65-9c0a-d7e6ed61af47.png)
