### PR TITLE
fix (Form): passing `formItemProps` and `fieldProps` as functions did not work when using `EditableTable` in `Form`

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -213,6 +213,12 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
       )
     : baseTableDom;
 
+  useEffect(() => {
+    if (props.name) {
+      counter.setEditorTableForm(props.editable!.form!);
+    }
+  }, [counter, props.editable, props.name]);
+
   const tableContentDom = useMemo(() => {
     if (props.editable && !props.name) {
       return (

--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -300,20 +300,22 @@ function FieldEditableTable<
       {...props?.formItemProps}
       name={props.name}
     >
-      <>
-        <Field shouldUpdate={true} name={props.name} isList>
-          {(control) => {
-            if (control.value === undefined || !Array.isArray(control.value)) return null;
-            return (
-              <EditableTable<DataType, Params, ValueType>
-                {...props}
-                value={control.value}
-                onChange={control.onChange}
-              />
-            );
-          }}
-        </Field>
-      </>
+      <Field shouldUpdate={true} name={props.name} isList>
+        {(control, _, form) => {
+          if (control.value === undefined || !Array.isArray(control.value)) return null;
+          return (
+            <EditableTable<DataType, Params, ValueType>
+              {...props}
+              editable={{
+                ...props.editable,
+                form: form as ProFormInstance,
+              }}
+              value={control.value}
+              onChange={control.onChange}
+            />
+          );
+        }}
+      </Field>
     </Form.Item>
   );
 }

--- a/packages/table/src/utils/cellRenderToFromItem.tsx
+++ b/packages/table/src/utils/cellRenderToFromItem.tsx
@@ -97,10 +97,8 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
           );
 
           const generateFormItem = useCallback(() => {
-            const formItemProps = getFieldPropsOrFormItemProps(
-              columnProps?.formItemProps,
-              ...needProps,
-            );
+            const formItemProps =
+              getFieldPropsOrFormItemProps(columnProps?.formItemProps, ...needProps) || {};
 
             formItemProps.messageVariables = {
               label: (columnProps?.title as string) || '此项',

--- a/packages/table/src/utils/cellRenderToFromItem.tsx
+++ b/packages/table/src/utils/cellRenderToFromItem.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import type { useContainer } from '../container';
 import type { ProFormFieldProps } from '@ant-design/pro-form';
 import { ProFormField, ProFormDependency } from '@ant-design/pro-form';
 import type { ProFieldEmptyText } from '@ant-design/pro-field';
@@ -9,6 +7,7 @@ import { isDeepEqualReact } from '@ant-design/pro-utils';
 import { runFunction } from '@ant-design/pro-utils';
 import { getFieldPropsOrFormItemProps, InlineErrorFormItem } from '@ant-design/pro-utils';
 import type { ProColumnType } from '../index';
+import type { useContainer } from '../container';
 
 const SHOW_EMPTY_TEXT_LIST = ['', null, undefined];
 
@@ -56,6 +55,7 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
     () =>
       memo<CellRenderFromItemProps<T>>(
         ({ columnProps, prefixName, text, counter, rowData, index, recordKey, proFieldProps }) => {
+          const { editableForm } = counter;
           const key = recordKey || index;
           const [name, setName] = useState<React.Key[]>([]);
 
@@ -76,7 +76,7 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
           const needProps = useMemo(
             () =>
               [
-                counter?.editableForm,
+                editableForm,
                 {
                   ...columnProps,
                   rowKey: rowName,
@@ -84,47 +84,36 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
                   isEditable: true,
                 },
               ] as const,
-            [columnProps, counter?.editableForm, index, rowName],
+            [columnProps, editableForm, index, rowName],
           );
 
-          const formItemProps = useMemo(
-            () => getFieldPropsOrFormItemProps(columnProps?.formItemProps, ...needProps),
-            [columnProps?.formItemProps, needProps],
-          );
-
-          const messageVariables = useMemo(
-            () => ({
-              label: (columnProps?.title as string) || '此项',
-              type: (columnProps?.valueType as string) || '文本',
-              ...formItemProps?.messageVariables,
-            }),
-            [columnProps?.title, columnProps?.valueType, formItemProps?.messageVariables],
-          );
-
-          const initialValue = useMemo(() => {
-            const _value = formItemProps?.initialValue ?? columnProps?.initialValue;
-            if (prefixName) return _value;
-            return text ?? _value;
-          }, [columnProps?.initialValue, formItemProps?.initialValue, prefixName, text]);
-
-          const InlineItem = useCallback<React.FC>(
-            ({ children }) => (
-              <InlineErrorFormItem
-                key={key}
-                errorType="popover"
-                name={name}
-                {...formItemProps}
-                messageVariables={messageVariables}
-                initialValue={initialValue}
-              >
+          const InlineItem = useCallback<React.FC<any>>(
+            ({ children, ...restProps }) => (
+              <InlineErrorFormItem key={key} errorType="popover" name={name} {...restProps}>
                 {children}
               </InlineErrorFormItem>
             ),
-            [key, name, formItemProps, messageVariables, initialValue],
+            [key, name],
           );
 
           const generateFormItem = useCallback(() => {
-            const inputDom = (
+            const formItemProps = getFieldPropsOrFormItemProps(
+              columnProps?.formItemProps,
+              ...needProps,
+            );
+
+            formItemProps.messageVariables = {
+              label: (columnProps?.title as string) || '此项',
+              type: (columnProps?.valueType as string) || '文本',
+              ...formItemProps?.messageVariables,
+            };
+
+            formItemProps.initialValue =
+              (prefixName ? null : text) ??
+              formItemProps?.initialValue ??
+              columnProps?.initialValue;
+
+            let fieldDom: React.ReactNode = (
               <ProFormField
                 cacheForSwr
                 key={key}
@@ -139,42 +128,42 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
             /**
              * 如果没有自定义直接返回
              */
-            if (!columnProps?.renderFormItem) {
-              return <InlineItem>{inputDom}</InlineItem>;
+            if (columnProps?.renderFormItem) {
+              fieldDom = columnProps.renderFormItem(
+                {
+                  ...columnProps,
+                  index,
+                  isEditable: true,
+                  type: 'table',
+                },
+                {
+                  defaultRender: () => <InlineItem {...formItemProps}>{fieldDom}</InlineItem>,
+                  type: 'form',
+                  recordKey,
+                  record: {
+                    ...rowData,
+                    ...editableForm?.getFieldValue([key]),
+                  },
+                  isEditable: true,
+                },
+                editableForm as any,
+              );
             }
 
-            const renderDom = columnProps.renderFormItem?.(
-              {
-                ...columnProps,
-                index,
-                isEditable: true,
-                type: 'table',
-              },
-              {
-                defaultRender: () => <InlineItem>{inputDom}</InlineItem>,
-                type: 'form',
-                recordKey,
-                record: {
-                  ...rowData,
-                  ...counter?.editableForm?.getFieldValue([key]),
-                },
-                isEditable: true,
-              },
-              counter?.editableForm as any,
-            );
-
-            return <InlineItem>{renderDom}</InlineItem>;
+            return <InlineItem {...formItemProps}>{fieldDom}</InlineItem>;
           }, [
-            key,
-            InlineItem,
             columnProps,
-            counter?.editableForm,
-            index,
-            name,
             needProps,
+            prefixName,
+            text,
+            key,
+            name,
             proFieldProps,
+            index,
             recordKey,
             rowData,
+            editableForm,
+            InlineItem,
           ]);
 
           if (name.length === 0) {

--- a/packages/table/src/utils/columnRender.tsx
+++ b/packages/table/src/utils/columnRender.tsx
@@ -136,7 +136,7 @@ export function columnRender<T>({
   if (mode === 'edit') {
     if (columnProps.valueType === 'option') {
       return (
-        <OptionsCell record={rowData} form={editableForm}>
+        <OptionsCell record={rowData} form={editableForm!}>
           {(inform) => {
             return editableUtils.actionRender(
               {

--- a/packages/table/src/utils/columnRender.tsx
+++ b/packages/table/src/utils/columnRender.tsx
@@ -16,7 +16,6 @@ import type { ActionType, ProColumns } from '../typing';
 import type { useContainer } from '../container';
 import { isMergeCell } from '.';
 import type { ProFormInstance } from '@ant-design/pro-form';
-import ProForm from '@ant-design/pro-form';
 
 /** 转化列的定义 */
 type ColumnRenderInterface<T> = {
@@ -76,7 +75,7 @@ export const defaultOnFilter = (value: string, record: any, dataIndex: string | 
 class OptionsCell extends React.Component<{
   children: (form: ProFormInstance) => React.ReactNode;
   record: any;
-  form?: ProFormInstance;
+  form: ProFormInstance;
 }> {
   shouldComponentUpdate(nextProps: any) {
     const { children, ...restProps } = this.props;
@@ -84,14 +83,7 @@ class OptionsCell extends React.Component<{
     return !isDeepEqualReact(restProps, restNextProps);
   }
   render() {
-    if (this.props.form) return <Space>{this.props.children(this.props.form)}</Space>;
-    return (
-      <ProForm.Item noStyle shouldUpdate={true}>
-        {(form) => {
-          return <Space>{this.props.children(form as ProFormInstance<any>)}</Space>;
-        }}
-      </ProForm.Item>
-    );
+    return <Space>{this.props.children(this.props.form)}</Space>;
   }
 }
 /**

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -726,6 +726,59 @@ describe('EditorProTable', () => {
     );
   });
 
+  it('📝 EditableProTable ensures that xxxProps are functions also executed', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const formItemPropsFn = jest.fn();
+    const fieldPropsFn = jest.fn();
+
+    const currentlyColumns: ProColumns<DataSourceType>[] = [
+      {
+        dataIndex: 'index',
+        valueType: 'indexBorder',
+        width: 48,
+        renderFormItem: () => <InputNumber />,
+      },
+      {
+        title: '标题',
+        dataIndex: 'title',
+        formItemProps: formItemPropsFn,
+        fieldProps: fieldPropsFn,
+      },
+    ];
+
+    const wrapper = mount(
+      <ProForm
+        initialValues={{
+          table: [
+            {
+              id: '624748504',
+              title: '🐛 [BUG]yarn install命令 antd2.4.5会报错',
+            },
+          ],
+        }}
+      >
+        <EditableProTable<DataSourceType>
+          rowKey="id"
+          controlled
+          name="table"
+          editable={{
+            editableKeys: ['624748504'],
+          }}
+          columns={currentlyColumns}
+        />
+      </ProForm>,
+    );
+    await waitForComponentToPaint(wrapper, 100);
+
+    expect(formItemPropsFn).toBeCalled();
+    expect(fieldPropsFn).toBeCalled();
+
+    expect(errorSpy).not.toBeCalled();
+
+    errorSpy.mockRestore();
+  });
+
   it('📝 EditableProTable support recordCreatorProps.position', async () => {
     const wrapper = mount(
       <EditableProTable<DataSourceType>


### PR DESCRIPTION
fix: #4696