### PR TITLE
feat(ProTable): `newRecordType: cache` support parentKey

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -27,6 +27,8 @@ import {
   useEditableArray,
   ErrorBoundary,
   useDeepCompareEffectDebounce,
+  editableRowByKey,
+  recordKeyToString,
 } from '@ant-design/pro-utils';
 
 import useFetchData from './useFetchData';
@@ -67,6 +69,7 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
     onFilterChange: (sort: any) => void;
     editableUtils: any;
     rootRef: React.RefObject<HTMLDivElement>;
+    getRowKey: GetRowKey<any>;
   },
 ) {
   const {
@@ -94,6 +97,7 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
     cardBordered,
     editableUtils,
     rootRef,
+    getRowKey,
     ...rest
   } = props;
   const counter = Container.useContainer();
@@ -138,8 +142,25 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
    *
    * @returns
    */
-  const editableDataSource = (): T[] => {
+  const editableDataSource = (dataSource: any[]): T[] => {
     const { options: newLineOptions, defaultValue: row } = editableUtils.newLineRecord || {};
+    if (newLineOptions?.parentKey) {
+      const actionProps = {
+        data: dataSource,
+        getRowKey: getRowKey,
+        row: {
+          ...row,
+          map_row_parentKey: newLineOptions?.parentKey
+            ? recordKeyToString(newLineOptions?.parentKey)?.toString()
+            : undefined,
+        },
+        key: newLineOptions?.recordKey,
+        childrenColumnName: props.expandable?.childrenColumnName || 'children',
+      };
+
+      return editableRowByKey(actionProps, newLineOptions.position === 'top' ? 'top' : 'update');
+    }
+
     if (newLineOptions?.position === 'top') {
       return [row, ...action.dataSource];
     }
@@ -164,7 +185,9 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
     style: tableStyle,
     columns: columns.map((item) => (item.isExtraColumns ? item.extraColumn : item)),
     loading: action.loading,
-    dataSource: editableUtils.newLineRecord ? editableDataSource() : action.dataSource,
+    dataSource: editableUtils.newLineRecord
+      ? editableDataSource(action.dataSource)
+      : action.dataSource,
     pagination,
     onChange: (
       changePagination: TablePaginationConfig,
@@ -785,6 +808,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
       onSortChange={setProSort}
       onFilterChange={setProFilter}
       editableUtils={editableUtils}
+      getRowKey={getRowKey}
     />
   );
 };

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -150,9 +150,7 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
         getRowKey: getRowKey,
         row: {
           ...row,
-          map_row_parentKey: newLineOptions?.parentKey
-            ? recordKeyToString(newLineOptions?.parentKey)?.toString()
-            : undefined,
+          map_row_parentKey: recordKeyToString(newLineOptions?.parentKey)?.toString(),
         },
         key: newLineOptions?.recordKey,
         childrenColumnName: props.expandable?.childrenColumnName || 'children',

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -19,7 +19,7 @@ import type {
   UseEditableType,
   UseEditableUtilType,
 } from './useEditableArray';
-import useEditableArray from './useEditableArray';
+import useEditableArray, { editableRowByKey, recordKeyToString } from './useEditableArray';
 import type { UseEditableMapType, UseEditableMapUtilType } from './useEditableMap';
 import useEditableMap from './useEditableMap';
 import useMountMergeState from './useMountMergeState';
@@ -139,6 +139,8 @@ export {
   getFieldPropsOrFormItemProps,
   dateArrayFormatter,
   nanoid,
+  editableRowByKey,
+  recordKeyToString,
   // hooks
   useEditableArray,
   useEditableMap,

--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -142,7 +142,7 @@ export type ActionRenderConfig<T, LineConfig = NewLineConfig<T>> = {
  * @param params
  * @param action
  */
-function editableRowByKey<RecordType>(
+export function editableRowByKey<RecordType>(
   params: {
     data: RecordType[];
     childrenColumnName: string;

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -328,6 +328,50 @@ describe('EditorProTable', () => {
     wrapper.unmount();
   });
 
+  it('📝 EditableProTable add support parentKey when newRecordType = cache', async () => {
+    const fn = jest.fn();
+    const wrapper = mount(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        recordCreatorProps={{
+          newRecordType: 'cache',
+          record: () => ({
+            id: 555,
+          }),
+          parentKey: () => 624748504,
+          id: 'add_new',
+        }}
+        columns={columns}
+        defaultValue={defaultData}
+        onChange={(list) => fn(list.length)}
+        expandable={{
+          defaultExpandAllRows: true,
+        }}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+    act(() => {
+      wrapper.find('button#add_new').at(0).simulate('click');
+    });
+    await waitForComponentToPaint(wrapper, 2000);
+
+    expect(fn).not.toBeCalled();
+    act(() => {
+      wrapper
+        .find('.ant-table-tbody tr.ant-table-row')
+        .at(1)
+        .find(`td .ant-input`)
+        .at(0)
+        .simulate('change', {
+          target: {
+            value: 'zqran',
+          },
+        });
+    });
+
+    wrapper.unmount();
+  });
+
   it('📝 EditableProTable support maxLength', async () => {
     const wrapper = mount(
       <EditableProTable<DataSourceType>

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -372,6 +372,51 @@ describe('EditorProTable', () => {
     wrapper.unmount();
   });
 
+  it('📝 EditableProTable add support without parentKey when newRecordType = cache', async () => {
+    const fn = jest.fn();
+    const wrapper = mount(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        recordCreatorProps={{
+          newRecordType: 'cache',
+          position: 'top',
+          record: () => ({
+            id: 555,
+          }),
+          id: 'add_new',
+        }}
+        columns={columns}
+        defaultValue={defaultData}
+        onChange={(list) => fn(list.length)}
+        expandable={{
+          defaultExpandAllRows: true,
+        }}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+    act(() => {
+      wrapper.find('button#add_new').at(0).simulate('click');
+    });
+    await waitForComponentToPaint(wrapper, 2000);
+
+    expect(fn).not.toBeCalled();
+
+    act(() => {
+      wrapper
+        .find('.ant-table-tbody tr.ant-table-row')
+        .at(0)
+        .find(`td .ant-input`)
+        .at(0)
+        .simulate('change', {
+          target: {
+            value: 'zqran',
+          },
+        });
+    });
+
+    wrapper.unmount();
+  });
+
   it('📝 EditableProTable support maxLength', async () => {
     const wrapper = mount(
       <EditableProTable<DataSourceType>

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -372,51 +372,6 @@ describe('EditorProTable', () => {
     wrapper.unmount();
   });
 
-  it('📝 EditableProTable add support without parentKey when newRecordType = cache', async () => {
-    const fn = jest.fn();
-    const wrapper = mount(
-      <EditableProTable<DataSourceType>
-        rowKey="id"
-        recordCreatorProps={{
-          newRecordType: 'cache',
-          position: 'top',
-          record: () => ({
-            id: 555,
-          }),
-          id: 'add_new',
-        }}
-        columns={columns}
-        defaultValue={defaultData}
-        onChange={(list) => fn(list.length)}
-        expandable={{
-          defaultExpandAllRows: true,
-        }}
-      />,
-    );
-    await waitForComponentToPaint(wrapper, 1000);
-    act(() => {
-      wrapper.find('button#add_new').at(0).simulate('click');
-    });
-    await waitForComponentToPaint(wrapper, 2000);
-
-    expect(fn).not.toBeCalled();
-
-    act(() => {
-      wrapper
-        .find('.ant-table-tbody tr.ant-table-row')
-        .at(0)
-        .find(`td .ant-input`)
-        .at(0)
-        .simulate('change', {
-          target: {
-            value: 'zqran',
-          },
-        });
-    });
-
-    wrapper.unmount();
-  });
-
   it('📝 EditableProTable support maxLength', async () => {
     const wrapper = mount(
       <EditableProTable<DataSourceType>


### PR DESCRIPTION
说明：

当前版本存在的问题：newRecordType 必须是 dataSource，parentKey 才会生效

```ts
actionRef.current?.addEditRecord(
  {
    id: (Math.random() * 1000000).toFixed(0),
  },
  // 此处，newRecordType 必须是 dataSource，parentKey 才会生效
  { parentKey: record.id, position: 'top', newRecordType: 'dataSource' },
)
```

该 PR 为 newRecordType 为 `'cache'`（默认值），增加了 parentKey 支持，可以插入到指定节点下