### PR TITLE
docs: Update the recommended way of dynamic rendering

### DIFF
--- a/packages/form/src/components/SchemaForm/demos/dynamic-rerender.tsx
+++ b/packages/form/src/components/SchemaForm/demos/dynamic-rerender.tsx
@@ -81,15 +81,27 @@ const columns: ProFormColumnsType<DataItem>[] = [
     },
   },
   {
-    title: 'title为hidden时隐藏',
-    dataIndex: 'hidden',
-    valueType: 'date',
-    renderFormItem: (_, __, form) => {
-      if (form.getFieldValue('title') === 'hidden') {
-        return false;
-      } else {
-        return <Input />;
-      }
+    valueType: 'dependency',
+    fieldProps: {
+      name: ['title'],
+    },
+    columns: ({ title }) => {
+      return title !== 'hidden'
+        ? [
+            {
+              title: 'title为hidden时隐藏',
+              dataIndex: 'hidden',
+              valueType: 'date',
+              renderFormItem: (_, __, form) => {
+                if (form.getFieldValue('title') === 'hidden') {
+                  return false;
+                } else {
+                  return <Input />;
+                }
+              },
+            },
+          ]
+        : [];
     },
   },
   {

--- a/packages/form/src/components/SchemaForm/index.en-US.md
+++ b/packages/form/src/components/SchemaForm/index.en-US.md
@@ -53,7 +53,7 @@ The most important thing about the SchemaForm form is the type definition of the
 | `formItemProps` | `(form,config)=>formItemProps` \| `formItemProps` | Configuration passed to Form.Item |
 | `renderText` | `(text: any, record: Entity, index: number, action: ProCoreActionType) => any` | The modified data will be consumed by the rendering component defined by valueType |
 | `render` | `(dom,entity,index, action, schema) => React.ReactNode` | custom read-only mode dom, read-only mode managed by `render` method only, edit mode needs to use `renderFormItem` |
-| `renderFormItem` | `(schema,config,form) => React.ReactNode` | Custom edit mode, return a ReactNode, will automatically wrap value and onChange. If it returns false,null,undefined, the item will not be displayed |
+| `renderFormItem` | `(schema,config,form) => React.ReactNode` | Custom edit mode, return a ReactNode, will automatically wrap value and onChange. ~~If it returns false,null,undefined, the item will not be displayed~~ It is recommended to use dependent components to control whether to render or not |
 | `request` | `(params,props) => Promise<{label,value}[]>` | Request network data remotely, generally used to select class components |
 | `params` | `Record<string, any>` | The additional parameters passed to `request` will not be processed by the component, but changes will cause `request` to request data again |
 | `dependencies` | `string \| number \| (string \| number)[]` | After the dependent values changes, trigger renderFormItem, fieldProps, formItemProps to re-execute, and inject values into params [example](#use-dependencies-to-trigger-fieldprops-formitemprops-renderformitem-updates) |

--- a/packages/form/src/components/SchemaForm/index.md
+++ b/packages/form/src/components/SchemaForm/index.md
@@ -54,7 +54,7 @@ SchemaForm 表单最重要就是 Schema 的类型定义，我们使用了与 tab
 | `proFieldProps` | `proFieldProps` | 设置到 `ProField` 上面的 `props`，内部属性 |
 | `renderText` | `(text: any, record: Entity, index: number, action: ProCoreActionType) => any` | 修改的数据是会被 valueType 定义的渲染组件消费 |
 | `render` | `(dom,entity,index, action, schema) => React.ReactNode` | 自定义只读模式的 dom,`render` 方法只管理的只读模式，编辑模式需要使用 `renderFormItem` |
-| `renderFormItem` | `(schema,config,form) => React.ReactNode` | 自定义编辑模式,返回一个 ReactNode，会自动包裹 value 和 onChange。如返回 false,null,undefined 将不展示表单项 |
+| `renderFormItem` | `(schema,config,form) => React.ReactNode` | 自定义编辑模式,返回一个 ReactNode，会自动包裹 value 和 onChange。~~如返回 false,null,undefined 将不展示表单项~~ 请使用 dependency 组件控制是否渲染列 |
 | `request` | `(params,props) => Promise<{label,value}[]>` | 从远程请求网络数据，一般用于选择类组件 |
 | `params` | `Record<string, any>` | 额外传递给 `request` 的参数，组件不做处理,但是变化会引起`request` 重新请求数据 |
 | `dependencies` | `string \| number \| (string \| number)[]` | 所依赖的 values 变化后，触发 renderFormItem，fieldProps，formItemProps 重新执行，并把 values 注入到 params 里 [示例](#使用-dependencies-触发-fieldpropsformitempropsrenderformitem-更新) |


### PR DESCRIPTION
fix: #4867

我现在知道为什么要renderFormItem返回false，null，undefined时不渲染列了，实现的时候应该还没有valueType: dependency所以这种方式实现动态渲染列的，不过很明显不是一种好的方案，renderFormItem现在每次render都需要执行两次才能实现这个方案

现在先把示例和文档先改了，等之后SchemaForm正式版的时候应该把这个砍了，用dependency去控制重渲染，或者hideInForm接受一个函数返回一个formInstance控制是否渲染