### PR TITLE
fix(table): Incorrect value of sub-column when using EditableTable in Form

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -677,6 +677,8 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
       columnEmptyText,
       type,
       editableUtils,
+      rowKey,
+      childrenColumnName: props.expandable?.childrenColumnName,
     }).sort(columnSort(counter.columnsMap));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/packages/table/src/utils/cellRenderToFromItem.tsx
+++ b/packages/table/src/utils/cellRenderToFromItem.tsx
@@ -45,6 +45,7 @@ type CellRenderFromItemProps<T> = {
   prefixName?: string;
   counter: ReturnType<typeof useContainer>;
   proFieldProps: ProFormFieldProps;
+  subName: string[];
 };
 
 const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
@@ -54,7 +55,17 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
   const Component = useMemo(
     () =>
       memo<CellRenderFromItemProps<T>>(
-        ({ columnProps, prefixName, text, counter, rowData, index, recordKey, proFieldProps }) => {
+        ({
+          columnProps,
+          prefixName,
+          text,
+          counter,
+          rowData,
+          index,
+          recordKey,
+          subName,
+          proFieldProps,
+        }) => {
           const { editableForm } = counter;
           const key = recordKey || index;
           const [name, setName] = useState<React.Key[]>([]);
@@ -66,6 +77,7 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
           useEffect(() => {
             const value = spellNamePath(
               prefixName,
+              subName,
               prefixName ? index : key,
               columnProps?.key ?? columnProps?.dataIndex ?? index,
             );
@@ -224,7 +236,9 @@ function cellRenderToFromItem<T>(config: CellRenderFromItemProps<T>): React.Reac
 
   const columnKey = columnProps?.key || columnProps?.dataIndex?.toString();
 
-  /** 生成公用的 proField dom 配置 */
+  /**
+   * 生成公用的 proField dom 配置
+   */
   const proFieldProps: ProFormFieldProps = {
     valueEnum: runFunction<[T | undefined]>(columnProps?.valueEnum, rowData),
     request: columnProps?.request,

--- a/packages/table/src/utils/columnRender.tsx
+++ b/packages/table/src/utils/columnRender.tsx
@@ -27,6 +27,7 @@ type ColumnRenderInterface<T> = {
   type: ProSchemaComponentTypes;
   counter: ReturnType<typeof useContainer>;
   editableUtils: UseEditableUtilType;
+  subName: string[];
 };
 
 /**
@@ -99,6 +100,7 @@ export function columnRender<T>({
   columnEmptyText,
   counter,
   type,
+  subName,
   editableUtils,
 }: ColumnRenderInterface<T>): any {
   const { action, prefixName, editableForm } = counter;
@@ -114,6 +116,7 @@ export function columnRender<T>({
     valueType: (columnProps.valueType as ProFieldValueType) || 'text',
     index,
     rowData,
+    subName,
     columnProps: {
       ...columnProps,
       // 为了兼容性，原来写了个错别字

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { createRef, useRef } from 'react';
 import { Button, Input, InputNumber } from 'antd';
 import type { TableRowEditable, ProColumns, ActionType } from '@ant-design/pro-table';
 import { EditableProTable } from '@ant-design/pro-table';
@@ -817,6 +817,74 @@ describe('EditorProTable', () => {
 
     expect(formItemPropsFn).toBeCalled();
     expect(fieldPropsFn).toBeCalled();
+
+    expect(errorSpy).not.toBeCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  it('📝sub-column values are correct in the form', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const currentlyColumns: ProColumns<DataSourceType>[] = [
+      {
+        title: '标题',
+        dataIndex: 'title',
+      },
+    ];
+
+    const editableKeys: any[] = [];
+    let resultTitle = '';
+    const tableData = (function generateData(prefix = '', depth = 1): any {
+      const curData = [];
+      if (depth > 3) {
+        return;
+      }
+      let start = 1;
+      while (start++ <= 3) {
+        const title = `title${prefix}${depth}${start}`;
+        resultTitle += title;
+        const children = generateData(`${prefix}${start}`, depth + 1);
+        const id = `${prefix}${depth}${start}`;
+        editableKeys.push(id);
+        curData.push({
+          id,
+          title,
+          children,
+        });
+      }
+      return curData;
+    })();
+
+    const wrapper = mount(
+      <ProForm
+        initialValues={{
+          table: tableData,
+        }}
+      >
+        <EditableProTable<DataSourceType>
+          rowKey="id"
+          controlled
+          name="table"
+          expandable={{
+            defaultExpandAllRows: true,
+          }}
+          editable={{
+            editableKeys,
+          }}
+          columns={currentlyColumns}
+        />
+      </ProForm>,
+    );
+    await waitForComponentToPaint(wrapper, 100);
+
+    let answerTitle = '';
+
+    wrapper.find('input').forEach((item) => {
+      answerTitle += item.prop('value') as string;
+    });
+
+    expect(answerTitle).toMatch(resultTitle);
 
     expect(errorSpy).not.toBeCalled();
 

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useRef } from 'react';
+import React, { useRef } from 'react';
 import { Button, Input, InputNumber } from 'antd';
 import type { TableRowEditable, ProColumns, ActionType } from '@ant-design/pro-table';
 import { EditableProTable } from '@ant-design/pro-table';


### PR DESCRIPTION
fix: #4854

更好的解决方案应该需要在Antd Table执行render时提供是否为sub-column及传递namepath过来

现在的解决方案对每个子项做了一个遍历缓存子列此时的name path位置，不是很棒的解决方案