### PR TITLE
fix(ProTable): fix actionSaveRef logic when add new line

### DIFF
--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -683,7 +683,7 @@ function useEditableArray<RecordType>(
       const res = await props?.onSave?.(recordKey, editRow, originRow, newLine);
       // 保存时解除编辑模式
       cancelEditable(recordKey);
-      if (newLine && options?.recordKey === recordKey) {
+      if (newLine && !options?.parentKey && options?.recordKey === recordKey) {
         if (options?.position === 'top') {
           props.setDataSource([editRow, ...props.dataSource]);
         } else {
@@ -694,12 +694,19 @@ function useEditableArray<RecordType>(
       const actionProps = {
         data: props.dataSource,
         getRowKey: props.getRowKey,
-        row: editRow,
+        row: newLine
+          ? {
+              ...editRow,
+              map_row_parentKey: recordKeyToString(options?.parentKey ?? '')?.toString(),
+            }
+          : editRow,
         key: recordKey,
         childrenColumnName: props.childrenColumnName || 'children',
       };
 
-      props.setDataSource(editableRowByKey(actionProps, 'update'));
+      props.setDataSource(
+        editableRowByKey(actionProps, options?.position === 'top' ? 'top' : 'update'),
+      );
       return res;
     },
   );
@@ -749,7 +756,7 @@ function useEditableArray<RecordType>(
       cancelEditable,
       index: row.index,
       tableName: props.tableName,
-      newLineConfig: newLineRecordCache,
+      newLineConfig: newLineRecordRef.current,
       onCancel: actionCancelRef,
       onDelete: actionDeleteRef,
       onSave: actionSaveRef,

--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -679,11 +679,11 @@ function useEditableArray<RecordType>(
       },
       newLine?: NewLineConfig<RecordType>,
     ) => {
-      const { options } = newLine || {};
+      const { options } = newLine || newLineRecordRef.current || {};
       const res = await props?.onSave?.(recordKey, editRow, originRow, newLine);
       // 保存时解除编辑模式
       cancelEditable(recordKey);
-      if (newLine && !options?.parentKey && options?.recordKey === recordKey) {
+      if (!options?.parentKey && options?.recordKey === recordKey) {
         if (options?.position === 'top') {
           props.setDataSource([editRow, ...props.dataSource]);
         } else {
@@ -694,7 +694,7 @@ function useEditableArray<RecordType>(
       const actionProps = {
         data: props.dataSource,
         getRowKey: props.getRowKey,
-        row: newLine
+        row: options
           ? {
               ...editRow,
               map_row_parentKey: recordKeyToString(options?.parentKey ?? '')?.toString(),
@@ -756,7 +756,7 @@ function useEditableArray<RecordType>(
       cancelEditable,
       index: row.index,
       tableName: props.tableName,
-      newLineConfig: newLineRecordRef.current,
+      newLineConfig: newLineRecordCache,
       onCancel: actionCancelRef,
       onDelete: actionDeleteRef,
       onSave: actionSaveRef,

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -375,7 +375,7 @@ describe('EditorProTable', () => {
     expect(wrapper.find('.ant-table-tbody').find('tr.ant-table-row').length).toBe(6);
 
     act(() => {
-      wrapper.find('.ant-table-tbody tr.ant-table-row').at(1).find(`td a`).at(1).simulate('click');
+      wrapper.find('.ant-table-tbody tr.ant-table-row').at(1).find(`td a`).at(0).simulate('click');
     });
 
     await waitForComponentToPaint(wrapper, 1000);

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -369,6 +369,19 @@ describe('EditorProTable', () => {
         });
     });
 
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect.any(wrapper.find('.ant-table-tbody tr.ant-table-row').at(1).find('input').exists());
+    expect(wrapper.find('.ant-table-tbody').find('tr.ant-table-row').length).toBe(6);
+
+    act(() => {
+      wrapper.find('.ant-table-tbody tr.ant-table-row').at(1).find(`td a`).at(1).simulate('click');
+    });
+
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect(wrapper.find('.ant-table-row.ant-table-row-level-1').length).toBe(2);
+
     wrapper.unmount();
   });
 


### PR DESCRIPTION
修复：

- 新添加一行数据，newRecordType 为 `cache`（默认值）时，保存后新生成数据层级错误问题
- 修复 newRecordType 为 `cache`（默认值）时，editable 的 onSave 拿不到 newLineConfig 参数的问题