### PR TITLE
feat(table): customize columnSetting icon

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -27,6 +27,7 @@ type ColumnSettingProps<T = any> = {
   checkable?: boolean;
   extra?: React.ReactNode;
   checkedReset?: boolean;
+  children?: React.ReactNode;
 };
 
 const ToolTipIcon: React.FC<{
@@ -388,9 +389,11 @@ function ColumnSetting<T>(props: ColumnSettingProps<T>) {
         />
       }
     >
-      <Tooltip title={intl.getMessage('tableToolBar.columnSetting', '列设置')}>
-        <SettingOutlined />
-      </Tooltip>
+      {props.children || (
+        <Tooltip title={intl.getMessage('tableToolBar.columnSetting', '列设置')}>
+          <SettingOutlined />
+        </Tooltip>
+      )}
     </Popover>
   );
 }

--- a/packages/table/src/components/ToolBar/index.tsx
+++ b/packages/table/src/components/ToolBar/index.tsx
@@ -32,6 +32,7 @@ export type OptionConfig = {
         checkable?: boolean;
         checkedReset?: boolean;
         extra?: React.ReactNode;
+        children?: React.ReactNode;
       };
   search?: (OptionSearchProps & { name?: string }) | boolean;
 };

--- a/packages/table/src/demos/columns-setting-custom-icon.tsx
+++ b/packages/table/src/demos/columns-setting-custom-icon.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import type { ProColumns } from '@ant-design/pro-table';
+import ProTable from '@ant-design/pro-table';
+
+const HeartSvg = () => (
+  <svg width="1em" height="1em" fill="currentColor" viewBox="0 0 1024 1024">
+    <path d="M923 283.6c-13.4-31.1-32.6-58.9-56.9-82.8-24.3-23.8-52.5-42.4-84-55.5-32.5-13.5-66.9-20.3-102.4-20.3-49.3 0-97.4 13.5-139.2 39-10 6.1-19.5 12.8-28.5 20.1-9-7.3-18.5-14-28.5-20.1-41.8-25.5-89.9-39-139.2-39-35.5 0-69.9 6.8-102.4 20.3-31.4 13-59.7 31.7-84 55.5-24.4 23.9-43.5 51.7-56.9 82.8-13.9 32.3-21 66.6-21 101.9 0 33.3 6.8 68 20.3 103.3 11.3 29.5 27.5 60.1 48.2 91 32.8 48.9 77.9 99.9 133.9 151.6 92.8 85.7 184.7 144.9 188.6 147.3l23.7 15.2c10.5 6.7 24 6.7 34.5 0l23.7-15.2c3.9-2.5 95.7-61.6 188.6-147.3 56-51.7 101.1-102.7 133.9-151.6 20.7-30.9 37-61.5 48.2-91 13.5-35.3 20.3-70 20.3-103.3 0.1-35.3-7-69.6-20.9-101.9z" />
+  </svg>
+);
+
+export type TableListItem = {
+  id: number;
+  name: string;
+  lastName: string;
+};
+const tableListDataSource: TableListItem[] = [];
+
+for (let i = 0; i < 2; i += 1) {
+  tableListDataSource.push({
+    id: i,
+    name: `John ${i}`,
+    lastName: `Doe ${i}`,
+  });
+}
+
+const columns: ProColumns<TableListItem>[] = [
+  {
+    title: 'User First Name',
+    dataIndex: 'name',
+  },
+  {
+    title: 'User Last Name',
+    dataIndex: 'surname',
+  },
+  {
+    title: 'ID',
+    dataIndex: 'id',
+  },
+];
+
+export default () => {
+  return (
+    <ProTable<TableListItem>
+      columns={columns}
+      request={() => Promise.resolve(tableListDataSource)}
+      options={{
+        search: true,
+        setting: {
+          children: <HeartSvg />,
+        },
+      }}
+      rowKey="id"
+      search={false}
+    />
+  );
+};

--- a/tests/table/columnSetting.test.tsx
+++ b/tests/table/columnSetting.test.tsx
@@ -790,4 +790,56 @@ describe('Table ColumnSetting', () => {
 
     expect(html.find('.ant-tree-treenode').length).toBe(2);
   });
+
+  it('🎏 columnSetting support replacement for default setting icon', async () => {
+    const html = mount(
+      <ProTable
+        size="small"
+        options={{
+          setting: {
+            children: <button className="custom-setting-button">Click Me!</button>,
+          },
+        }}
+        columns={[
+          {
+            title: 'Name',
+            key: 'name',
+            dataIndex: 'name',
+            copyable: true,
+            hideInSetting: true,
+          },
+          {
+            title: 'Name2',
+            key: 'name2',
+            dataIndex: 'name2',
+            copyable: true,
+          },
+          {
+            title: 'Name3',
+            key: 'name3',
+            dataIndex: 'name3',
+            hideInTable: true,
+          },
+        ]}
+        dataSource={[
+          {
+            key: 1,
+            name: `TradeCode ${1}`,
+            createdAt: 1602572994055,
+          },
+        ]}
+        rowKey="key"
+      />,
+    );
+
+    await waitForComponentToPaint(html, 200);
+    act(() => {
+      const element = html.find('.ant-pro-table-list-toolbar-setting-item .custom-setting-button');
+      element.simulate('click');
+    });
+
+    await waitForComponentToPaint(html, 1000);
+
+    expect(html.find('.ant-tree-treenode').length).toBe(2);
+  });
 });


### PR DESCRIPTION
The idea behind this PR is be able to to control "icon" of column setting - and not only the tooltip massage. 

In am planning to check settings section to make it more flexible and eg. to allow user change order of table settings displayed 