### PR TITLE
🐛 fix(form): fix 表单在colSize!==1下展示异常

### DIFF
--- a/packages/form/src/layouts/QueryFilter/index.tsx
+++ b/packages/form/src/layouts/QueryFilter/index.tsx
@@ -214,22 +214,35 @@ const QueryFilterContent: React.FC<{
   // totalSpan 统计控件占的位置，计算 offset 保证查询按钮在最后一列
   let totalSpan = 0;
   let itemLength = 0;
+  //首个表单项是否占满第一行
+  let firstRowFull = false;
+  // totalSize 统计控件占的份数
+  let totalSize = 0;
 
   // for split compute
   let currentSpan = 0;
   const doms = flatMapItems(items, props.ignoreRules)
     .map((item, index): { itemDom: React.ReactNode; hidden: boolean; colSpan: number } => {
       // 如果 formItem 自己配置了 hidden，默认使用它自己的
-      const colSize = React.isValidElement<any>(item) ? item?.props?.colSize : 1;
+      const colSize = React.isValidElement<any>(item) ? item?.props?.colSize ?? 1 : 1;
       const colSpan = Math.min(spanSize.span * (colSize || 1), 24);
       // 计算总的 totalSpan 长度
       totalSpan += colSpan;
+      // 计算总的 colSize 长度
+      totalSize += colSize;
+
+      if (index === 0) {
+        firstRowFull =
+          colSpan === 24 && !(item as ReactElement<{ hidden: boolean }>)?.props?.hidden;
+      }
+
       const hidden: boolean =
         (item as ReactElement<{ hidden: boolean }>)?.props?.hidden ||
         // 如果收起了
         (collapsed &&
-          // 如果 超过显示长度 且 总长度超过了 24
-          index >= showLength - 1 &&
+          (firstRowFull ||
+            // 如果 超过显示长度 且 总长度超过了 24
+            totalSize >= showLength - 1) &&
           !!index &&
           totalSpan >= 24);
 
@@ -298,7 +311,7 @@ const QueryFilterContent: React.FC<{
 
   /** 是否需要展示 collapseRender */
   const needCollapseRender = useMemo(() => {
-    if (totalSpan < 24 || itemLength < showLength) {
+    if (totalSpan < 24 || totalSize < showLength) {
       return false;
     }
     return true;

--- a/packages/layout/src/components/SettingDrawer/index.tsx
+++ b/packages/layout/src/components/SettingDrawer/index.tsx
@@ -10,7 +10,11 @@ import { useUrlSearchParams } from '@umijs/use-params';
 
 import { Button, Divider, Drawer, List, Switch, ConfigProvider, message, Alert } from 'antd';
 import React, { useState, useEffect, useRef } from 'react';
-import { disable as darkreaderDisable, enable as darkreaderEnable } from '@umijs/ssr-darkreader';
+import {
+  disable as darkreaderDisable,
+  enable as darkreaderEnable,
+  setFetchMethod as setFetch,
+} from '@umijs/ssr-darkreader';
 
 import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import omit from 'omit.js';
@@ -118,7 +122,10 @@ const updateTheme = async (dark: boolean, color?: string) => {
       ignoreImageAnalysis: [],
       disableStyleSheetsProxy: true,
     };
-    if (window.MutationObserver) darkreaderEnable(defaultTheme, defaultFixes);
+    if (window.MutationObserver && window.fetch) {
+      setFetch(window.fetch);
+      darkreaderEnable(defaultTheme, defaultFixes);
+    }
   } else {
     if (window.MutationObserver) darkreaderDisable();
   }

--- a/tests/form/queryFilter.test.tsx
+++ b/tests/form/queryFilter.test.tsx
@@ -228,6 +228,34 @@ describe('QueryFilter', () => {
     expect(wrapper.find('a.ant-pro-form-collapse-button').text()).toBe('close');
   });
 
+  it('🕵️‍♀️ colSize不全都是1，collapseRender应该存在', async () => {
+    const wrapper = mount(
+      <QueryFilter defaultColsNumber={4} defaultCollapsed={false}>
+        <ProFormText name="name" label="应用名称" rules={[{ required: true }]} colSize={4} />
+        <ProFormText name="creater" label="创建人" colSize={3} />
+      </QueryFilter>,
+    );
+
+    expect(wrapper.find('a.ant-pro-form-collapse-button').length).toEqual(1);
+  });
+
+  it('🕵️‍♀️ 表单首项独占一行，收起时应该只展示一项就行了', async () => {
+    const wrapper = mount(
+      <QueryFilter defaultCollapsed defaultColsNumber={4}>
+        <ProFormText name="name" label="应用名称" rules={[{ required: true }]} colSize={4} />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+        <ProFormText name="creater" label="创建人" />
+      </QueryFilter>,
+    );
+
+    expect(wrapper.find('.ant-row.ant-form-item-hidden').length).toEqual(7);
+  });
+
   it('🕵️‍♀️ QueryFilter support ProForm.Group', async () => {
     const wrapper = mount(
       <QueryFilter collapsed={true} layout="vertical">


### PR DESCRIPTION
此为缺少收起按钮
![Snipaste_2022-03-31_16-12-51](https://user-images.githubusercontent.com/53564781/161030660-5a65261a-5811-47df-a73c-201b351310d4.png)
此为没收起完整
![Snipaste_2022-03-31_11-28-51](https://user-images.githubusercontent.com/53564781/161030730-c11791ee-10d4-4733-ac4c-6a67148be229.png)

具体是判断表单首项是否占满整行，以及用每个表单项的colSize来判断是否超出区域

fix:#2642