### PR TITLE
fix(table): useEditableArray fix child record traversal

### DIFF
--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -453,7 +453,7 @@ function useEditableArray<RecordType>(
         map.set(index.toString(), recordKeyToString(props.getRowKey(record, -1)));
         map.set(recordKeyToString(props.getRowKey(record, -1))?.toString(), index.toString());
         if (props.childrenColumnName && record[props.childrenColumnName]) {
-          loopGetKey([record[props.childrenColumnName]]);
+          loopGetKey(record[props.childrenColumnName]);
         }
       });
     };

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -282,6 +282,69 @@ describe('EditorProTable', () => {
     wrapper.unmount();
   });
 
+  it('📝 EditableProTable add support nested children column', async () => {
+    const onchange = jest.fn();
+    const wrapper = render(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        pagination={{
+          pageSize: 2,
+          current: 2,
+        }}
+        editable={{}}
+        expandable={{
+          childrenColumnName: 'children',
+        }}
+        onChange={(data) => {
+          onchange(data[0].children![0]!.children!.length);
+        }}
+        recordCreatorProps={{
+          position: 'top',
+          newRecordType: 'dataSource',
+          parentKey: () => 6246747901,
+          record: {
+            id: 555,
+          },
+          id: 'addEditRecord',
+        }}
+        columns={columns}
+        value={[
+          {
+            id: 624674790,
+            title: '🧐 [问题] build 后还存在 es6 的代码（Umi@2.13.13）',
+            labels: [{ name: 'question', color: 'success' }],
+            state: 'open',
+            time: {
+              created_at: '2020-05-26T07:54:25Z',
+            },
+            children: [
+              {
+                id: 6246747901,
+                title: '嵌套数据的编辑',
+                labels: [{ name: 'question', color: 'success' }],
+                state: 'closed',
+                time: {
+                  created_at: '2020-05-26T07:54:25Z',
+                },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+
+    await act(async () => {
+      (await wrapper.queryAllByText('添加一行数据')).at(0)?.click();
+    });
+
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect(onchange).toBeCalledWith(1);
+
+    wrapper.unmount();
+  });
+
   it("📝 EditableProTable can't find record by parentKey", async () => {
     const onchange = jest.fn();
     const wrapper = render(


### PR DESCRIPTION
### Problem:
I had issues creating nested child rows in `EditableProTable` using `RecordCreator`. My experience was similar to #3342, #3914, #3881, and #4246.

Specifically, I saw a console error message thrown by [addEditRecord](https://github.com/ant-design/pro-components/blob/b076d289bee24bc0812831c51a7c7d2f3951b7b5/packages/utils/src/useEditableArray/index.tsx#L633).
```
can't find record by key xxxxx
```

### Solution:

After some investigation, it occurs to me that `dataSourceKeyIndexMapRef` does not contain keys from nested child rows. This PR fixes the issue and allows me to add nested child rows in `EditableProTable`.


<img width="955" alt="Screen Shot 2022-05-17 at 11 46 02 PM" src="https://user-images.githubusercontent.com/4694896/168975057-8779f74e-59d1-42ba-b0bf-f2e121d54d5c.png">
