### PR TITLE
fix(form): validateFieldsReturnFormatValue 可能为undefined

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -302,7 +302,8 @@ function BaseFormComponents<T = Record<string, any>>(props: BaseFormProps<T>) {
       validateFieldsReturnFormatValue: async (nameList?: NamePath[]) => {
         if (!Array.isArray(nameList) && nameList) throw new Error('nameList must be array');
         const values = await formRef.current?.validateFields(nameList);
-        return transformKey(values, omitNil);
+        const transformedKey = transformKey(values, omitNil) 
+        return transformedKey ? transformedKey : {};
       },
       formRef,
     }),


### PR DESCRIPTION
validateFieldsReturnFormatValue 应该总是返回对象

<img width="1033" alt="image" src="https://user-images.githubusercontent.com/36926073/171359093-334698b0-3dc9-4796-8f8f-3a8c4342496c.png">

```
Unhandled Rejection (TypeError): Cannot read properties of undefined (reading 'start_date')
_callee$
.bi-v3/src/pages/currency/get/index.tsx:117:22
  114 |   title: '获取总数',
  115 |   dataIndex: 'total_num',
  116 | },
> 117 | ...dates(params.start_date, params.end_date).map((date) => ({
      |                ^  118 |   title: date,
  119 |   dataIndex: date,
  120 | })),
View compiled
```

```
  const onFinish = async () => {
    actionRef.current?.reset?.()

    const params = await formRef.current?.validateFieldsReturnFormatValue?.()

    setColumns([
      {
        title: '获取途径',
        dataIndex: 'key',
      },
      {
        title: '获取总数',
        dataIndex: 'total_num',
      },
      ...dates(params.start_date, params.end_date).map((date) => ({
        title: date,
        dataIndex: date,
      })),
    ])
    run(params)
  }
```



