### PR TITLE
 feat(form): add ProCapthcha component ref

### DIFF
--- a/packages/form/src/components/Captcha/index.tsx
+++ b/packages/form/src/components/Captcha/index.tsx
@@ -1,7 +1,7 @@
 ﻿import { Button, Input, Form } from 'antd';
 import type { ButtonProps } from 'antd/lib/button';
 import type { InputProps } from 'antd/lib/input';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useImperativeHandle } from 'react';
 import createField from '../../BaseForm/createField';
 import type { ProFormItemProps } from '../../interface';
 
@@ -81,6 +81,10 @@ const ProFormCaptcha: React.FC<ProFormCaptchaProps> = React.forwardRef((props, r
     }
     return () => clearInterval(interval);
   }, [timing]);
+
+  useImperativeHandle(ref, () => ({
+    setTiming: setTiming,
+  }));
 
   return (
     <Form.Item noStyle shouldUpdate>


### PR DESCRIPTION
`ProFormCaptcha` 组件中暴露ref功能，外部可直接开启计数功能，

使用场景：可以便于 点击后分布验证才可发送获取验证码等一系列 分步操作。