### PR TITLE
feat(form): add syncToUrlAsImportant prop

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -82,6 +82,12 @@ export type CommonFormProps<T = Record<string, any>, U = Record<string, any>> = 
    * @name 同步结果到 url 中
    * */
   syncToUrl?: boolean | ((values: T, type: 'get' | 'set') => T);
+
+  /**
+   * @name 当 syncToUrl 为 true，在页面回显示时，以url上的参数为主，默认为false
+   */
+  syncToUrlAsImportant?: boolean;
+
   /**
    * @name 额外的 url 参数 中
    * */
@@ -208,6 +214,7 @@ function BaseFormComponents<T = Record<string, any>>(props: BaseFormProps<T>) {
     formComponentType,
     extraUrlParams = {},
     syncToUrl,
+    syncToUrlAsImportant = false,
     syncToInitialValues = true,
     onReset,
     omitNil = true,
@@ -497,10 +504,11 @@ function BaseFormComponents<T = Record<string, any>>(props: BaseFormProps<T>) {
               form={inlineForm}
               {...rest}
               // 组合 urlSearch 和 initialValues
-              initialValues={{
-                ...urlParamsMergeInitialValues,
-                ...rest.initialValues,
-              }}
+              initialValues={
+                syncToUrlAsImportant
+                  ? { ...rest.initialValues, ...urlParamsMergeInitialValues }
+                  : { ...urlParamsMergeInitialValues, ...rest.initialValues }
+              }
               onValuesChange={(changedValues, values) => {
                 rest?.onValuesChange?.(
                   transformKey(changedValues, omitNil),

--- a/tests/form/base.test.tsx
+++ b/tests/form/base.test.tsx
@@ -71,6 +71,40 @@ describe('ProForm', () => {
     expect(fn).toHaveBeenCalledWith('realDark');
   });
 
+  it('📦 ProForm support sync form url as important', async () => {
+    const fn = jest.fn();
+    const wrapper = mount<{ navTheme: string }>(
+      <ProForm
+        onFinish={async (values) => {
+          fn(values.navTheme);
+        }}
+        syncToUrl
+        syncToUrlAsImportant
+      >
+        <ProFormText
+          tooltip={{
+            title: '主题',
+            icon: <FontSizeOutlined />,
+          }}
+          name="navTheme"
+        />
+      </ProForm>,
+    );
+    await waitForComponentToPaint(wrapper);
+
+    act(() => {
+      wrapper.find('button.ant-btn-primary').simulate('click');
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(fn).toHaveBeenCalledWith('realDark');
+
+    act(() => {
+      wrapper.find('button.ant-btn').at(1).simulate('click');
+    });
+    await waitForComponentToPaint(wrapper);
+    expect(fn).toHaveBeenCalledWith('realDark');
+  });
+
   it('📦 ProForm support sync form url and rest', async () => {
     const onFinish = jest.fn();
     const wrapper = mount<{ navTheme: string }>(


### PR DESCRIPTION
目前设置 syncToUrl 为true时, 在页面回显时,不会使用url上的参数来拉去页面数据, 不满足分享url的需求, 加入一个prop, 用于满足该场景