### PR TITLE
fix(table): default close revalidateOnFocus

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -399,6 +399,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     manualRequest,
     polling,
     tooltip,
+    revalidateOnFocus = false,
     ...rest
   } = props;
 
@@ -491,7 +492,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     onLoadingChange,
     onRequestError,
     postData,
-    revalidateOnFocus: props.revalidateOnFocus ?? false,
+    revalidateOnFocus,
     manual: formSearch === undefined,
     polling,
     effects: [stringify(params), stringify(formSearch), stringify(proFilter), stringify(proSort)],
@@ -513,7 +514,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     if (
       props.manualRequest ||
       !props.request ||
-      props.revalidateOnFocus === false ||
+      !revalidateOnFocus ||
       props.form?.ignoreRules
     )
       return;

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -290,7 +290,7 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 | editable | Related configuration of editable table | [TableRowEditable<T>](/components/editable-table#editable-Editable row configuration) | - |
 | cardBordered | Border of Card components around Table and Search | `boolean \| {search?: boolean, table?: boolean}` | false |
 | debounceTime | Debounce time | `number` | 10 |
-| revalidateOnFocus | Automatically re-request when the window is focused | `boolean` | `true` |
+| revalidateOnFocus | Automatically re-request when the window is focused | `boolean` | `false` |
 | columnsState | Column Status Control, you can operate the display hide | `ColumnsStateType` | - |
 
 #### RecordCreator

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -341,7 +341,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 | editable | 可编辑表格的相关配置 | [TableRowEditable<T>](/components/editable-table#editable-编辑行配置) | - |
 | cardBordered | Table 和 Search 外围 Card 组件的边框 | `boolean \| {search?: boolean, table?: boolean}` | false |
 | debounceTime | 防抖时间 | `number` | 10 |
-| revalidateOnFocus | 窗口聚焦时自动重新请求 | `boolean` | `true` |
+| revalidateOnFocus | 窗口聚焦时自动重新请求 | `boolean` | `false` |
 | columnsState | 受控的列状态，可以操作显示隐藏 | `columnsStateType` | - |
 | ErrorBoundary | 自带了错误处理功能，防止白屏，`ErrorBoundary=false` 关闭默认错误边界 | `ReactNode` | 内置 ErrorBoundary |
 


### PR DESCRIPTION
revalidateOnFocus 这个属性在 @ant-design/pro-table@2.75.0 的默认值根本没有被置为 false。今天升级了版本直接被拉去祭天了