### PR TITLE
fix(provide): Translation of the `items` (PT-Br)

### DIFF
--- a/packages/provider/src/locale/pt_BR.tsx
+++ b/packages/provider/src/locale/pt_BR.tsx
@@ -26,7 +26,7 @@ export default {
     total: {
       range: ' ',
       total: 'de',
-      item: 'items',
+      item: 'itens',
     },
   },
   tableToolBar: {


### PR DESCRIPTION
fix the translation of the word `items` to `itens`, in Portuguese BR, it is only allowed to use the letter `m` before the consonants `p` and `b`.