### PR TITLE
docs: 修复文档内ts代码被误执行，导致页面白屏

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -286,7 +286,7 @@ const valueEnum = {
 };
 ```
 
-```tsx
+```tsx | pure
 import { ProFormSelect } from '@ant-design/pro-components';
 
 const valueEnum = {
@@ -363,7 +363,7 @@ const columns = [
 ];
 ```
 
-```tsx
+```tsx | pure
 import { ProFormSelect } from '@ant-design/pro-components';
 
 const options = [
@@ -432,7 +432,7 @@ const columns = [
 ];
 ```
 
-```tsx
+```tsx | pure
 import { ProForm, ProFormSelect, ProFormText } from '@ant-design/pro-components';
 
 const request = async (params) => {

--- a/packages/form/src/form.md
+++ b/packages/form/src/form.md
@@ -335,30 +335,85 @@ ProFormInstance 与 antd 的 form 相比增加了一些能力。
 <code src="./demos/formRef.tsx" height="548px" title="formRef的使用" />
 
 ```tsx | pure
-const App = () => {
-  // 绑定一个 ProFormInstance 实例
-  const formRef = useRef<
-    ProFormInstance<{
-      date: string;
-    }>
-  >();
+import type { ProFormInstance } from '@ant-design/pro-components';
+import { ProForm, ProFormDatePicker, ProFormText } from '@ant-design/pro-components';
+import { Button, message } from 'antd';
+import moment from 'moment';
+import { useRef } from 'react';
+
+const waitTime = (time: number = 100) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(true);
+    }, time);
+  });
+};
+
+export default () => {
+  const formRef = useRef<ProFormInstance>();
+  const onFill = () => {
+    formRef?.current?.setFieldsValue({
+      name: '张三',
+      company: '蚂蚁金服',
+    });
+  };
+
+  const getCompanyName = () => {
+    message.info(`公司名称为 "${formRef?.current?.getFieldValue('company')}"`);
+  };
+
+  const getFormatValues = () => {
+    console.log('格式化后的所有数据：', formRef.current?.getFieldsFormatValue?.());
+  };
+
+  const validateAndGetFormatValue = () => {
+    formRef.current?.validateFieldsReturnFormatValue?.().then((values) => {
+      console.log('校验表单并返回格式化后的所有数据：', values);
+    });
+  };
 
   return (
     <ProForm
-      onValuesChange={async () => {
-        formRef.current?.validateFieldsReturnFormatValue?.().then((val) => {
-          // 以下为格式化之后的表单值
-          console.log(val.date);
-        });
-      }}
-      // 通过formRef进行绑定
+      title="新建表单"
       formRef={formRef}
+      submitter={{
+        render: (props, doms) => {
+          return [
+            ...doms,
+            <Button htmlType="button" onClick={onFill} key="edit">
+              一键填写
+            </Button>,
+            <Button htmlType="button" onClick={getCompanyName} key="read">
+              读取公司
+            </Button>,
+            <Button.Group key="refs" style={{ display: 'block' }}>
+              <Button htmlType="button" onClick={getFormatValues} key="format">
+                获取格式化后的所有数据
+              </Button>
+              <Button htmlType="button" onClick={validateAndGetFormatValue} key="format">
+                校验表单并返回格式化后的所有数据
+              </Button>
+            </Button.Group>,
+          ];
+        },
+      }}
+      onFinish={async (values) => {
+        await waitTime(2000);
+        console.log(values);
+        message.success('提交成功');
+        return true;
+      }}
     >
-      <ProFormDatePicker
-        name="date"
-        initialValue={moment('2021-08-09')}
-        fieldProps={{ open: true }}
+      <ProFormText
+        width="md"
+        name="name"
+        label="签约客户名称"
+        tooltip="最长为 24 位"
+        placeholder="请输入名称"
       />
+
+      <ProFormText width="md" name="company" label="我方公司名称" placeholder="请输入名称" />
+      <ProFormDatePicker name="date" initialValue={moment('2021-08-09')} />
     </ProForm>
   );
 };


### PR DESCRIPTION
当进入架构设计  => 通用配置总览 => 滚动到远程数据及以下时 代码片段会被执行，而丢失了import React from 'react', 会找不到react.createElement, 报错： `react_devtools_backend.js:4026 TypeError: Cannot read properties of undefined (reading 'createElement')
`