### PR TITLE
fix(table): method coverRowKey 关于 at 兼容性问题修复

### DIFF
--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -181,7 +181,7 @@ function EditableTable<
      */
     if (typeof finlayRowKey === 'number' && !props.name) {
       if (finlayRowKey >= value.length) return finlayRowKey;
-      const rowData = value?.at(finlayRowKey);
+      const rowData = value && value[finlayRowKey];
       return getRowKey?.(rowData!, finlayRowKey);
     }
 


### PR DESCRIPTION
在 360 浏览器不支持 at 语法， 导致调用 setRowData 方法报错