### PR TITLE
fix(table): useEditableArray fix nested children can not be add when position is not top and expandable.childrenColumnName isundefined

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -626,7 +626,7 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
     ...props.editable,
     tableName: props.name,
     getRowKey,
-    childrenColumnName: props.expandable?.childrenColumnName,
+    childrenColumnName: props.expandable?.childrenColumnName || 'children',
     dataSource: action.dataSource || [],
     setDataSource: (data) => {
       props.editable?.onValuesChange?.(undefined as any, data);

--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -456,16 +456,16 @@ function useEditableArray<RecordType>(
   useDeepCompareEffectDebounce(() => {
     const map = new Map<React.Key, React.Key>();
     //存在children时会覆盖Map的key,导致使用数组索引查找key错误
-    const loopGetKey = (dataSource: RecordType[], parentIndex?: number) => {
+    const loopGetKey = (dataSource: RecordType[], parentKey?: string) => {
       dataSource?.forEach((record, index) => {
         const key =
-          parentIndex === undefined
+          parentKey === undefined || parentKey === null
             ? index.toString()
-            : parentIndex.toString() + '_' + index.toString();
+            : parentKey + '_' + index.toString();
         map.set(key, recordKeyToString(props.getRowKey(record, -1)));
         map.set(recordKeyToString(props.getRowKey(record, -1))?.toString(), key);
         if (props.childrenColumnName && record[props.childrenColumnName]) {
-          loopGetKey(record[props.childrenColumnName], index);
+          loopGetKey(record[props.childrenColumnName], key);
         }
       });
     };

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -787,11 +787,68 @@ describe('EditorProTable', () => {
       );
     });
 
-    waitForComponentToPaint(wrapper, 100);
+    await waitForComponentToPaint(wrapper, 100);
     expect(
       wrapper.container.querySelectorAll<HTMLInputElement>(
         '.ant-table-cell .ant-row.ant-form-item .ant-form-item-control-input input',
       )[1].value,
     ).toBe('🐛 [BUG]无法创建工程npm create umi');
+  });
+
+  it('📝 EditableProTable support nested children column without config "childrenColumnName:children" and "position:top"', async () => {
+    const fn = jest.fn();
+    const wrapper = render(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        pagination={{
+          pageSize: 2,
+          current: 2,
+        }}
+        editable={{
+          onChange: (keys) => fn(keys[0]),
+        }}
+        recordCreatorProps={{
+          parentKey: () => 6246747901,
+          record: {
+            id: 555,
+          },
+          id: 'addEditRecord',
+        }}
+        columns={columns}
+        value={[
+          {
+            id: 624674790,
+            title: '🧐 [问题] build 后还存在 es6 的代码（Umi@2.13.13）',
+            labels: [{ name: 'question', color: 'success' }],
+            state: 'open',
+            time: {
+              created_at: '2020-05-26T07:54:25Z',
+            },
+            children: [
+              {
+                id: 6246747901,
+                title: '嵌套数据的编辑',
+                labels: [{ name: 'question', color: 'success' }],
+                state: 'closed',
+                time: {
+                  created_at: '2020-05-26T07:54:25Z',
+                },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+
+    await act(async () => {
+      (await wrapper.queryAllByText('添加一行数据')).at(0)?.click();
+    });
+
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect(fn).toBeCalledWith(555);
+
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
When creating nested child rows in EditableProTable, if not set position to top and not set expandable:{childrenColumnName:'children'} in cache record type, the nested children (at least in level 2) can not be add correctly

related issues:clsoe #5566