### PR TITLE
fix(form): destroyOnClose does not work as expected 

### DIFF
--- a/packages/form/src/layouts/DrawerForm/index.tsx
+++ b/packages/form/src/layouts/DrawerForm/index.tsx
@@ -207,7 +207,7 @@ function DrawerForm<T = Record<string, any>>({
               const result = await onFinishHandle(values);
               const form = rest.formRef?.current ?? formRef.current;
               // 返回真值，重置表单
-              if (result && form) {
+              if (result && form && drawerProps?.destroyOnClose) {
                 form.resetFields();
               }
               return result;

--- a/packages/form/src/layouts/ModalForm/index.tsx
+++ b/packages/form/src/layouts/ModalForm/index.tsx
@@ -210,7 +210,7 @@ function ModalForm<T = Record<string, any>>({
             const result = await onFinishHandle(values);
             const form = rest.formRef?.current ?? formRef.current;
             // 返回真值，重置表单
-            if (result && form) {
+            if (result && form && modalProps?.destroyOnClose) {
               form.resetFields();
             }
             return result;


### PR DESCRIPTION
fix #5516

曾经 #3739 特意考虑了这个问题，默认是不重置表单，不知道出于什么考虑又取消了，先帮忙看一看这样改对不对，谢谢！