### PR TITLE
fix(layout): 水印导致页面发起404请求

### DIFF
--- a/packages/layout/src/components/WaterMark/index.tsx
+++ b/packages/layout/src/components/WaterMark/index.tsx
@@ -181,7 +181,9 @@ const WaterMark: React.FC<WaterMarkProps> = (props) => {
           backgroundSize: `${gapX + width}px`,
           pointerEvents: 'none',
           backgroundRepeat: 'repeat',
-          backgroundImage: `url('${base64Url}')`,
+          ...(base64Url ? {
+            backgroundImage: `url('${base64Url}')`,
+          } : null),
           ...markStyle,
         }}
       />

--- a/tests/layout/__snapshots__/demo.test.ts.snap
+++ b/tests/layout/__snapshots__/demo.test.ts.snap
@@ -3909,7 +3909,7 @@ exports[`layout demos 📸 renders ./packages/layout/src/components/WaterMark/de
     </div>
     <div
       class="ant-pro-layout-watermark"
-      style="z-index: 9; position: absolute; left: 0px; top: 0px; width: 100%; height: 100%; background-size: 327px; pointer-events: none; background-repeat: repeat; background-image: url();"
+      style="z-index: 9; position: absolute; left: 0px; top: 0px; width: 100%; height: 100%; background-size: 327px; pointer-events: none; background-repeat: repeat;"
     />
   </div>
 </DocumentFragment>

--- a/tests/layout/__snapshots__/waterMark.test.tsx.snap
+++ b/tests/layout/__snapshots__/waterMark.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`WaterMark test image watermark 1`] = `
       className="ant-pro-layout-watermark"
       style={
         Object {
-          "backgroundImage": "url('')",
           "backgroundRepeat": "repeat",
           "backgroundSize": "332px",
           "height": "100%",


### PR DESCRIPTION
第一次生命周期内，base64Url为空字符串，水印组件引用了空图片，实际上发起了一个location.href的多余请求