### PR TITLE
fix: 修复 pro-form submitter 类型定义与文档不一致问题

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -57,7 +57,7 @@ export type CommonFormProps<T = Record<string, any>, U = Record<string, any>> = 
     | SubmitterProps<{
         form?: FormInstance<any>;
       }>
-    | false;
+    | boolean;
 
   /**
    * @name 表单结束后调用


### PR DESCRIPTION
问题：pro-form submitter 类型定义与文档不一致问题
文档中定义可以为 boolean 类型，但实际传入 true 却会导致 TS 类型报错
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/19701675/185021645-56011615-5bef-4499-82d0-3b2c2d06bf73.png">

这在某些情况下是需要传入 true 的，比如通过其他条件判断是否需要展示提交按钮
![image](https://user-images.githubusercontent.com/19701675/185021947-36232655-b0a7-4656-9fac-8e72122bd24c.png)
