### PR TITLE
fix(table): editable table 增加children时没有按照position方向增加

### DIFF
--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -212,15 +212,22 @@ export function editableRowByKey<RecordType>(
   ) => {
     const kvArrayMap = new Map<string, RecordType[]>();
     const kvSource: RecordType[] = [];
-    map.forEach((value) => {
-      if (value.map_row_parentKey && !value.map_row_key) {
-        const { map_row_parentKey, ...rest } = value;
-        kvArrayMap.set(map_row_parentKey, [
-          ...(kvArrayMap.get(map_row_parentKey) || []),
-          rest as unknown as RecordType,
-        ]);
-      }
-    });
+    const fillNewRecord = () => {
+      map.forEach((value) => {
+        if (value.map_row_parentKey && !value.map_row_key) {
+          const { map_row_parentKey, ...rest } = value;
+          kvArrayMap.set(map_row_parentKey, [
+            ...(kvArrayMap.get(map_row_parentKey) || []),
+            rest as unknown as RecordType,
+          ]);
+        }
+      });
+    };
+
+    if (action === 'top') {
+      fillNewRecord();
+    }
+
     map.forEach((value) => {
       if (value.map_row_parentKey && value.map_row_key) {
         const { map_row_parentKey, map_row_key, ...rest } = value;
@@ -233,6 +240,11 @@ export function editableRowByKey<RecordType>(
         ]);
       }
     });
+
+    if (action === 'update') {
+      fillNewRecord();
+    }
+
     map.forEach((value) => {
       if (!value.map_row_parentKey) {
         const { map_row_key, ...rest } = value;

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -851,4 +851,137 @@ describe('EditorProTable', () => {
 
     wrapper.unmount();
   });
+
+  it('📝 EditableProTable add new child line when position = top', async () => {
+    const fn = jest.fn();
+    const wrapper = render(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        pagination={{
+          pageSize: 2,
+          current: 2,
+        }}
+        editable={{
+          onChange: (keys) => fn(keys[0]),
+        }}
+        recordCreatorProps={{
+          parentKey: () => 624674790,
+          position: 'top',
+          record: {
+            id: 555,
+          },
+          id: 'addEditRecord',
+        }}
+        columns={columns}
+        expandable={{
+          defaultExpandAllRows: true,
+        }}
+        value={[
+          {
+            id: 624674790,
+            title: '🧐 [问题] build 后还存在 es6 的代码（Umi@2.13.13）',
+            labels: [{ name: 'question', color: 'success' }],
+            state: 'open',
+            time: {
+              created_at: '2020-05-26T07:54:25Z',
+            },
+            children: [
+              {
+                id: 6246747901,
+                title: '嵌套数据的编辑',
+                labels: [{ name: 'question', color: 'success' }],
+                state: 'closed',
+                time: {
+                  created_at: '2020-05-26T07:54:25Z',
+                },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+
+    await act(async () => {
+      (await wrapper.queryAllByText('添加一行数据')).at(0)?.click();
+    });
+
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect(fn).toBeCalledWith(555);
+
+    const { dataset } = wrapper.container.querySelectorAll(
+      '.ant-table-tbody tr.ant-table-row',
+    )[1] as HTMLElement;
+
+    expect(dataset.rowKey).toBe('555');
+
+    wrapper.unmount();
+  });
+
+  it('📝 EditableProTable add new child line when position <> top', async () => {
+    const fn = jest.fn();
+    const wrapper = render(
+      <EditableProTable<DataSourceType>
+        rowKey="id"
+        pagination={{
+          pageSize: 2,
+          current: 2,
+        }}
+        editable={{
+          onChange: (keys) => fn(keys[0]),
+        }}
+        recordCreatorProps={{
+          parentKey: () => 624674790,
+          record: {
+            id: 555,
+          },
+          id: 'addEditRecord',
+        }}
+        columns={columns}
+        expandable={{
+          defaultExpandAllRows: true,
+        }}
+        value={[
+          {
+            id: 624674790,
+            title: '🧐 [问题] build 后还存在 es6 的代码（Umi@2.13.13）',
+            labels: [{ name: 'question', color: 'success' }],
+            state: 'open',
+            time: {
+              created_at: '2020-05-26T07:54:25Z',
+            },
+            children: [
+              {
+                id: 6246747901,
+                title: '嵌套数据的编辑',
+                labels: [{ name: 'question', color: 'success' }],
+                state: 'closed',
+                time: {
+                  created_at: '2020-05-26T07:54:25Z',
+                },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+    await waitForComponentToPaint(wrapper, 1000);
+
+    await act(async () => {
+      (await wrapper.queryAllByText('添加一行数据')).at(0)?.click();
+    });
+
+    await waitForComponentToPaint(wrapper, 1000);
+
+    expect(fn).toBeCalledWith(555);
+
+    const { dataset } = wrapper.container.querySelectorAll(
+      '.ant-table-tbody tr.ant-table-row',
+    )[2] as HTMLElement;
+
+    expect(dataset.rowKey).toBe('555');
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
问题: 之前的PR #5643 修复了多层嵌套结构(存在2级及以上)情况下在不做额外配置情况下无法正确添加子节点,目前可以正常添加但是非根节点下添加子节点只会增加到同级的顶端, 也就是无论是否配置top都是top方向