### PR TITLE
fix(table): 解决 EditableTable 与 ProForm 配合使用时初始化数据也会触发 onValuesChange 的问题

### DIFF
--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -431,7 +431,8 @@ function EditableTable<
               return !isDeepEqualReact(item, preData?.[index]);
             });
             if (!changeItem) return null;
-            props?.editable?.onValuesChange?.(changeItem, list);
+            // 如果不存在 preData 说明是初始化，此时不需要触发 onValuesChange
+            if (preData) props?.editable?.onValuesChange?.(changeItem, list);
             return null;
           }}
         </ProFormDependency>

--- a/tests/table/editor-table.test.tsx
+++ b/tests/table/editor-table.test.tsx
@@ -984,4 +984,57 @@ describe('EditorProTable', () => {
 
     wrapper.unmount();
   });
+
+  it('📝 EditableProTable onValuesChange will not trigger when init', async () => {
+    const valuesChangeFn = jest.fn();
+    const wrapper = render(
+      <ProForm<{
+        table: DataSourceType[];
+      }>
+        initialValues={{
+          table: defaultData,
+        }}
+        validateTrigger="onBlur"
+      >
+        <EditableProTable<DataSourceType>
+          rowKey="id"
+          scroll={{
+            x: 960,
+          }}
+          headerTitle="可编辑表格"
+          maxLength={5}
+          name="table"
+          columns={columns}
+          editable={{
+            type: 'multiple',
+            onValuesChange: (values) => {
+              valuesChangeFn(values.title);
+            },
+          }}
+        />
+      </ProForm>,
+    );
+
+    await waitForComponentToPaint(wrapper, 300);
+    expect(valuesChangeFn).toBeCalledTimes(0);
+
+    await act(async () => {
+      (await wrapper.queryAllByText('编辑')).at(0)?.click();
+    });
+    await waitForComponentToPaint(wrapper, 500);
+    act(() => {
+      fireEvent.change(
+        wrapper.container
+          .querySelectorAll('.ant-table-tbody tr.ant-table-row')[0]
+          .querySelectorAll(`td .ant-input`)[0],
+        {
+          target: {
+            value: 'test',
+          },
+        },
+      );
+    });
+    expect(valuesChangeFn).toBeCalledTimes(1);
+    expect(valuesChangeFn).toBeCalledWith('test');
+  });
 });


### PR DESCRIPTION
fix: #5749 