### PR TITLE
fix(layout): header add `colorHeaderTitle` token

### DIFF
--- a/packages/layout/src/components/GlobalHeader/style.ts
+++ b/packages/layout/src/components/GlobalHeader/style.ts
@@ -6,6 +6,7 @@ import { ProLayoutContext } from '../../context/ProLayoutContext';
 export interface GlobalHeaderToken extends ProAliasToken {
   componentCls: string;
   heightLayoutHeader: number;
+  colorHeaderTitle: string;
 }
 
 const genGlobalHeaderStyle: GenerateStyle<GlobalHeaderToken> = (token) => {
@@ -27,7 +28,7 @@ const genGlobalHeaderStyle: GenerateStyle<GlobalHeaderToken> = (token) => {
       },
       '&-collapsed-button': {
         minHeight: '22px',
-        color: token.colorTextHeading,
+        color: token.colorHeaderTitle,
         fontSize: '22px',
         marginInlineStart: '16px',
       },
@@ -73,6 +74,7 @@ export function useStyle(prefixCls: string) {
       ...token,
       componentCls: `.${prefixCls}`,
       heightLayoutHeader: header.heightLayoutHeader,
+      colorHeaderTitle: header.colorHeaderTitle,
     };
 
     return [genGlobalHeaderStyle(GlobalHeaderToken)];

--- a/packages/layout/src/layout.en-US.md
+++ b/packages/layout/src/layout.en-US.md
@@ -454,6 +454,7 @@ Sider Token is the color value of the side menu, unlike the top menu.
 
 | token | Description | The default value is |
 | --- | --- | --- |
+| colorBgHeader | The background color of header is | `rgba(240, 242, 245, 0.4)` |
 | colorHeaderTitle | The title font color of the sider is | `colorTextHeading` |
 | colorTextMenu | MenuItem's font color | `colorText` |
 | colorTextMenuSecondary | Secondary font colors for menus, such as footers and icons for actions | `colorText` |

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -500,6 +500,7 @@ Sider Token 是 侧边菜单的色值，与顶部菜单不同。
 
 | token | 说明 | 默认值 |
 | --- | --- | --- |
+| colorBgHeader | header 的背景颜色 | `rgba(240, 242, 245, 0.4)` |
 | colorHeaderTitle | sider 的标题字体颜色 | `colorTextHeading` |
 | colorTextMenu | menuItem 的字体颜色 | `colorText` |
 | colorTextMenuSecondary | menu 的二级字体颜色，比如 footer 和 action 的 icon | `colorText` |


### PR DESCRIPTION
主要是为了改小屏幕下的展开收起菜单按钮的颜色

<img width="128" alt="image" src="https://user-images.githubusercontent.com/69514654/189098837-71012a7c-4838-49ad-8290-4161c8962435.png">


不好意思，之前 https://github.com/ant-design/pro-components/pull/5889 姿势不对。直接用 `colorHeaderTitle`。




另外这个字段 `colorMenuBackground` 是不是应该改为 `colorBgMenu` 更合适。