### PR TITLE
fix(card): fixed col width precision lose

### DIFF
--- a/packages/card/src/components/Card/style.ts
+++ b/packages/card/src/components/Card/style.ts
@@ -287,7 +287,7 @@ const genColStyle = (index: number, token: ProCardToken) => {
   return {
     [`${componentCls}-col-${index}`]: {
       flexShrink: 0,
-      width: `${Math.round((index / GRID_COLUMNS) * 100)}%`,
+      width: `${(index / GRID_COLUMNS) * 100}%`,
     },
   };
 };


### PR DESCRIPTION
解决计算时候col宽度精度丢失问题，导致的展示对不齐的问题