### PR TITLE
fix(list): 修复类型问题：未将RecordType的泛型传入meta中

### DIFF
--- a/packages/list/src/index.tsx
+++ b/packages/list/src/index.tsx
@@ -1,17 +1,19 @@
 import type { ProCardProps } from '@ant-design/pro-card';
 import type { ActionType, ProColumnType, ProTableProps } from '@ant-design/pro-table';
-import ProTable from '@ant-design/pro-table';
-import type { ListProps, PaginationProps } from 'antd';
+import 'antd/es/list/style';
+
 import { ConfigProvider } from 'antd';
-import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
 import classNames from 'classnames';
 import React, { useContext, useImperativeHandle, useMemo, useRef } from 'react';
-import type { ItemProps } from './Item';
+
+import ProTable from '@ant-design/pro-table';
+
 import ListView from './ListView';
 import { useStyle } from './style/index';
 
-import 'antd/es/list/style';
-
+import type { ListProps, PaginationProps } from 'antd';
+import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
+import type { ItemProps } from './Item';
 export type AntdListProps<RecordType> = Omit<ListProps<RecordType>, 'rowKey'>;
 
 export type ProListMeta<T> = Pick<
@@ -50,7 +52,7 @@ export type BaseProListMetas<T = any> = {
   content?: ProListMeta<T>;
   actions?: ProListMetaAction<T>;
 };
-export type ProListMetas<T = any> = BaseProListMetas & {
+export type ProListMetas<T = any> = BaseProListMetas<T> & {
   [key in keyof T]?: IsAny<T> extends true ? ProListMetaAction<T> : ProListMeta<T>;
 };
 

--- a/packages/list/src/index.tsx
+++ b/packages/list/src/index.tsx
@@ -1,19 +1,17 @@
 import type { ProCardProps } from '@ant-design/pro-card';
 import type { ActionType, ProColumnType, ProTableProps } from '@ant-design/pro-table';
-import 'antd/es/list/style';
-
+import ProTable from '@ant-design/pro-table';
+import type { ListProps, PaginationProps } from 'antd';
 import { ConfigProvider } from 'antd';
+import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
 import classNames from 'classnames';
 import React, { useContext, useImperativeHandle, useMemo, useRef } from 'react';
-
-import ProTable from '@ant-design/pro-table';
-
+import type { ItemProps } from './Item';
 import ListView from './ListView';
 import { useStyle } from './style/index';
 
-import type { ListProps, PaginationProps } from 'antd';
-import type { LabelTooltipType } from 'antd/es/form/FormItemLabel';
-import type { ItemProps } from './Item';
+import 'antd/es/list/style';
+
 export type AntdListProps<RecordType> = Omit<ListProps<RecordType>, 'rowKey'>;
 
 export type ProListMeta<T> = Pick<


### PR DESCRIPTION
现在的问题是
![image](https://user-images.githubusercontent.com/20397245/191399478-e5bddd2b-42a4-4deb-abc1-e580dc831726.png)
原因是这里没有传入泛型
![image](https://user-images.githubusercontent.com/20397245/191399577-2bfa3630-5cc3-463b-a978-849ea641574e.png)
修复之后
![image](https://user-images.githubusercontent.com/20397245/191399641-75b89803-3beb-462c-b68a-ce46ed6ef151.png)
