### PR TITLE
doc: 修复SettingDrawerProps文档api错误

### DIFF
--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -239,8 +239,8 @@ menu 中支持了部分常用的 menu 配置， 可以帮助我们更好的管�
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| collapsed | 控制 SettingDrawer 的收起和展开 | `boolean` | - |
-| onCollapse | SettingDrawer 的折叠收起事件 | `(collapsed: boolean) => void` | - |
+| collapse | 控制 SettingDrawer 的收起和展开 | `boolean` | - |
+| onCollapseChange | SettingDrawer 的折叠收起事件 | `(collapsed: boolean) => void` | - |
 | settings | layout 的设置 | [`Settings`](#Settings) \| [`Settings`](#Settings) | - |
 | onSettingChange | [`Settings`](#Settings) 发生更改事件 | `(settings: [`Settings`](#Settings) ) => void` | - |
 | hideHintAlert | 删除下方的提示信息 | `boolean` | - |


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/25569373/194794583-50b02565-ed30-4bb0-a230-c38e2ae028a6.png)

为啥不用dumi的自动生成api功能呢,不然每次api改动还要重新调整文档