### PR TITLE
fix(segmented): remove invalid property `allowClear`

### DIFF
--- a/packages/field/src/components/Segmented/index.tsx
+++ b/packages/field/src/components/Segmented/index.tsx
@@ -45,7 +45,7 @@ const FieldSegmented: ProFieldFC<
     return dom;
   }
   if (mode === 'edit' || mode === 'update') {
-    const dom = <Segmented ref={inputRef} allowClear {...fieldProps} options={options} />;
+    const dom = <Segmented ref={inputRef} {...fieldProps} options={options} />;
 
     if (renderFormItem) {
       return renderFormItem(rest.text, { mode, ...fieldProps, options }, dom);


### PR DESCRIPTION
Segmented上没有这个属性呀：https://ant.design/components/segmented-cn/#API

<img width="1381" alt="image" src="https://user-images.githubusercontent.com/16148054/195000155-38d8b4f9-251c-4354-bde6-c4fa276d813d.png">
