### PR TITLE
doc: Correct the remove method parameters in document

### DIFF
--- a/packages/form/src/components/Group/index.en-US.md
+++ b/packages/form/src/components/Group/index.en-US.md
@@ -202,7 +202,7 @@ return (
    * @name custom action button
    *
    * @example delete button
-   * actionRender:(field,action)=><a onClick={()=>action.remove(field.key)}>remove</a>
+   * actionRender:(field,action)=><a onClick={()=>action.remove(field.name)}>remove</a>
    * @example can only add up to three new lines
    * actionRender:(f,action,_,count)=><a onClick={()=>
    * count>2?alert("Up to three lines!"):action.add({id:"xx"})}>delete

--- a/packages/form/src/components/Group/index.md
+++ b/packages/form/src/components/Group/index.md
@@ -191,7 +191,7 @@ return (
    * @name 自定义操作按钮
    *
    * @example 删除按钮
-   * actionRender:(field,action)=><a onClick={()=>action.remove(field.key)}>删除</a>
+   * actionRender:(field,action)=><a onClick={()=>action.remove(field.name)}>删除</a>
    * @example 最多只能新增三行
    * actionRender:(f,action,_,count)=><a onClick={()=>
    *   count>2?alert("最多三行！"):action.add({id:"xx"})}>删除

--- a/packages/form/src/components/List/ListItem.tsx
+++ b/packages/form/src/components/List/ListItem.tsx
@@ -148,7 +148,7 @@ export type ProFromListCommonProps = {
    * @name 自定义操作按钮
    *
    * @example 删除按钮
-   * actionRender:(field,action)=><a onClick={()=>action.remove(field.key)}>删除</a>
+   * actionRender:(field,action)=><a onClick={()=>action.remove(field.name)}>删除</a>
    * @example 最多只能新增三行
    * actionRender:(f,action,_,count)=><a onClick={()=>
    *   count>2?alert("最多三行！"):action.add({id:"xx"})}>删除


### PR DESCRIPTION
### 🐛 bug 描述
`action.remove` 方法参数应与源码中一致为 `field.name`。
按照当前文档参数为 `field.key`，删除操作后，再次添加，删除条目不正确
源码如下
![image](https://user-images.githubusercontent.com/19289091/195059148-f933ec61-f74c-442f-8048-863fe89d0017.png)

### 📷 复现步骤
1. 创建若干条item，并填写值
2. 点击第二条“delete by key”
3. 新增一条
4. 点击最后一条“delete by key”，删除失败。删除其他条目，删除条目不正确。
5. 点击“delete by name”，删除正确

https://codesandbox.io/s/proform-list-forked-z8osfh?file=/App.tsx

### 🏞 期望结果
文档中将该示例改为 `action.remove(field.name)`