### PR TITLE
feat(table): add new api actionRef.saveEditable

### DIFF
--- a/packages/utils/src/useEditableMap/index.tsx
+++ b/packages/utils/src/useEditableMap/index.tsx
@@ -171,15 +171,15 @@ export function useEditableMap<RecordType>(
         ...config,
       };
 
-      const defaultDoms = defaultActionRender(props.dataSource, renderConfig);
+      const renderResult = defaultActionRender(props.dataSource, renderConfig);
       if (props.actionRender) {
         return props.actionRender(props.dataSource, renderConfig, {
-          save: defaultDoms[0],
-          delete: defaultDoms[1],
-          cancel: defaultDoms[2],
+          save: renderResult.save,
+          delete: renderResult.delete,
+          cancel: renderResult.cancel,
         });
       }
-      return defaultDoms;
+      return [renderResult.save, renderResult.delete, renderResult.cancel];
     },
     [editableKeys && editableKeys.join(','), props.dataSource],
   );


### PR DESCRIPTION
### [EditableTable]
`editable`对象`actionRender`方法的`defaultDoms`参数对每个action按钮都扩展了一个ref对象，可以让调用者以编程的方式直接触发对应的action。
相较于新的api，调用者只能调用config对象的`onSave/onDelete/onCancel`方法，但需要传递很多参数(尤其是onSave)，需要了解很多内部知识，自己需要用form来获取整个编辑行的数据，门槛太高。而新的方法，内部获取所有信息，无需传参。
### 应用场景：
如果页面上存在多个tab，或者编辑表格会动态显示/隐藏，如果编辑行没有保存就被隐藏了，那最后保存表单时这一行就会丢失掉。借助新方法，调用者可以在隐藏表格之前自动保存编辑行，避免数据丢失的问题。
* bad(图)
![without-auto-saving](https://user-images.githubusercontent.com/3147149/196044681-5c2b7393-8bea-4198-86c7-4e4dc65f9a9d.gif)
* good(图)
![auto-saving](https://user-images.githubusercontent.com/3147149/196044751-d06e4d4f-2683-451b-be27-6877e1e3fb84.gif)

