### PR TITLE
fix(form): ProFormDigit value will fixed when not set precision

### DIFF
--- a/packages/field/src/components/Digit/index.tsx
+++ b/packages/field/src/components/Digit/index.tsx
@@ -30,7 +30,9 @@ const FieldDigit: ProFieldFC<FieldDigitProps> = (
         val = Number(val);
       }
       if (typeof val === 'number') {
-        val = val?.toFixed?.(fieldProps.precision ?? 0);
+        if (fieldProps.precision) {
+          val = val?.toFixed?.(fieldProps.precision ?? 0);
+        }
         val = Number(val);
       }
       return fieldProps?.onChange?.(val);


### PR DESCRIPTION
修复 ProFormDigit 失失焦后自动规整的问题