### PR TITLE
feat(SettingDrawer): 支持 colorList 传 title 属性作为 tooltip

### DIFF
--- a/packages/layout/src/components/SettingDrawer/ThemeColor.tsx
+++ b/packages/layout/src/components/SettingDrawer/ThemeColor.tsx
@@ -19,6 +19,7 @@ export type ThemeColorProps = {
   colorList?: {
     key: string;
     color: string;
+    title?: string;
   }[];
   prefixCls: string;
   value: string;
@@ -41,14 +42,17 @@ const ThemeColor: React.ForwardRefRenderFunction<HTMLDivElement, ThemeColorProps
   const baseClassName = `${prefixCls}-theme-color`;
   return (
     <div className={`${baseClassName} ${hashId}`}>
-      {colorList?.map(({ key, color }) => {
+      {colorList?.map(({ key, color, title }) => {
         if (!key) return null;
         return (
           <Tooltip
             key={color}
-            title={formatMessage({
-              id: `app.setting.themecolor.${key}`,
-            })}
+            title={
+              title ??
+              formatMessage({
+                id: `app.setting.themecolor.${key}`,
+              })
+            }
           >
             <Tag
               className={`${baseClassName}-block ${hashId}`}

--- a/packages/layout/src/components/SettingDrawer/index.tsx
+++ b/packages/layout/src/components/SettingDrawer/index.tsx
@@ -74,7 +74,7 @@ export type SettingDrawerProps = {
   /** 使用实验性质的黑色主题 */
   enableDarkTheme?: boolean;
   prefixCls?: string;
-  colorList?: false | { key: string; color: string }[];
+  colorList?: false | { key: string; color: string; title?: string }[];
   onSettingChange?: (settings: MergerSettingsType<ProSettings>) => void;
   pathname?: string;
   disableUrlParams?: boolean;


### PR DESCRIPTION
现象：当前SettingDrawer内的ThemeColor组件在遍历colorList时查找的是/packages/layout/src/locales/zh-CN文件里的key作为tooltip的值，如果自定义colorList则tooltip会不显示
[https://github.com/ant-design/ant-design-pro/issues/10126](url)

改进的方案：如果colorList的item传入title则会作为tooltip的value显示
```js
import React, {useEffect} from 'react';
import ProLayout, { SettingDrawer } from '@ant-design/pro-layout';
const Pro = () => {
  const [opts, setOpts] = useState({});
  const colorList = [
    {key: 'ifss-default', color: '#4684ff', title: '自定义提示'},
    {key: 'ifss-daybreak', color: '#1890ff'},
    {key: 'ifss-dust', color: '#F5222D'},
    {key: 'ifss-volcano', color: '#FA541C'},
    {key: 'ifss-sunset', color: '#FAAD14'},
    {key: 'ifss-cyan', color: '#13C2C2'},
    {key: 'ifss-green', color: '#52C41A'},
    {key: 'ifss-geekblue', color: '#2F54EB'},
    {key: 'ifss-purple', color: '#722ED1'}
  ];
  return (
   <ProLayout .......>
       <SettingDrawer enableDarkTheme colorList={colorList} settings={opts} onSettingChange={setOpts} themeOnly />
   <ProLayout/>
  );
};

export default Pro;
```