### PR TITLE
fix(table): 修复 DragSortTable 的 dataSource 值变更后未正常渲染

### DIFF
--- a/packages/table/src/components/DragSortTable/index.tsx
+++ b/packages/table/src/components/DragSortTable/index.tsx
@@ -33,12 +33,13 @@ function DragSortTable<
     onDragSortEnd,
     onDataSourceChange,
     columns: propsColumns,
+    defaultData,
     dataSource: oriDs,
     onLoad,
     ...otherProps
   } = props;
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
-  const [mergedDs, setMergedDs] = useMergedState(oriDs);
+  const [mergedDs, setMergedDs] = useMergedState(defaultData);
 
   // 默认拖拽把手
   const DragHandle = useMemo(
@@ -118,7 +119,7 @@ function DragSortTable<
         {...(otherProps as ProTableProps<T, U, ValueType>)}
         onLoad={wrapOnload}
         rowKey={rowKey}
-        dataSource={mergedDs}
+        dataSource={oriDs ?? mergedDs}
         components={components}
         columns={columns}
         onDataSourceChange={onDataSourceChange}
@@ -129,7 +130,7 @@ function DragSortTable<
         {...(otherProps as ProTableProps<T, U, ValueType>)}
         onLoad={wrapOnload}
         rowKey={rowKey}
-        dataSource={mergedDs}
+        dataSource={oriDs ?? mergedDs}
         columns={columns}
         onDataSourceChange={onDataSourceChange}
       />


### PR DESCRIPTION
修复 DragSortTable 支持 request 时引入的 bug。

bug 描述：
useMergedState 缓存了 props.dataSource 第一次传入的值，后续 dataSource 值再次改变时 mergedDs 仍然是首次缓存的值，导致新的 dataSource 未能正确渲染。

期望：
当传入 dataSource（dataSouce 不是 null / undefined 时） 时优先使用 dataSource 进行数据渲染。