### PR TITLE
fix(form): 修复SearchSelect组件在设置了showSearch和 多选模式下，当搜索并选中后，搜索的文字没有清空的问题

### DIFF
--- a/packages/field/src/components/Select/SearchSelect/index.tsx
+++ b/packages/field/src/components/Select/SearchSelect/index.tsx
@@ -89,7 +89,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     onSearch,
     onFocus,
     onChange,
-    autoClearSearchValue,
+    autoClearSearchValue = true,
     searchOnFocus = false,
     resetAfterSelect = false,
     fetchDataOnSearch = true,


### PR DESCRIPTION
修复SearchSelect组件在设置了showSearch和 多选模式下，当搜索并选中后，搜索的文字没有清空的问题

close  #6258 