### PR TITLE
fix(table): 修复table使用后端分页时（频繁变化dataSource场景）多选功能 selectedRow 缓存丢失

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -522,13 +522,11 @@ const ProTable = <T extends Record<string, any>, U extends ParamsType, ValueType
 
   useMemo(() => {
     if (action.dataSource?.length) {
-      const newCache = new Map<any, T>();
       const keys = action.dataSource.map((data) => {
         const dataRowKey = getRowKey(data, -1);
-        newCache.set(dataRowKey, data);
+        preserveRecordsRef.current.set(dataRowKey, data);
         return dataRowKey;
       });
-      preserveRecordsRef.current = newCache;
       return keys;
     }
     return [];


### PR DESCRIPTION
问题导致 preserveSelectedRowKeys 开启后无法正常在 tableAlertOptionRender 和
toolBarRender 中获取到 selectedRows ,而 selectedRowKeys 可以正常获取