### PR TITLE
fix(card): 修复 statistic 元素中 hashId 在 trend 属性下不生效的问题

### DIFF
--- a/packages/card/src/components/Statistic/index.tsx
+++ b/packages/card/src/components/Statistic/index.tsx
@@ -59,8 +59,7 @@ const Statistic: React.FC<StatisticProps> = (props) => {
   const wrapperClass = classNames(`${prefixCls}-wrapper`, hashId);
   const contentClass = classNames(`${prefixCls}-content`, hashId);
 
-  const statisticClassName = classNames({
-    hashId,
+  const statisticClassName = classNames(hashId, {
     [`${prefixCls}-layout-${layout}`]: layout,
     [`${prefixCls}-trend-${trend}`]: trend,
   });


### PR DESCRIPTION
修复 statistic 元素中 hashId 在 trend 属性下不生效的问题，导致对应的 css 样式失效
详情见此问题：https://github.com/ant-design/pro-components/issues/6186#issuecomment-1333802449