### PR TITLE
fix(layout): 修复PageContainer设置为fixedHeader，内容滚动的时候Title抖动问题

### DIFF
--- a/packages/layout/src/components/PageContainer/index.tsx
+++ b/packages/layout/src/components/PageContainer/index.tsx
@@ -393,7 +393,7 @@ const PageContainerBase: React.FC<PageContainerProps> = (props) => {
             // 在 hasHeader 且 fixedHeader 的情况下，才需要设置高度
             <Affix
               offsetTop={
-                value.hasHeader && value.fixedHeader ? token?.layout?.header?.heightLayoutHeader : 0
+                value.hasHeader && value.fixedHeader ? token?.layout?.header?.heightLayoutHeader : 1
               }
               {...affixProps}
               className={`${basePageContainer}-affix ${hashId}`}


### PR DESCRIPTION
Signed-off-by: 周立华 <zhoulihua.rd@gmail.com>
fix(PageContainer): 修复PageContainer设置为fixedHeader，内容滚动的时候Title抖动问题
bugID：#6329