### PR TITLE
fix(field): 修复 ProFormSelect 在LightFilter 中自定义过滤无效

### DIFF
--- a/packages/field/src/components/Select/LightSelect/index.tsx
+++ b/packages/field/src/components/Select/LightSelect/index.tsx
@@ -189,14 +189,14 @@ const LightSelect: React.ForwardRefRenderFunction<any, SelectProps<any> & LightS
         }}
         prefixCls={customizePrefixCls}
         options={
-          keyword
-            ? options?.filter((o) => {
+          onSearch || !keyword
+            ? options
+            : options?.filter((o) => {
                 return (
                   String(o[labelPropsName])?.toLowerCase()?.includes(keyword) ||
                   o[valuePropsName]?.toString()?.toLowerCase()?.includes(keyword)
                 );
               })
-            : options
         }
       />
       <FieldLabel


### PR DESCRIPTION
修复 ProFormSelect 在LightFilter 中自定义过滤无效.

close #6309