### PR TITLE
fix(privider): antd根据prefixcls生成样式错误

### DIFF
--- a/packages/provider/src/index.tsx
+++ b/packages/provider/src/index.tsx
@@ -424,7 +424,7 @@ const ConfigProVoidContainer: React.FC<{
     );
 
     return (
-      <div className={`${getPrefixCls?.('pro') || 'ant-pro'}${hashId ? ' ' + hashId : ''}`}>
+      <div className={`${getPrefixCls('pro') || 'ant-pro'}${hashId ? ' ' + hashId : ''}`}>
         {provide}
       </div>
     );


### PR DESCRIPTION
getPrefixCls是一个方法，?.('pro')会固定返回undefined，导致无法正确使用prefixcls