### PR TITLE
docs(docs): 修改ProDescriptions文档参数错误

### DIFF
--- a/packages/descriptions/src/descriptions.en-US.md
+++ b/packages/descriptions/src/descriptions.en-US.md
@@ -97,8 +97,6 @@ API is the same as ProTable
 | --- | --- | --- | --- |
 | title | The title of the description list, displayed at the top | `ReactNode` | - |
 | tooltip | Supplementary description of the content, displayed after hover | `string` | - |
-| ellipsis | Whether to abbreviate automatically | `boolean` | - |
-| copyable | Whether to support copying | `boolean` | - |
 | loading | Display a loaded skeleton screen, the skeleton screen and dom will not correspond one-to-one | `boolean` | - |
 | extra | Describe the operation area of ​​the list, displayed on the upper right | `string` \| `ReactNode` | - |
 | bordered | Whether to display the border | boolean | false |
@@ -133,6 +131,8 @@ API is the same as ProTable
 | --- | --- | --- | --- |
 | label | Description of content | ReactNode | - |
 | tooltip | Supplementary description of the content, displayed after hover | string | - |
+| ellipsis | Whether to abbreviate automatically | `boolean` | - |
+| copyable | Whether to support copying | `boolean` | - |
 | span | number of columns included | number | 1 |
 | valueType | Formatted type | `ValueType` | - |
 | valueEnum | Enumeration of current column values ​​[valueEnum](/components/table#valueenum) | `Record` | - |

--- a/packages/descriptions/src/descriptions.md
+++ b/packages/descriptions/src/descriptions.md
@@ -101,8 +101,6 @@ API 与 ProTable 相同
 | --- | --- | --- | --- |
 | title | 描述列表的标题，显示在最顶部 | `ReactNode` | - |
 | tooltip | 内容的补充描述，hover 后显示 | `string` | - |
-| ellipsis | 是否自动缩略 | `boolean` | - |
-| copyable | 是否支持复制 | `boolean` | - |
 | loading | 展示一个加载的骨架屏，骨架屏和 dom 不会一一对应 | `boolean` | - |
 | extra | 描述列表的操作区域，显示在右上方 | `string` \| `ReactNode` | - |
 | bordered | 是否展示边框 | boolean | false |
@@ -140,6 +138,8 @@ API 与 ProTable 相同
 | --- | --- | --- | --- |
 | label | 内容的描述 | ReactNode | - |
 | tooltip | 内容的补充描述，hover 后显示 | string | - |
+| ellipsis | 是否自动缩略 | `boolean` | - |
+| copyable | 是否支持复制 | `boolean` | - |
 | span | 包含列的数量 | number | 1 |
 | valueType | 格式化的类型 | `ValueType` | - |
 | valueEnum | 当前列值的枚举 [valueEnum](/components/table#valueenum) | `Record` | - |


### PR DESCRIPTION
docs(docs): 修改ProDescriptions文档中ellipsis和copyable参数的错误位置，这两个参数应当为ProDescriptions.Item的参数，但被放在了ProDescriptions参数列表中；
