### PR TITLE
fix(table): slove nested table background color was cover by card

### DIFF
--- a/packages/table/src/style/index.ts
+++ b/packages/table/src/style/index.ts
@@ -41,6 +41,9 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
       [`${token.antCls}-table${token.antCls}-table-middle ${token.componentCls}`]: {
         marginBlock: 0,
         marginInline: -8,
+        [`${token.proComponentsCls}-card`]: {
+          backgroundColor: 'initial',
+        },
       },
 
       '& &-search': {


### PR DESCRIPTION
修复子表格背景色被卡片背景色覆盖的问题。
修改前
![image](https://user-images.githubusercontent.com/52664827/208870892-71bf6bc7-9033-4618-a5e3-7f0530eeb5e9.png)


修改后
![image](https://user-images.githubusercontent.com/52664827/208870315-889b4c07-3b8b-462f-bc67-e47690151e66.png)
