### PR TITLE
轻量筛选替换查询表单，将 padding 调为 8px 更为统一美观

### DIFF
--- a/packages/utils/src/components/FilterDropdown/style.ts
+++ b/packages/utils/src/components/FilterDropdown/style.ts
@@ -16,7 +16,7 @@ const genProStyle: GenerateStyle<ProToken> = (token) => {
         boxSizing: 'border-box',
       },
     },
-    [`${token.componentCls}-content`]: { paddingBlock: 16, paddingInline: 16 },
+    [`${token.componentCls}-content`]: { paddingBlock: 8, paddingInline: 8 },
   };
 };
 


### PR DESCRIPTION
https://github.com/ant-design/pro-components/issues/6421