### PR TITLE
fix: code replaces a single label with a double label

### DIFF
--- a/docs/components.en-US.md
+++ b/docs/components.en-US.md
@@ -23,7 +23,7 @@ ProComponents was developed to reduce the cost of implementing CRUD in the middl
 
 The main feature of ProForm is that it has a lot of pre-defined layouts, so if you need to switch you just need to change the Layout of the outer wrapper, here is a demo.
 
-<code src="../packages/form/src/demos/layout-change.tsx">
+<code src="../packages/form/src/demos/layout-change.tsx"></code>
 
 ## Configuring Use with the Web Request Library
 

--- a/docs/playground/curd.playground.md
+++ b/docs/playground/curd.playground.md
@@ -13,4 +13,4 @@ ProTable，ProDescriptions，ProForm 都是基于 ProField 来进行封装。Pro
 
 使用同样的底层实现为 ProTable，ProDescriptions，ProForm 打通带来了便利。ProForm 可以很方便的实现只读模式，ProTable 可以快速实现查询表单和可编辑表格。ProDescriptions 可以实现节点编辑，以下有个例子可以切换三个组件。
 
-<code src="../../packages/table/src/demos/crud.tsx"   height="500px" iframe="650px" >
+<code src="../../packages/table/src/demos/crud.tsx" height="500px" iframe="650px"></code>

--- a/docs/playground/pro-descriptions.playground.md
+++ b/docs/playground/pro-descriptions.playground.md
@@ -9,4 +9,4 @@ group:
 
 # ProDescriptions Playground
 
-<code src="../../packages/descriptions/src/demos/dynamic-descriptions.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"/>
+<code src="../../packages/descriptions/src/demos/dynamic-descriptions.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"></code>

--- a/docs/playground/pro-form.playground.md
+++ b/docs/playground/pro-form.playground.md
@@ -13,8 +13,8 @@ group:
 
 ProForm 的主要功能是预设了很多 layout，如果需要切换只需要改变外面包裹的 Layout 即可，以下是个 demo。
 
-<code src="../../packages/form/src/demos/layout-change.tsx" height="709px"/>
+<code src="../../packages/form/src/demos/layout-change.tsx" height="709px"></code>
 
 ## FormList
 
-<code src="../../packages/form/src/components/Group/demos/customize.tsx" title="ProForm.List" height="1002px"/>
+<code src="../../packages/form/src/components/Group/demos/customize.tsx" title="ProForm.List" height="1002px"></code>

--- a/docs/playground/pro-layout.playground.md
+++ b/docs/playground/pro-layout.playground.md
@@ -11,8 +11,8 @@ group:
 
 ## Layout 自定义
 
-<code src="../../packages/layout/src/demos/dynamic-settings.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"/>
+<code src="../../packages/layout/src/demos/dynamic-settings.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"></code>
 
 ## 水印自定义
 
-<code src="../../packages/layout/src/components/WaterMark/demos/custom.tsx" background="#f7f8fa"/>
+<code src="../../packages/layout/src/components/WaterMark/demos/custom.tsx" background="#f7f8fa"></code>

--- a/docs/playground/pro-table.playground.md
+++ b/docs/playground/pro-table.playground.md
@@ -9,4 +9,4 @@ group:
 
 # ProTable Playground
 
-<code src="../../packages/table/src/demos/dynamic-settings.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"/>
+<code src="../../packages/table/src/demos/dynamic-settings.tsx" height="500px" iframe="760px" background="#f5f5f5" title="属性展示"></code>

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -118,7 +118,7 @@ export type ProSchema<T = unknown, U = string, Extra = unknown> = {
 
 ## valueType 列表
 
-<code src="./demos/valueType.tsx" height="154px" title="schema 表单" />
+<code src="./demos/valueType.tsx" height="154px" title="schema 表单"></code>
 
 ### API
 
@@ -204,7 +204,7 @@ return { type: 'percent', showSymbol: true | false, precision: 2 };
 
 ### 自定义 valueType
 
-<code src="./demos/customization-value-type.tsx" height="154px" title="schema 表单" />
+<code src="./demos/customization-value-type.tsx" height="154px" title="schema 表单"></code>
 
 ### valueEnum
 

--- a/packages/card/src/card.en-US.md
+++ b/packages/card/src/card.en-US.md
@@ -27,19 +27,19 @@ In-page container cards that provide standard card styles, card segmentation and
 
 When used alone a `ProCard` is just a regular card.
 
-<code src="./demos/basic.tsx" background="#f0f2f5" title="Basic Card" />
+<code src="./demos/basic.tsx" background="#f0f2f5" title="Basic Card"></code>
 
 ### Grid layout
 
 When nesting child cards, the component will automatically switch to `flex` flex box layout, you can set `direction` to `column` to specify the flex direction, you can also configure the `ghost` property to `true` to remove Background color and padding facilitate in-page layout.
 
-<code src="./demos/colspan.tsx" background="#f0f2f5" title="Grid Layout" />
+<code src="./demos/colspan.tsx" background="#f0f2f5" title="Grid Layout"></code>
 
 ### Responsive
 
 `colSpan` supports [Grid Responsive Layout](https://ant.design/components/grid-cn/#components-grid-demo-responsive) defined by antd. There are six preset response sizes: `xs` `sm` `md` `lg` `xl` `xxl`. If you want to support responsiveness, you can write `{ xs: 4, sm: 8, md: 10, lg: 12 }`.
 
-<code src="./demos/responsive.tsx" background="#f0f2f5" title="responsive" />
+<code src="./demos/responsive.tsx" background="#f0f2f5" title="responsive"></code>
 
 ### Card segmentation
 
@@ -48,114 +48,114 @@ In layout mode, by configuring `split`, you can easily split the card, and you c
 - The content `padding` of the parent card will be set to 0 when splitting.
 - `border-radius` of subcards will be set to 0 when splitting.
 
-<code src="./demos/split2.tsx" background="#f0f2f5" title="Card Splitting" />
+<code src="./demos/split2.tsx" background="#f0f2f5" title="Card Splitting"></code>
 
 ### Left and right columns
 
 Through the card segmentation ability, we can easily achieve the effect of left and right columns, which is very suitable for the structure of the list on the left and the details on the right.
 
-<code src="./demos/split23.tsx" background="#f0f2f5" title="Left and right columns" />
+<code src="./demos/split23.tsx" background="#f0f2f5" title="Left and right columns"></code>
 
 ### Complex segmentation
 
 Through the card segmentation capability, we can achieve more complex data presentation forms.
 
-<code src="./demos/split.tsx" background="#f0f2f5" title="Complex Split" />
+<code src="./demos/split.tsx" background="#f0f2f5" title="Complex Split"></code>
 
 ### Grid interval
 
 The grid often needs to cooperate with the interval. You can use the `gutter` property. We recommend using `(16+8n)px` as the grid interval (n is a natural number). If you want to support responsiveness, you can write it as `{ xs: 8, sm: 16, md: 24, lg: 32 }`. If vertical spacing is required, it can be written in array form `[horizontal spacing, vertical spacing][16, { xs: 8, sm: 16, md: 24, lg: 32 }]`.
 
-<code src="./demos/gutter.tsx" background="#f0f2f5" title="Grid Gutter" />
+<code src="./demos/gutter.tsx" background="#f0f2f5" title="Grid Gutter"></code>
 
 ### Multi-Line Cards
 
 The default card layout does not wrap, you can configure `wrap` to `true` to enable line wrapping between multiple cards, which is suitable for multiple card layouts.
 
-<code src="./demos/multipleLine.tsx" background="#f0f2f5" title="Multiple Line Cards" />
+<code src="./demos/multipleLine.tsx" background="#f0f2f5" title="Multiple Line Cards"></code>
 
 ### group display
 
 You can nest card components to group content, and `Divider` subcomponents to separate those content.
 
-<code src="./demos/divider.tsx" background="#f0f2f5" title="Group Indicator" />
+<code src="./demos/divider.tsx" background="#f0f2f5" title="Group Indicator"></code>
 
 ### Title with dividing line
 
 When adding a divider it automatically increases the height of the header to separate it from the content area.
 
-<code src="./demos/headerBordered.tsx" background="#f0f2f5" title="Title with dividing line"/>
+<code src="./demos/headerBordered.tsx" background="#f0f2f5" title="Title with dividing line"></code>
 
 ### Collapsible
 
 - You can use `collapsible` to configure whether the card is collapsible or not, and configure whether the card is collapsed by default through the `defaultCollapsed` property.
 - Or you can customize it by controlling the `collapsed` property.
 
-<code src="./demos/collapsible.tsx" background="#f0f2f5" title="collapsible" />
+<code src="./demos/collapsible.tsx" background="#f0f2f5" title="collapsible"></code>
 
 ### Deck expansion
 
 With the `ghost` ghost mode and collapsible ability, the card deck can be expanded.
 
-<code src="./demos/group.tsx" background="#f0f2f5" title="Card group expansion" />
+<code src="./demos/group.tsx" background="#f0f2f5" title="Card group expansion"></code>
 
 ### Content centered
 
 Configure the `layout` property to `center` to control the vertical centering of the content. When setting the centering, the content part is converted to a `flex` layout. You can use `direction` to control the `flex` direction.
 
-<code src="./demos/layout.tsx" background="#f0f2f5" title="Center content" />
+<code src="./demos/layout.tsx" background="#f0f2f5" title="Center content"></code>
 
 ### Loading
 
 Configure the `loading` property to `true` to control the loading of the card. You can also pass the DOM to `loading` to customize the loading display.
 
-<code src="./demos/loading.tsx" background="#f0f2f5" title="Loading" />
+<code src="./demos/loading.tsx" background="#f0f2f5" title="Loading"></code>
 
 ### Action items
 
 Configure the `actions` property to configure card actions.
 
-<code src="./demos/actions.tsx" background="#f0f2f5" title="Actions" />
+<code src="./demos/actions.tsx" background="#f0f2f5" title="Actions"></code>
 
 ### Untitled
 
 The header is automatically hidden when there is no content.
 
-<code src="./demos/headless.tsx" background="#f0f2f5" title="Untitled" />
+<code src="./demos/headless.tsx" background="#f0f2f5" title="Untitled"></code>
 
 ### with border
 
 Configure the `bordered` property to control whether the card is bordered.
 
-<code src="./demos/bordered.tsx" title="With border" />
+<code src="./demos/bordered.tsx" title="With border"></code>
 
 ### floating effect
 
-<code src="./demos/hoverable.tsx" title="Flyover" desc="Configure popover via hoverable" background="#f0f2f5"/>
+<code src="./demos/hoverable.tsx" title="Flyover" desc="Configure popover via hoverable" background="#f0f2f5"></code>
 
 ### bookmark
 
 Configure the `tabs` property with the `ProCard.TabPane` subcomponent to configure the tab bar of the card.
 
-<code src="./demos/tabs.tsx" background="#f0f2f5" title="tabs" />
+<code src="./demos/tabs.tsx" background="#f0f2f5" title="tabs"></code>
 
 ### Card Tab
 
 Set the `type` of `tab` to `card` to configure card-style tabs.
 
-<code src="./demos/tabs-card.tsx" background="#f0f2f5" title="Card Tabs" />
+<code src="./demos/tabs-card.tsx" background="#f0f2f5" title="Card Tabs"></code>
 
 ### Internal Cards
 
 Can be placed inside a card to display information in a multi-level structure.
 
-<code src="./demos/inner.tsx" title="Inner Card" />
+<code src="./demos/inner.tsx" title="Inner Card"></code>
 
 ### Vertical step example
 
 The `Steps` component is combined with the `ProCard` component to complete the vertical step example.
 
-<code src="./demos/steps-v.tsx" background="#f0f2f5" title="Example of vertical steps" />
+<code src="./demos/steps-v.tsx" background="#f0f2f5" title="Example of vertical steps"></code>
 
 ## API
 

--- a/packages/card/src/card.md
+++ b/packages/card/src/card.md
@@ -27,19 +27,19 @@ group:
 
 当单独使用时 `ProCard` 就是一个普通的卡片。
 
-<code src="./demos/basic.tsx" background="#f7f8fa" title="基础卡片" />
+<code src="./demos/basic.tsx" background="#f7f8fa" title="基础卡片"></code>
 
 ### 栅格布局
 
 当嵌套子卡片时, 组件会自动切换为 `flex` 弹性盒布局，你可以将 `direction`设置为`column`来指定 Flex 方向，你还可以通过配置 `ghost` 属性为 `true` 来去掉背景色和 padding 方便页内布局。
 
-<code src="./demos/colspan.tsx" background="#f0f2f5" title="栅格布局" height="642px"/>
+<code src="./demos/colspan.tsx" background="#f0f2f5" title="栅格布局" height="642px"></code>
 
 ### 响应式
 
 `colSpan` 支持 antd 定义的[栅格式响应布局](https://ant.design/components/grid-cn/#components-grid-demo-responsive)。预设六个响应尺寸：`xs` `sm` `md` `lg` `xl` `xxl`。如果要支持响应式，可以写成 `{ xs: 4, sm: 8, md: 10, lg: 12 }`。
 
-<code src="./demos/responsive.tsx" background="#f0f2f5" title="响应式" height="588px"/>
+<code src="./demos/responsive.tsx" background="#f0f2f5" title="响应式" height="588px"></code>
 
 ### 卡片切分
 
@@ -48,114 +48,114 @@ group:
 - 切分时父卡片的内容 `padding` 会被设置为 0。
 - 切分时子卡片的 `border-radius`会被设置为 0。
 
-<code src="./demos/split2.tsx" background="#f0f2f5" title="卡片切分" height="590px"/>
+<code src="./demos/split2.tsx" background="#f0f2f5" title="卡片切分" height="590px"></code>
 
 ### 左右分栏
 
 通过卡片切分能力我们很容易实现左右分栏的效果，很适合左侧是列表，右侧是详情的结构。
 
-<code src="./demos/split23.tsx" background="#f0f2f5" title="左右分栏" height="547px"/>
+<code src="./demos/split23.tsx" background="#f0f2f5" title="左右分栏" height="547px"></code>
 
 ### 复杂切分
 
 通过卡片切分能力我们可以实现更加复杂的数据展现形式。
 
-<code src="./demos/split.tsx" background="#f0f2f5" title="复杂切分" height="565px"/>
+<code src="./demos/split.tsx" background="#f0f2f5" title="复杂切分" height="565px"></code>
 
 ### 栅格间隔
 
 栅格常常需要和间隔进行配合，你可以使用 `gutter` 属性，我们推荐使用 `(16+8n)px` 作为栅格间隔(n 是自然数)，如果要支持响应式，可以写成 `{ xs: 8, sm: 16, md: 24, lg: 32 }`。如果需要垂直间距，可以写成数组形式 `[水平间距, 垂直间距][16, { xs: 8, sm: 16, md: 24, lg: 32 }]`。
 
-<code src="./demos/gutter.tsx" background="#f0f2f5" title="栅格间隔" height="531px"/>
+<code src="./demos/gutter.tsx" background="#f0f2f5" title="栅格间隔" height="531px"></code>
 
 ### 多行卡片
 
 默认卡片布局不可换行，你可以配置 `wrap` 为 `true` 来让多个卡片之间可以换行，适用于多个卡片排版的情况。
 
-<code src="./demos/multipleLine.tsx" background="#f0f2f5" title="多行卡片" height="338px"/>
+<code src="./demos/multipleLine.tsx" background="#f0f2f5" title="多行卡片" height="338px"></code>
 
 ### 分组展示
 
 你可以嵌套卡片组件来将内容分组, 以及 `Divider` 子组件来分隔这些内容。
 
-<code src="./demos/divider.tsx" background="#f0f2f5" title="分组指标" height="234px"/>
+<code src="./demos/divider.tsx" background="#f0f2f5" title="分组指标" height="234px"></code>
 
 ### 标题带分割线
 
 当添加分隔线时会自动增加标题的高度与内容区域分开。
 
-<code src="./demos/headerBordered.tsx" background="#f0f2f5" title="标题带分割线" height="209px"/>
+<code src="./demos/headerBordered.tsx" background="#f0f2f5" title="标题带分割线" height="209px"></code>
 
 ### 可折叠
 
 - 你可以使用 `collapsible` 来配置卡片是否可折叠，通过 `defaultCollapsed` 属性配置是否默认折叠。
 - 或者你可以通过 `collapsed` 属性受控进行自定义。
 
-<code src="./demos/collapsible.tsx" background="#f0f2f5" title="可折叠" height="284px"/>
+<code src="./demos/collapsible.tsx" background="#f0f2f5" title="可折叠" height="284px"></code>
 
 ### 卡片组展开
 
 配合 `ghost`幽灵模式和可折叠能力可以实现卡片组展开。
 
-<code src="./demos/group.tsx" background="#f0f2f5" title="卡片组展开" height="210px"/>
+<code src="./demos/group.tsx" background="#f0f2f5" title="卡片组展开" height="210px"></code>
 
 ### 内容居中
 
 配置 `layout` 属性为 `center` 控制内容垂直居中，设置居中时内容部分转为 `flex` 布局，可以使用 `direction` 控制 `flex` 方向。
 
-<code src="./demos/layout.tsx" background="#f0f2f5" title="内容居中" height="281px"/>
+<code src="./demos/layout.tsx" background="#f0f2f5" title="内容居中" height="281px"></code>
 
 ### 加载中
 
 配置 `loading`属性为`true`控制卡片加载中，也可以传入 DOM 给`loading`来自定义 loading 展示。
 
-<code src="./demos/loading.tsx" background="#f0f2f5" title="加载中" height="540px"/>
+<code src="./demos/loading.tsx" background="#f0f2f5" title="加载中" height="540px"></code>
 
 ### 操作项
 
 配置 `actions` 属性来配置卡片操作项。
 
-<code src="./demos/actions.tsx" background="#f0f2f5" title="操作项" height="284px"/>
+<code src="./demos/actions.tsx" background="#f0f2f5" title="操作项" height="284px"></code>
 
 ### 无标题
 
 头部没有内容时会自动隐藏。
 
-<code src="./demos/headless.tsx" background="#f0f2f5" title="无标题" height="151px"/>
+<code src="./demos/headless.tsx" background="#f0f2f5" title="无标题" height="151px"></code>
 
 ### 带边框
 
 配置 `bordered` 属性控制是否卡片带边框。
 
-<code src="./demos/bordered.tsx" title="带边框" height="194px"/>
+<code src="./demos/bordered.tsx" title="带边框" height="194px"></code>
 
 ### 浮出效果
 
-<code src="./demos/hoverable.tsx" title="浮出效果" desc="通过 hoverable 配置浮出效果" background="#f0f2f5" height="153px"/>
+<code src="./demos/hoverable.tsx" title="浮出效果" desc="通过 hoverable 配置浮出效果" background="#f0f2f5" height="153px"></code>
 
 ### 页签
 
 配置 `tabs` 属性配合 `ProCard.TabPane` 子组件可以配置卡片的标签栏。
 
-<code src="./demos/tabs.tsx" background="#f0f2f5" title="页签" height="253px"/>
+<code src="./demos/tabs.tsx" background="#f0f2f5" title="页签" height="253px"></code>
 
 ### 卡片式页签
 
 配置 `tab` 的 `type` 为 `card` 来配置卡片式页签。
 
-<code src="./demos/tabs-card.tsx" background="#f0f2f5" title="卡片式页签" height="199px"/>
+<code src="./demos/tabs-card.tsx" background="#f0f2f5" title="卡片式页签" height="199px"></code>
 
 ### 内部卡片
 
 可以放在卡片内部，展示多层级结构的信息。
 
-<code src="./demos/inner.tsx" title="内部卡片" height="712px"/>
+<code src="./demos/inner.tsx" title="内部卡片" height="712px"></code>
 
 ### 竖向步骤示例
 
 `Steps` 组件结合 `ProCard` 组件完成竖向步骤示例。
 
-<code src="./demos/steps-v.tsx" background="#f0f2f5" title="竖向步骤示例" height="401px"/>
+<code src="./demos/steps-v.tsx" background="#f0f2f5" title="竖向步骤示例" height="401px"></code>
 
 ## API
 

--- a/packages/card/src/components/CheckCard/index.md
+++ b/packages/card/src/components/CheckCard/index.md
@@ -27,109 +27,109 @@ nav:
 
 最常用的选项卡示例，包括头像，标题，描述等部分，可被选择。
 
-<code src="./demos/basic.tsx" height="215px"/>
+<code src="./demos/basic.tsx" height="215px"></code>
 
 ### 单选模式
 
 在多个选项存在的情况下可通过 `CheckCard.Group` 分组，默认选项卡组件为单选模式。
 
-<code src="./demos/single.tsx" title="多选卡片 - 单选模式" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/be0fcade-afae-4e85-95ef-a3cc90f6d4b3/kc60kq47_w1362_h412.jpeg" height="261px"/>
+<code src="./demos/single.tsx" title="多选卡片 - 单选模式" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/be0fcade-afae-4e85-95ef-a3cc90f6d4b3/kc60kq47_w1362_h412.jpeg" height="261px"></code>
 
 ### 多选模式
 
 通过设置 `CheckCard.Group` 的 `multiple` 属性配置多选，注意多选模式下表单项返回值为数组。
 
-<code src="./demos/multiple.tsx" title="多选卡片 - 多选模式" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/06963ad4-ba2b-4733-a1c5-778e7f696ac1/kc61xhvk_w1364_h280.jpeg" height="193px"/>
+<code src="./demos/multiple.tsx" title="多选卡片 - 多选模式" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/06963ad4-ba2b-4733-a1c5-778e7f696ac1/kc61xhvk_w1364_h280.jpeg" height="193px"></code>
 
 ### 不同尺寸
 
 配置 `size` 尺寸大小，当前可选 `large`，`default`，`small`，不同尺寸仅宽度不同。
 
-<code src="./demos/size.tsx" height="219px"/>
+<code src="./demos/size.tsx" height="219px"></code>
 
 当然你也可以通过 `style` 或 `className` 自定义卡片大小。
 
 ### 自定义尺寸
 
-<code src="./demos/custom.tsx" height="297px"/>
+<code src="./demos/custom.tsx" height="297px"></code>
 
 ### 表单中使用
 
 CheckCard 可以和表单组件一起使用，这里给出演示示例。
 
-<code src="./demos/form.tsx" title="多选卡片 - 表单中使用" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/c8fa2080-5a46-4f50-ae99-846b1804f56d/kc62b0ug_w1360_h656.jpeg" height="415px"/>
+<code src="./demos/form.tsx" title="多选卡片 - 表单中使用" thumbnail="https://gw.alipayobjects.com/zos/bmw-prod/c8fa2080-5a46-4f50-ae99-846b1804f56d/kc62b0ug_w1360_h656.jpeg" height="415px"></code>
 
 ### 组合样式
 
 头像，标题，描述区域可以自由组合或者单独呈现，组件会为你调整为最合适的对齐方式。
 
-<code src="./demos/compose.tsx" height="835px"/>
+<code src="./demos/compose.tsx" height="835px"></code>
 
 ### 自定义头像
 
 你可以通过 `avatar` 属性自定义头像区域。
 
-<code src="./demos/avatar.tsx" height="163px"/>
+<code src="./demos/avatar.tsx" height="163px"></code>
 
 ### 自定义标题
 
 你可以通过 `title` 属性自定义标题区域。
 
-<code src="./demos/title.tsx" height="193px"/>
+<code src="./demos/title.tsx" height="193px"></code>
 
 ### 自定义描述
 
 描述区域可通过 `description` 自定义 React 节点。
 
-<code src="./demos/description.tsx" height="215px"/>
+<code src="./demos/description.tsx" height="215px"></code>
 
 ### 默认选中
 
 通过配置 `defaultChecked` 属性为 `true` 来配置选项默认被选中。
 
-<code src="./demos/defaultChecked.tsx" height="171px"/>
+<code src="./demos/defaultChecked.tsx" height="171px"></code>
 
 ### 操作栏
 
 配置 `extra` 为卡片添加操作栏。
 
-<code src="./demos/extra.tsx" height="218px"/>
+<code src="./demos/extra.tsx" height="218px"></code>
 
 ### 组件 Loading
 
 通过配置 `loading` 属性为 `true` 来配置内容在加载中。
 
-<code src="./demos/loading.tsx" height="233px"/>
+<code src="./demos/loading.tsx" height="233px"></code>
 
 ### 纯图片选项
 
 通过仅仅配置 `cover` 属性可以让你的选项成为一个纯图片选项。
 
-<code src="./demos/image.tsx" height="250px"/>
+<code src="./demos/image.tsx" height="250px"></code>
 
 ### 选项不可用
 
 通过配置 `disabled` 属性配置选项不可用。
 
-<code src="./demos/disabled.tsx" height="419px"/>
+<code src="./demos/disabled.tsx" height="419px"></code>
 
 ### 选项列表
 
 `CheckCard.Group` 支持通过 `options` 属性配置化来列表展示多个选项。
 
-<code src="./demos/group.tsx" height="777px"/>
+<code src="./demos/group.tsx" height="777px"></code>
 
 ### 应用列表示例
 
 这里展示在实际 AiDesk 中图像算法选择的使用示例。
 
-<code src="./demos/list.tsx" height="399px"/>
+<code src="./demos/list.tsx" height="399px"></code>
 
 ### 布局
 
 `CheckCard.Group` 内嵌 `CheckCard` 并与 `Grid` 组件一起使用，可以实现更灵活的布局。
 
-<code src="./demos/grid.tsx" height="171px"/>
+<code src="./demos/grid.tsx" height="171px"></code>
 
 ## API
 

--- a/packages/card/src/components/StatisticCard/index.md
+++ b/packages/card/src/components/StatisticCard/index.md
@@ -27,13 +27,13 @@ nav:
 
 使用数值统计配置 `statistic` 和 `chart` 完成基本的指标卡。
 
-<code src="./demos/basic.tsx" background="#f7f8fa" title="基本使用" />
+<code src="./demos/basic.tsx" background="#f7f8fa" title="基本使用"></code>
 
 ### 只有图表
 
 当图表单独展示在卡片中时。
 
-<code src="./demos/chart.tsx" background="#f0f2f5" title="只有图表" height="429px"/>
+<code src="./demos/chart.tsx" background="#f0f2f5" title="只有图表" height="429px"></code>
 
 ### 额外指标
 
@@ -42,11 +42,11 @@ nav:
 
 ### 总分/主次关系
 
-<code src="./demos/total.tsx" background="#f0f2f5" title="总分/主次关系" height="215px"/>
+<code src="./demos/total.tsx" background="#f0f2f5" title="总分/主次关系" height="215px"></code>
 
 ### 总分/业绩目标
 
-<code src="./demos/total-layout.tsx" background="#f0f2f5" title="总分/业绩目标" height="358px"/>
+<code src="./demos/total-layout.tsx" background="#f0f2f5" title="总分/业绩目标" height="358px"></code>
 
 ### 分组指标
 
@@ -54,55 +54,55 @@ nav:
 
 ### 分组指标带图表
 
-<code src="./demos/group-chart.tsx" background="#f7f8fa" title="分组指标带图表"/>
+<code src="./demos/group-chart.tsx" background="#f7f8fa" title="分组指标带图表"></code>
 
 ### 公式计算指标
 
 `Operation` 可以接受子元素，借此可以实现各种各样的公式计算指标。
 
-<code src="./demos/fomula.tsx" background="#f0f2f5" title="公式计算指标" height="193px"/>
+<code src="./demos/fomula.tsx" background="#f0f2f5" title="公式计算指标" height="193px"></code>
 
 ### 状态展示
 
 你可以给每个数值统计配置 `status` 展示其状态。
 
-<code src="./demos/status.tsx" background="#f0f2f5" title="状态展示" height="193px"/>
+<code src="./demos/status.tsx" background="#f0f2f5" title="状态展示" height="193px"></code>
 
 ### 图标展示
 
 你可以给每个数值统计配置 `icon` 展示其图标。
 
-<code src="./demos/icon.tsx" background="#f0f2f5" title="图标展示" height="193px"/>
+<code src="./demos/icon.tsx" background="#f0f2f5" title="图标展示" height="193px"></code>
 
 ### 卡片布局
 
 配合 `ProCard` 的卡片切分能力可以实现复杂的卡片布局。
 
-<code src="./demos/layout.tsx" background="#f0f2f5" title="卡片布局" height="732px"/>
+<code src="./demos/layout.tsx" background="#f0f2f5" title="卡片布局" height="732px"></code>
 
 ### 图表在右
 
 配置 `chartPlacement` 为 `right` 可以指定图表在数值统计的右边。默认为上下结构。
 
-<code src="./demos/horizontal.tsx" background="#f0f2f5" title="图表在右" height="241px"/>
+<code src="./demos/horizontal.tsx" background="#f0f2f5" title="图表在右" height="241px"></code>
 
 ### 图表在左
 
 配置 `chartPlacement` 为 `left` 可以指定图表在数值统计的左边。
 
-<code src="./demos/horizontal-left.tsx" background="#f0f2f5" title="图表在左" height="241px"/>
+<code src="./demos/horizontal-left.tsx" background="#f0f2f5" title="图表在左" height="241px"></code>
 
 ### 指标页签联动
 
 结合 `Statistic` 可以实现带指标统计的页签。
 
-<code src="./demos/tabs-statistic.tsx" background="#f0f2f5" title="带指标页签" height="325px"/>
+<code src="./demos/tabs-statistic.tsx" background="#f0f2f5" title="带指标页签" height="325px"></code>
 
 ### 环比趋势
 
 你可以使用 `Statistic` 组件配置布局 `layout` 为 `inline` 以及 `trend` 来展示环比趋势。
 
-<code src="./demos/trend.tsx" background="#f0f2f5" title="环比趋势" height="203px"/>
+<code src="./demos/trend.tsx" background="#f0f2f5" title="环比趋势" height="203px"></code>
 
 ## API
 

--- a/packages/descriptions/src/descriptions.en-US.md
+++ b/packages/descriptions/src/descriptions.en-US.md
@@ -55,37 +55,37 @@ interface RequestData {
 
 ### Basic usage
 
-<code src="./demos/base.tsx" title="Basic definition list" />
+<code src="./demos/base.tsx" title="Basic definition list"></code>
 
 ### Request data remotely
 
 Display the definition list by requesting interface data
 
-<code src="./demos/request.tsx" title="remote request data" />
+<code src="./demos/request.tsx" title="remote request data"></code>
 
 ### columns configuration
 
 Display the definition list by requesting interface data and columns
 
-<code src="./demos/columns.tsx" title="columns configuration" />
+<code src="./demos/columns.tsx" title="columns configuration"></code>
 
 ### format configuration
 
 Format the date according to format
 
-<code src="./demos/format.tsx" title="format configuration" />
+<code src="./demos/format.tsx" title="format configuration"></code>
 
 ### dataSource configuration data
 
 ProDescriptions supports the same dataSource as Table
 
-<code src="./demos/use-data-source.tsx" title="dataSource configuration data"/>
+<code src="./demos/use-data-source.tsx" title="dataSource configuration data"></code>
 
 ### Editable definition list
 
 API is the same as ProTable
 
-<code src="./demos/editable.tsx" title="Editable definition list" />
+<code src="./demos/editable.tsx" title="Editable definition list"></code>
 
 ## API
 

--- a/packages/descriptions/src/descriptions.md
+++ b/packages/descriptions/src/descriptions.md
@@ -55,41 +55,41 @@ interface RequestData {
 
 ### 基本使用
 
-<code src="./demos/base.tsx" title="基础定义列表" height="938px"/>
+<code src="./demos/base.tsx" title="基础定义列表" height="938px"></code>
 
 ### 数组类型 dataIndex
 
-<code src="./demos/arrayDataIndex.tsx" title="数组类型dataIndex" height="172px"/>
+<code src="./demos/arrayDataIndex.tsx" title="数组类型dataIndex" height="172px"></code>
 
 ### 格式化配置
 
 根据配置格式化日期
 
-<code src="./demos/format.tsx" title="format configuration" height="265px"/>
+<code src="./demos/format.tsx" title="format configuration" height="265px"></code>
 
 ### 远程请求数据
 
 通过请求接口数据来展示定义列表
 
-<code src="./demos/request.tsx" title="远程请求数据" height="172px"/>
+<code src="./demos/request.tsx" title="远程请求数据" height="172px"></code>
 
 ### columns 配置
 
 通过请求接口数据和 columns 来展示定义列表
 
-<code src="./demos/columns.tsx" title="columns 配置" height="243px"/>
+<code src="./demos/columns.tsx" title="columns 配置" height="243px"></code>
 
 ### dataSource 配置数据
 
 ProDescriptions 支持了和 Table 相同的 dataSource
 
-<code src="./demos/use-data-source.tsx" title="dataSource 配置数据" height="204px"/>
+<code src="./demos/use-data-source.tsx" title="dataSource 配置数据" height="204px"></code>
 
 ### 可编辑的定义列表
 
 API 与 ProTable 相同
 
-<code src="./demos/editable.tsx" title="可编辑的定义列表" height="253px"/>
+<code src="./demos/editable.tsx" title="可编辑的定义列表" height="253px"></code>
 
 ## API
 

--- a/packages/field/src/field.md
+++ b/packages/field/src/field.md
@@ -15,17 +15,17 @@ nav:
 
 ## DEMO
 
-<code src="./demos/base.tsx" height="1202px"/>
+<code src="./demos/base.tsx" height="1202px"></code>
 
-<code src="./demos/base_test.tsx" debug/>
+<code src="./demos/base_test.tsx" debug></code>
 
-<code src="./demos/search-value.tsx" debug/>
+<code src="./demos/search-value.tsx" debug></code>
 
-<code src="./demos/search-value-autoClearSearchValue.tsx" debug/>
+<code src="./demos/search-value-autoClearSearchValue.tsx" debug></code>
 
-<code src="./demos/tree-select-search-value.tsx" debug/>
+<code src="./demos/tree-select-search-value.tsx" debug></code>
 
-<code src="./demos/select-request.tsx" debug/>
+<code src="./demos/select-request.tsx" debug></code>
 
 ## API
 

--- a/packages/form/src/components/Dependency/index.en-US.md
+++ b/packages/form/src/components/Dependency/index.en-US.md
@@ -42,7 +42,7 @@ The name parameter must be an array. If it is a nested structure, it can be conf
 
 ### Interdependent Forms
 
-<code src="./demos/dependency.tsx" title="ProForm.List" />
+<code src="./demos/dependency.tsx" title="ProForm.List"></code>
 
 ### Get form dependency values
 
@@ -53,4 +53,4 @@ The following examples demonstrate the order in which dependencies are evaluated
   - `ignoreFormListField` of `<ProFormDependency>` is `true`: according to the dependency declared by `name`, the value is taken from the global (case 2)
   - `ignoreFormListField` of `<ProFormDependency>` is `false`: according to the dependency declared by `name`, the value is taken locally (case 3)
 
-<code src="./demos/dependency2.tsx" height="1774px" title="ProForm.List" />
+<code src="./demos/dependency2.tsx" height="1774px" title="ProForm.List"></code>

--- a/packages/form/src/components/Dependency/index.md
+++ b/packages/form/src/components/Dependency/index.md
@@ -42,7 +42,7 @@ name 参数必须要是一个数组，如果是嵌套的结构可以这样配置
 
 ### 互相依赖表单
 
-<code src="./demos/dependency.tsx" title="互相依赖表单" height="371px"/>
+<code src="./demos/dependency.tsx" title="互相依赖表单" height="371px"></code>
 
 ### 获取表单依赖值
 
@@ -53,4 +53,4 @@ name 参数必须要是一个数组，如果是嵌套的结构可以这样配置
   - `<ProFormDependency>`的`ignoreFormListField`为`true`：根据`name`声明的依赖项，从全局取值（情形 2）
   - `<ProFormDependency>`的`ignoreFormListField`为`false`：根据`name`声明的依赖项，从局部取值（情形 3）
 
-<code src="./demos/dependency2.tsx" height="1168px" title="获取表单依赖值"/>
+<code src="./demos/dependency2.tsx" height="1168px" title="获取表单依赖值"></code>

--- a/packages/form/src/components/FieldSet/index.en-US.md
+++ b/packages/form/src/components/FieldSet/index.en-US.md
@@ -32,27 +32,27 @@ So the props we set for ProFormText are actually for Form.Item, and the fieldPro
 
 ### Full amount of form field
 
-<code src="./demos/components-other.tsx"/>
+<code src="./demos/components-other.tsx"></code>
 
 ### Query form
 
-<code src="./demos/search-select.tsx" title=" Query form"/>
+<code src="./demos/search-select.tsx" title=" Query form"></code>
 
 ### Date form
 
-<code src="./demos/datatime.tsx" title="Date form"/>
+<code src="./demos/datatime.tsx" title="Date form"></code>
 
 ### Upload form
 
-<code src="./demos/upload.tsx" title="Upload form"/>
+<code src="./demos/upload.tsx" title="Upload form"></code>
 
 ### Structured data
 
-<code src="./demos/form-fieldset.tsx" title="Structured data"/>
+<code src="./demos/form-fieldset.tsx" title="Structured data"></code>
 
 ### Read-only for form field
 
-<code src="./demos/components-other-readonly.tsx" debug/>
+<code src="./demos/components-other-readonly.tsx" debug></code>
 
 ## API
 

--- a/packages/form/src/components/FieldSet/index.md
+++ b/packages/form/src/components/FieldSet/index.md
@@ -56,27 +56,27 @@ const ProFormText = (props) => {
 
 ### 表单项
 
-<code src="./demos/components-other.tsx" title="表单项" height="862px"/>
+<code src="./demos/components-other.tsx" title="表单项" height="862px"></code>
 
 ### 查询表单
 
-<code src="./demos/search-select.tsx" title="查询表单" height="193px"/>
+<code src="./demos/search-select.tsx" title="查询表单" height="193px"></code>
 
 ### 结构化数据
 
-<code src="./demos/form-fieldset.tsx" title="结构化数据" height="489px"/>
+<code src="./demos/form-fieldset.tsx" title="结构化数据" height="489px"></code>
 
 ### 日期表单
 
-<code src="./demos/datatime.tsx" height="545px" title="日期表单"/>
+<code src="./demos/datatime.tsx" height="545px" title="日期表单"></code>
 
 ### 上传表单
 
-<code src="./demos/upload.tsx" height="620px" title="上传表单"/>
+<code src="./demos/upload.tsx" height="620px" title="上传表单"></code>
 
 ### 只读表单
 
-<code src="./demos/components-other-readonly.tsx"  debug/>
+<code src="./demos/components-other-readonly.tsx" debug></code>
 
 ## API
 
@@ -117,7 +117,7 @@ ProForm 自带的 Filed ,与 valueType 基本上一一对应。
 
 ProFormCaptcha 是为了支持中后台中常见的验证码功能开发的组件。
 
-<code src="./demos/pro-form-captCha.tsx" height="169px" title="captcha"/>
+<code src="./demos/pro-form-captCha.tsx" height="169px" title="captcha"></code>
 
 ```tsx | pure
 <ProFormCaptcha

--- a/packages/form/src/components/Group/index.md
+++ b/packages/form/src/components/Group/index.md
@@ -346,32 +346,32 @@ name 参数必须要是一个数组，如果是嵌套的结构可以这样配置
 
 ### 自定义删除和复制的 tooltip
 
-<code src="./demos/list-tooltip" title="ProForm.List" height="371px"/>
+<code src="./demos/list-tooltip" title="ProForm.List" height="371px"></code>
 
 ### 联动的 FormList
 
-<code src="./demos/base-use" title="ProForm.List" height="285px"/>
+<code src="./demos/base-use" title="ProForm.List" height="285px"></code>
 
 ### 可调整的新建按钮位置
 
-<code src="./demos/list.tsx" title="ProForm.List-position" height="686px"/>
+<code src="./demos/list.tsx" title="ProForm.List-position" height="686px"></code>
 
 ### 表单互相嵌套
 
-<code src="./demos/nested-list.tsx" title="ProForm.List-ProFormList" height="649px"/>
+<code src="./demos/nested-list.tsx" title="ProForm.List-ProFormList" height="649px"></code>
 
 ### 复杂联动
 
-<code src="./demos/dependency.tsx" title="ProForm.List-dependency" height="371px"/>
+<code src="./demos/dependency.tsx" title="ProForm.List-dependency" height="371px"></code>
 
 ### 行为守卫
 
-<code src="./demos/pro-form-list.tsx" height="447px" title="行为守卫"/>
+<code src="./demos/pro-form-list.tsx" height="447px" title="行为守卫"></code>
 
 ### 增删条目限制
 
-<code src="./demos/countLimit.tsx" height="285px" title="增删条目限制"/>
+<code src="./demos/countLimit.tsx" height="285px" title="增删条目限制"></code>
 
 ### 横向布局
 
-<code src="./demos/horizontal-layout.tsx" title="横向布局" height="380px"/>
+<code src="./demos/horizontal-layout.tsx" title="横向布局" height="380px"></code>

--- a/packages/form/src/components/LoginForm/index.en-US.md
+++ b/packages/form/src/components/LoginForm/index.en-US.md
@@ -14,11 +14,11 @@ LoginForm and LoginFormPage are variants of ProForm. They are specially implemen
 
 ## Login form
 
-<code src="./demos/login-form" background="#f5f5f5" height="320px" title="login-form" />
+<code src="./demos/login-form" background="#f5f5f5" height="320px" title="login-form"></code>
 
 ## page level LoginForm
 
-<code src="./demos/login-form-page.tsx" background="#f5f5f5" height="320px" title="Page level form" />
+<code src="./demos/login-form-page.tsx" background="#f5f5f5" height="320px" title="Page level form"></code>
 
 ### LoginForm
 

--- a/packages/form/src/components/LoginForm/index.md
+++ b/packages/form/src/components/LoginForm/index.md
@@ -14,11 +14,11 @@ LoginForm 和 LoginFormPage 是 ProForm 的变体，两者是为了适应常见�
 
 ## 登录表单
 
-<code src="./demos/login-form" background="#f5f5f5" height="580px" title="登录表单"/>
+<code src="./demos/login-form" background="#f5f5f5" height="580px" title="登录表单"></code>
 
 ## 页面级别的登录表单
 
-<code src="./demos/login-form-page.tsx" background="#f5f5f5" iframe="887px" height="507px" title="页面级别的表单"/>
+<code src="./demos/login-form-page.tsx" background="#f5f5f5" iframe="887px" height="507px" title="页面级别的表单"></code>
 
 ## API
 

--- a/packages/form/src/components/ModalForm/index.en-US.md
+++ b/packages/form/src/components/ModalForm/index.en-US.md
@@ -15,27 +15,27 @@ ModalForm and DrawerForm both provide triggers to reduce state usage, if you nee
 
 ## Modal Forms
 
-<code src="./demos/modal-form.tsx" background="#f5f5f5" height="32px" title="Modal Forms"/>
+<code src="./demos/modal-form.tsx" background="#f5f5f5" height="32px" title="Modal Forms"></code>
 
 ## Drawer Forms
 
-<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="32px" title="Drawer Forms"/>
+<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="32px" title="Drawer Forms"></code>
 
 ## Nested Drawer Forms
 
-<code src="./demos/drawer-form-nested.tsx" debug background="#f5f5f5" height="32px" title="Drawer Forms"/>
+<code src="./demos/drawer-form-nested.tsx" debug background="#f5f5f5" height="32px" title="Drawer Forms"></code>
 
 ## Custom Modal Forms' Button
 
-<code src="./demos/modal-form-submitter.tsx"  background="#f5f5f5" height="32px" title="Custom Modal Forms' Button"/>
+<code src="./demos/modal-form-submitter.tsx" background="#f5f5f5" height="32px" title="Custom Modal Forms' Button"></code>
 
 ## Use open and onOpenChange
 
-<code src="./demos/visible-on-visible-change.tsx"  background="#f5f5f5" height="32px" title="Use open and onOpenChange"/>
+<code src="./demos/visible-on-visible-change.tsx" background="#f5f5f5" height="32px" title="Use open and onOpenChange"></code>
 
 ## Reset Form
 
-<code src="./demos/modal-form-reset.tsx"  background="#f5f5f5" height="32px" title="Reset Form"/>
+<code src="./demos/modal-form-reset.tsx" background="#f5f5f5" height="32px" title="Reset Form"></code>
 
 ## API
 

--- a/packages/form/src/components/ModalForm/index.md
+++ b/packages/form/src/components/ModalForm/index.md
@@ -16,27 +16,27 @@ ModalForm 和 DrawerForm 都提供了 trigger 来减少 state 的使用，如果
 
 ## Modal 表单
 
-<code src="./demos/modal-form.tsx" background="#f5f5f5" height="113px" title="Modal 表单"/>
+<code src="./demos/modal-form.tsx" background="#f5f5f5" height="113px" title="Modal 表单"></code>
 
 ## Drawer 表单
 
-<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="113px" title="Drawer 表单"/>
+<code src="./demos/drawer-form.tsx" background="#f5f5f5" height="113px" title="Drawer 表单"></code>
 
 ## 嵌套浮层表单
 
-<code src="./demos/drawer-form-nested.tsx" debug background="#f5f5f5" height="32px" title="Drawer Forms"/>
+<code src="./demos/drawer-form-nested.tsx" debug background="#f5f5f5" height="32px" title="Drawer Forms"></code>
 
 ## 自定义 Modal 表单按钮
 
-<code src="./demos/modal-form-submitter.tsx" background="#f5f5f5" height="113px" title="自定义 Modal 表单按钮"/>
+<code src="./demos/modal-form-submitter.tsx" background="#f5f5f5" height="113px" title="自定义 Modal 表单按钮"></code>
 
 ## 使用 open 和 onOpenChange
 
-<code src="./demos/visible-on-visible-change.tsx" background="#f5f5f5" height="113px" title="使用 open 和 onOpenChange"/>
+<code src="./demos/visible-on-visible-change.tsx" background="#f5f5f5" height="113px" title="使用 open 和 onOpenChange"></code>
 
 ## 重置表单
 
-<code src="./demos/modal-form-reset.tsx" background="#f5f5f5" height="113px" title="重置表单"/>
+<code src="./demos/modal-form-reset.tsx" background="#f5f5f5" height="113px" title="重置表单"></code>
 
 ## API
 

--- a/packages/form/src/components/QueryFilter/index.en-US.md
+++ b/packages/form/src/components/QueryFilter/index.en-US.md
@@ -13,33 +13,33 @@ QueryFilter and LightFilter solve the problem of using the form with other compo
 
 ### Query Filter
 
-<code src="./demos/query-filter.tsx" height="168px"/>
+<code src="./demos/query-filter.tsx" height="168px"></code>
 
 ### Query filter - put away by default
 
-<code src="./demos/query-filter-collapsed.tsx" height="56px"/>
+<code src="./demos/query-filter-collapsed.tsx" height="56px"></code>
 
 ### query-filter-vertical-layout
 
-<code src="./demos/query-filter-vertical.tsx" height="172px"/>
+<code src="./demos/query-filter-vertical.tsx" height="172px"></code>
 
 ### query-filter-search
 
-<code src="./demos/search-filter.tsx" background="#f7f8fa" height="274px"/>
+<code src="./demos/search-filter.tsx" background="#f7f8fa" height="274px"></code>
 
 ### Lightweight filtering
 
-<code src="./demos/light-filter.tsx" height="86px"/>
+<code src="./demos/light-filter.tsx" height="86px"></code>
 
 ### Light filtering - border mode
 
-<code src="./demos/light-filter-bordered.tsx" height="32px" />
+<code src="./demos/light-filter-bordered.tsx" height="32px"></code>
 
 ### Light filtering - collapsed mode
 
 All options in collapsed mode are collapsed by default, with or without values, and the control's `secondary` will no longer be valid.
 
-<code src="./demos/light-filter-collapse.tsx" height="40px"/>
+<code src="./demos/light-filter-collapse.tsx" height="40px"></code>
 
 ## API
 

--- a/packages/form/src/components/QueryFilter/index.md
+++ b/packages/form/src/components/QueryFilter/index.md
@@ -14,45 +14,45 @@ nav:
 
 ### 查询筛选
 
-<code src="./demos/query-filter.tsx" height="137px" title="查询筛选"/>
+<code src="./demos/query-filter.tsx" height="137px" title="查询筛选"></code>
 
-<code src="./demos/query-filter-test.tsx" height="168px" title="查询筛选" debug/>
+<code src="./demos/query-filter-test.tsx" height="168px" title="查询筛选" debug></code>
 
 ### 查询筛选-默认收起
 
-<code src="./demos/query-filter-collapsed.tsx" height="137px" title="查询筛选-默认收起"/>
+<code src="./demos/query-filter-collapsed.tsx" height="137px" title="查询筛选-默认收起"></code>
 
 ### 查询筛选-垂直布局
 
-<code src="./demos/query-filter-vertical.tsx" height="167px" title="查询筛选-垂直布局"/>
+<code src="./demos/query-filter-vertical.tsx" height="167px" title="查询筛选-垂直布局"></code>
 
 ### 查询筛选-搜索
 
-<code src="./demos/search-filter.tsx" background="#f7f8fa" height="274px" title="查询筛选-搜索" />
+<code src="./demos/search-filter.tsx" background="#f7f8fa" height="274px" title="查询筛选-搜索"></code>
 
 ### 轻量筛选
 
-<code src="./demos/light-filter.tsx" height="287px" title="轻量筛选"/>
+<code src="./demos/light-filter.tsx" height="287px" title="轻量筛选"></code>
 
 ### 轻量筛选-自定义 footer
 
-<code src="./demos/light-filter-footer.tsx" height="283px" title="轻量筛选-自定义footer"/>
+<code src="./demos/light-filter-footer.tsx" height="283px" title="轻量筛选-自定义footer"></code>
 
 ### 轻量筛选-边框模式
 
-<code src="./demos/light-filter-bordered.tsx" height="113px" title="轻量筛选-边框模式"/>
+<code src="./demos/light-filter-bordered.tsx" height="113px" title="轻量筛选-边框模式"></code>
 
 ### 轻量筛选-折叠模式
 
 折叠模式下所有的选项都会默认折叠，不管是否有值，控件的 `secondary` 将不再有效。
 
-<code src="./demos/light-filter-collapse.tsx" height="113px" title="轻量筛选-折叠模式"/>
+<code src="./demos/light-filter-collapse.tsx" height="113px" title="轻量筛选-折叠模式"></code>
 
 ### 轻量筛选-弹出框对齐方式
 
 手动设置轻量筛选的弹出框，默认为 `bottomLeft`
 
-<code src="./demos/light-filter-placement.tsx" height="225px" title="轻量筛选-弹出框对齐方式"/>
+<code src="./demos/light-filter-placement.tsx" height="225px" title="轻量筛选-弹出框对齐方式"></code>
 
 ## API
 

--- a/packages/form/src/components/SchemaForm/index.en-US.md
+++ b/packages/form/src/components/SchemaForm/index.en-US.md
@@ -69,26 +69,26 @@ The most important thing about the SchemaForm form is the type definition of the
 
 ### JSON to generate the form
 
-<code src="./demos/schema.tsx" height="764px" title="schema form" />
+<code src="./demos/schema.tsx" height="764px" title="schema form"></code>
 
 ### JSON to generate distributed forms
 
-<code src="./demos/steps-form.tsx" height="464px" title="schema form" />
+<code src="./demos/steps-form.tsx" height="464px" title="schema form"></code>
 
 ### Embed in ProForm
 
-<code src="./demos/embed.tsx" height="464px" title="schema form" />
+<code src="./demos/embed.tsx" height="464px" title="schema form"></code>
 
 ### Use ProFormDependency
 
-<code src="./demos/dependency.tsx" height="300px" title="schema dependency" />
+<code src="./demos/dependency.tsx" height="300px" title="schema dependency"></code>
 
 ## High performance code examples
 
 ### Combining shouldUpdate=false with dependencies to trigger updates
 
-<code src="./demos/dependencies.tsx" height="500px" title="schema dependencies" />
+<code src="./demos/dependencies.tsx" height="500px" title="schema dependencies"></code>
 
 ### Dynamically control whether to re-render
 
-<code src="./demos/dynamic-rerender.tsx" height="500px" title="dynamic rerender" />
+<code src="./demos/dynamic-rerender.tsx" height="500px" title="dynamic rerender"></code>

--- a/packages/form/src/components/SchemaForm/index.md
+++ b/packages/form/src/components/SchemaForm/index.md
@@ -71,30 +71,30 @@ SchemaForm 表单最重要就是 Schema 的类型定义，我们使用了与 tab
 
 ### JSON 来生成表单
 
-<code src="./demos/schema.tsx" height="1035px" title="schema 表单"/>
+<code src="./demos/schema.tsx" height="1035px" title="schema 表单"></code>
 
 ### JSON 来生成分步表单
 
-<code src="./demos/steps-form.tsx" height="350px" title="schema 表单"/>
+<code src="./demos/steps-form.tsx" height="350px" title="schema 表单"></code>
 
 ### 嵌入到 ProForm 中
 
-<code src="./demos/embed.tsx" height="813px" title="schema 表单"/>
+<code src="./demos/embed.tsx" height="813px" title="schema 表单"></code>
 
 ### 使用 ProFormDependency
 
-<code src="./demos/dependency.tsx" height="200px" title="schema 表单"/>
+<code src="./demos/dependency.tsx" height="200px" title="schema 表单"></code>
 
 ## 高性能代码示例
 
 ### 结合 shouldUpdate=false 和 dependencies 触发更新
 
-<code src="./demos/dependencies.tsx" height="569px" title="schema dependencies"/>
+<code src="./demos/dependencies.tsx" height="569px" title="schema dependencies"></code>
 
 ### 动态控制是否重渲染
 
-<code src="./demos/dynamic-rerender.tsx" height="544px" title="dynamic rerender"/>
+<code src="./demos/dynamic-rerender.tsx" height="544px" title="dynamic rerender"></code>
 
 ### form-list-required
 
-<code src="./demos/form-list-required.tsx" height="600px" title="required" debug />
+<code src="./demos/form-list-required.tsx" height="600px" title="required" debug></code>

--- a/packages/form/src/components/StepsForm/index.en-US.md
+++ b/packages/form/src/components/StepsForm/index.en-US.md
@@ -16,19 +16,19 @@ StepsForm manages the data of sub forms through a Provider, each word form is a 
 
 ## Step-by-Step Forms
 
-<code src="./demos/steps-from.tsx" height="532px"/>
+<code src="./demos/steps-from.tsx" height="532px"></code>
 
 ## Step-by-Step Forms - Multi-Card
 
-<code src="./demos/multi-card-step-form.tsx"  background="#f5f5f5" height="868px"/>
+<code src="./demos/multi-card-step-form.tsx" background="#f5f5f5" height="868px"></code>
 
 ## Step-by-Step Forms - Works with Modal
 
-<code src="./demos/modal-step-form.tsx"  background="#f5f5f5" height="32px"/>
+<code src="./demos/modal-step-form.tsx" background="#f5f5f5" height="32px"></code>
 
 ## StepForm in edit scene
 
-<code src="./demos/add-or-edit-step-form.tsx" height="532px" title="自定义分步表单按钮"/>
+<code src="./demos/add-or-edit-step-form.tsx" height="532px" title="自定义分步表单按钮"></code>
 
 ## API
 

--- a/packages/form/src/components/StepsForm/index.md
+++ b/packages/form/src/components/StepsForm/index.md
@@ -16,27 +16,27 @@ StepsForm 通过 Provider 来管理子表单的数据，每个子表单都是完
 
 ## 分步表单
 
-<code src="./demos/steps-from.tsx" height="658px" title="分步表单"/>
+<code src="./demos/steps-from.tsx" height="658px" title="分步表单"></code>
 
 ## 分步表单垂直模式
 
-<code src="./demos/steps-form-vertical.tsx" height="582px" title="分步表单垂直模式"/>
+<code src="./demos/steps-form-vertical.tsx" height="582px" title="分步表单垂直模式"></code>
 
 ## 自定义分步表单按钮
 
-<code src="./demos/customize-steps-from.tsx" height="614px" title="自定义分步表单按钮"/>
+<code src="./demos/customize-steps-from.tsx" height="614px" title="自定义分步表单按钮"></code>
 
 ## 分步表单-多卡片
 
-<code src="./demos/multi-card-step-form.tsx" background="#f5f5f5" height="950px" title="分步表单-多卡片"/>
+<code src="./demos/multi-card-step-form.tsx" background="#f5f5f5" height="950px" title="分步表单-多卡片"></code>
 
 ## 分步表单-与 Modal 配合使用
 
-<code src="./demos/modal-step-form.tsx" background="#f5f5f5" height="113px" title="分步表单-与 Modal 配合使用"/>
+<code src="./demos/modal-step-form.tsx" background="#f5f5f5" height="113px" title="分步表单-与 Modal 配合使用"></code>
 
 ## 编辑场景下的分步表单
 
-<code src="./demos/add-or-edit-step-form.tsx" height="349px" title="自定义分步表单按钮"/>
+<code src="./demos/add-or-edit-step-form.tsx" height="349px" title="自定义分步表单按钮"></code>
 
 ## API
 

--- a/packages/form/src/form.en-US.md
+++ b/packages/form/src/form.en-US.md
@@ -149,37 +149,37 @@ ProForm is the best choice when you want to implement a form quickly but don't w
 
 ### Basic Usage
 
-<code src="./demos/base.tsx" height="548px"/>
+<code src="./demos/base.tsx" height="548px"></code>
 
 ### Grid mode
 
 supported in `ProForm`, `SchemaForm`, `ModalForm`, `DrawerForm`, `StepsForm`
 
-<code src="./demos/form-layout-grid.tsx" title="Grid layout" />
+<code src="./demos/form-layout-grid.tsx" title="Grid layout"></code>
 
 ### Form's layout toggle
 
-<code src="./demos/layout-change.tsx" height="548px"/>
+<code src="./demos/layout-change.tsx" height="548px"></code>
 
 ### Interdependent form entries
 
-<code src="./demos/dependency.tsx" height="248px"/>
+<code src="./demos/dependency.tsx" height="248px"></code>
 
 ### Sync submission results to url
 
-<code src="./demos/sync-to-url.tsx" height="548px"/>
+<code src="./demos/sync-to-url.tsx" height="548px"></code>
 
 ### Fixed footer
 
-<code src="./demos/layout-footer.tsx"  height="500px" iframe="500px" />
+<code src="./demos/layout-footer.tsx" height="500px" iframe="500px"></code>
 
 ### Money
 
-<code src="./demos/money.tsx" height="248px" title="Money" />
+<code src="./demos/money.tsx" height="248px" title="Money"></code>
 
 ### Form linkage
 
-<code src="./demos/linkage-customization.tsx" height="1774px" />
+<code src="./demos/linkage-customization.tsx" height="1774px"></code>
 
 ## Layouts API
 

--- a/packages/form/src/form.md
+++ b/packages/form/src/form.md
@@ -75,7 +75,7 @@ ProForm 是基于 antd Form 的可降级封装，与 antd 功能完全对齐，�
 | [LightFilter](/components/query-filter) | 一般用于作为行内内置的筛选，比如卡片操作栏和 表格操作栏。 |
 | [StepsForm](/components/steps-form) | 分步表单，需要配置 StepForm 使用。 |
 
-<code src="./demos/layout-change.tsx" height="709px" title="Form 的 layout 切换"/>
+<code src="./demos/layout-change.tsx" height="709px" title="Form 的 layout 切换"></code>
 
 ## 数据转化
 
@@ -160,52 +160,51 @@ formRef 内置了几个方法来获取转化之后的值，这也是相比 antd 
 
 ### 基本使用
 
-<code src="./demos/base.tsx" height="974px" title="基本使用"/>
+<code src="./demos/base.tsx" height="974px" title="基本使用"></code>
 
 ### 标签与表单项布局
 
 除了 `LightFilter` 和 `QueryFilter` 这样固定布局的表单样式，其他表单布局支持配置与 `antd` 一致的三种布局方式。
 
-<code src="./demos/form-layout.tsx" title="标签与表单项布局" height="337px"/>
+<code src="./demos/form-layout.tsx" title="标签与表单项布局" height="337px"></code>
 
 ### 栅格化布局
 
 同时支持在 `ProForm`, `SchemaForm`, `ModalForm`, `DrawerForm`, `StepsForm` 中使用
 
-<code src="./demos/form-layout-grid.tsx" title="栅格化布局" height="437px"/>
+<code src="./demos/form-layout-grid.tsx" title="栅格化布局" height="437px"></code>
 
 ### 表单联动
 
-<code src="./demos/dependency.tsx" height="457px" title="表单联动"/>
+<code src="./demos/dependency.tsx" height="457px" title="表单联动"></code>
 
 ### 表单方法调用
 
 你可以通过 `formRef` 获取到表单实例的引用，通过引用可以调用表单方法实现表单重置，设置表单，获取表单值等功能。
 
-<code src="./demos/formRef.tsx" height="341px" title="表单方法调用"/>
+<code src="./demos/formRef.tsx" height="341px" title="表单方法调用"></code>
 
 ### 同步提交结果到 url
 
 打开时也会把 url 的参数设置为默认值，支持 transform, 但是要注意字段的映射。
 
-<code src="./demos/sync-to-url.tsx" height="371px" title="同步提交结果到 url"/>
+<code src="./demos/sync-to-url.tsx" height="371px" title="同步提交结果到 url"></code>
 
 ### 金额
 
-<code src="./demos/money.tsx" height="629px" title="金额"/>
+<code src="./demos/money.tsx" height="629px" title="金额"></code>
 
 ### 固定页脚
 
-<code src="./demos/layout-footer.tsx" height="500px" iframe="874px" title="固定页脚"/>
+<code src="./demos/layout-footer.tsx" height="500px" iframe="874px" title="固定页脚"></code>
 
 ### ProForm 和 EditableTable 同时使用
 
-<code src="./demos/pro-form-editableTable.tsx" height="534px" title="ProForm 和 EditableTable 同时使用"/>
+<code src="./demos/pro-form-editableTable.tsx" height="534px" title="ProForm 和 EditableTable 同时使用"></code>
 
-<code src="./demos/linkage-customization.tsx" height="1774px" debug/>
+<code src="./demos/linkage-customization.tsx" height="1774px" debug></code>
 
-<code src="./demos/pro-form-dependency.debug.tsx" height="548px" title="formRef的使用" debug />
-<code src="./demos/label-col.tsx" height="548px"  debug />
+<code src="./demos/pro-form-dependency.debug.tsx" height="548px" title="formRef的使用" debug></code> <code src="./demos/label-col.tsx" height="548px" debug></code>
 
 ## ProForm
 
@@ -332,7 +331,7 @@ ProFormInstance 与 antd 的 form 相比增加了一些能力。
 
 该属性是 ProForm 在原有的 Antd 的 `FormInstance` 的基础上做的一个上层分装，增加了一些更加便捷的方法。使用方式如下：
 
-<code src="./demos/formRef.tsx" height="341px" title="formRef的使用"/>
+<code src="./demos/formRef.tsx" height="341px" title="formRef的使用"></code>
 
 ```tsx | pure
 import type { ProFormInstance } from '@ant-design/pro-components';

--- a/packages/layout/src/components/PageContainer/index.en-US.md
+++ b/packages/layout/src/components/PageContainer/index.en-US.md
@@ -50,11 +50,11 @@ We have added a footer attribute to make it easier to do things like forms, so y
 
 ### Basic usage
 
-<code src="./demos/basic.tsx" />
+<code src="./demos/basic.tsx"></code>
 
 ### Fixed table headers
 
-<code src="./demos/fixHeader.tsx" />
+<code src="./demos/fixHeader.tsx"></code>
 
 ### Hide breadcrumbs
 
@@ -62,7 +62,7 @@ We have added a footer attribute to make it easier to do things like forms, so y
 
 ### page loading
 
-<code src="./demos/loading.tsx" />
+<code src="./demos/loading.tsx"></code>
 
 ## API
 

--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -50,19 +50,19 @@ PageContainer 封装了 antd 的 PageHeader 组件，增加了 tabList 和 conte
 
 ### 基本使用
 
-<code src="./demos/basic.tsx" height="500px" iframe="665px" title="基本使用" desc="基本使用"/>
+<code src="./demos/basic.tsx" height="500px" iframe="665px" title="基本使用" desc="基本使用"></code>
 
 ### 固定表头
 
-<code src="./demos/fixHeader.tsx" height="500px" iframe="665px" title="固定表头" desc="通过 `fixedHeader` 固定表头，只有在溢出容器时才会开始计算。"/>
+<code src="./demos/fixHeader.tsx" height="500px" iframe="665px" title="固定表头" desc="通过 `fixedHeader` 固定表头，只有在溢出容器时才会开始计算。"></code>
 
 ### 隐藏面包屑
 
-<code src="./demos/hideBreadMenu.tsx" height="500px" iframe="665px" title="隐藏面包屑" desc="不配置 `header` 属性中的 `breadcrumb` 即可。"/>
+<code src="./demos/hideBreadMenu.tsx" height="500px" iframe="665px" title="隐藏面包屑" desc="不配置 `header` 属性中的 `breadcrumb` 即可。"></code>
 
 ### 页面加载中
 
-<code src="./demos/loading.tsx" height="500px" iframe="965px" title="页面加载中" desc="通过 `loading` 属性配置页面加载。"/>
+<code src="./demos/loading.tsx" height="500px" iframe="965px" title="页面加载中" desc="通过 `loading` 属性配置页面加载。"></code>
 
 ## API
 

--- a/packages/layout/src/components/WaterMark/index.md
+++ b/packages/layout/src/components/WaterMark/index.md
@@ -23,31 +23,31 @@ nav:
 
 水印组件默认实现为前置水印，即设想水印会显示在内容的上方，zIndex 默认设置为 9，如果你不希望水印遮挡上层内容，可以调整该值到小于上层内容的 zIndex。
 
-<code src="./demos/frontend.tsx" height="654px"/>
+<code src="./demos/frontend.tsx" height="654px"></code>
 
 ### 文字水印
 
 通过 `content` 指定文字水印内容。
 
-<code src="./demos/text.tsx" height="581px"/>
+<code src="./demos/text.tsx" height="581px"></code>
 
 ### 多行文字水印
 
 通过 `content`设置 字符串数组 指定多行文字水印内容。
 
-<code src="./demos/textRows.tsx" height="581px"/>
+<code src="./demos/textRows.tsx" height="581px"></code>
 
 ### 图片水印
 
 通过 `image` 指定图片地址。为保证图片高清且不被拉伸，请传入水印图片的宽高 width 和 height, 并上传至少两倍的宽高的 logo 图片地址。
 
-<code src="./demos/image.tsx" height="581px"/>
+<code src="./demos/image.tsx" height="581px"></code>
 
 ### 自定义配置
 
 这里给出一些通用配置项。如需进一步配置请联系我们。
 
-<code src="./demos/custom.tsx" background="#f7f8fa"/>
+<code src="./demos/custom.tsx" background="#f7f8fa"></code>
 
 ## API
 

--- a/packages/layout/src/layout.en-US.md
+++ b/packages/layout/src/layout.en-US.md
@@ -62,7 +62,7 @@ ProLayout will automatically select the menu based on `location.pathname` and au
 
 ### Basic usage
 
-<code src="./demos/base.tsx"  height="500px" iframe="650px" />
+<code src="./demos/base.tsx" height="500px" iframe="650px"></code>
 
 ### Load menu from server
 
@@ -70,57 +70,57 @@ ProLayout provides a powerful menu, but this necessarily encapsulates a lot of b
 
 The main APIs used to load menu from the server are `menuDataRender` and `menuRender`, `menuDataRender` controls the current menu data and `menuRender` controls the menu's dom node.
 
-<code src="./demos/dynamicMenu.tsx"  height="500px" iframe="500px" />
+<code src="./demos/dynamicMenu.tsx" height="500px" iframe="500px"></code>
 
 ### Load the menu from the server and use the icon
 
 Here is mainly a demo where we need to prepare an enumeration for icon rendering, which can significantly reduce the size of the package
 
-<code src="./demos/antd@4MenuIconFormServe.tsx"  height="500px" iframe="500px" />
+<code src="./demos/antd@4MenuIconFormServe.tsx" height="500px" iframe="500px"></code>
 
 ### Customize the content of the menu
 
 With `menuItemRender`, `subMenuItemRender`, `title`, `logo`, `menuHeaderRender` you can customize the menu style very easily. If you are really not satisfied, you can use `menuRender` to fully customize it.
 
-<code src="./demos/customizeMenu.tsx"  height="500px" iframe="500px" />
+<code src="./demos/customizeMenu.tsx" height="500px" iframe="500px"></code>
 
 ### Custom footer
 
 ProLayout does not provide footer by default, if you want to have the same style as Pro official website, you need to introduce a footer by yourself.
 
-<code src="./demos/footer.tsx"  height="500px" iframe="500px" />
+<code src="./demos/footer.tsx" height="500px" iframe="500px"></code>
 
 This is used to show various applications of ProLayout, if you think your usage can help others, feel free to PR.
 
 ### Search menu
 
-<code src="./demos/searchMenu.tsx"  height="500px" iframe="500px" />
+<code src="./demos/searchMenu.tsx" height="500px" iframe="500px"></code>
 
 ### Multiple routes correspond to one menu item
 
-<code src="./demos/MultipleMenuOnePath.tsx"  height="500px" iframe="500px" />
+<code src="./demos/MultipleMenuOnePath.tsx" height="500px" iframe="500px"></code>
 
 ### Open all menus by default
 
-<code src="./demos/DefaultOpenAllMenu.tsx"  height="500px" iframe="500px" />
+<code src="./demos/DefaultOpenAllMenu.tsx" height="500px" iframe="500px"></code>
 
 ### Using IconFont
 
-<code src="./demos/IconFont.tsx"  height="500px" iframe="500px" />
+<code src="./demos/IconFont.tsx" height="500px" iframe="500px"></code>
 
 ### ghost mode
 
 PageContainer configuration `ghost` can switch the page header to transparent mode.
 
-<code src="./demos/ghost.tsx"  height="500px" iframe="500px" />
+<code src="./demos/ghost.tsx" height="500px" iframe="500px"></code>
 
 ### Nested Layout
 
-<code src="./demos/Nested.tsx"  height="500px" iframe="500px" />
+<code src="./demos/Nested.tsx" height="500px" iframe="500px"></code>
 
 ### Customized collapsed
 
-<code src="./demos/customize-collapsed.tsx"  height="500px" iframe="500px" />
+<code src="./demos/customize-collapsed.tsx" height="500px" iframe="500px"></code>
 
 ## API
 

--- a/packages/layout/src/layout.md
+++ b/packages/layout/src/layout.md
@@ -21,67 +21,67 @@ ProLayout 可以提供一个标准又不失灵活的中后台标准布局，同�
 
 ### 基础使用
 
-<code src="./demos/base.tsx" height="500px" iframe="760px" title="基础使用"/>
+<code src="./demos/base.tsx" height="500px" iframe="760px" title="基础使用"></code>
 
 ### 通过 token 修改样式
 
-<code src="./demos/theme.tsx" iframe="650px" title="通过 token 修改样式"/>
+<code src="./demos/theme.tsx" iframe="650px" title="通过 token 修改样式"></code>
 
 ### 黑色主题
 
-<code src="./demos/dark.tsx" iframe="650px" title="黑色主题"/>
+<code src="./demos/dark.tsx" iframe="650px" title="黑色主题"></code>
 
 ### 侧栏导航
 
-<code src="./demos/siderMode.tsx" iframe="650px" title="侧栏导航 中后台产品默认推荐"/>
+<code src="./demos/siderMode.tsx" iframe="650px" title="侧栏导航 中后台产品默认推荐"></code>
 
 ### 混合导航
 
-<code src="./demos/mixMode.tsx" iframe="650px" title="混合导航"/>
+<code src="./demos/mixMode.tsx" iframe="650px" title="混合导航"></code>
 
 ### 顶部导航
 
-<code src="./demos/topMode.tsx" iframe="650px" title="顶部导航"/>
+<code src="./demos/topMode.tsx" iframe="650px" title="顶部导航"></code>
 
 ### 定制侧栏宽度
 
-<code src="./demos/designSiderMenu.tsx" iframe="650px" title="侧栏导航宽度256px"/>
+<code src="./demos/designSiderMenu.tsx" iframe="650px" title="侧栏导航宽度256px"></code>
 
 ### 页脚工具栏和全局公告
 
-<code src="./demos/footer-global-tools.tsx" iframe="650px" title="页脚工具栏和全局公告"/>
+<code src="./demos/footer-global-tools.tsx" iframe="650px" title="页脚工具栏和全局公告"></code>
 
 ### 收起时展示 title
 
-<code src="./demos/collapsedShowTitle.tsx" iframe="650px" title=" 收起时展示 title"/>
+<code src="./demos/collapsedShowTitle.tsx" iframe="650px" title=" 收起时展示 title"></code>
 
 ### 不分组菜单样式
 
-<code src="./demos/menu-group.tsx" iframe="650px" title="不分组菜单样式"/>
+<code src="./demos/menu-group.tsx" iframe="650px" title="不分组菜单样式"></code>
 
 ### 经典导航样式
 
-<code src="./demos/classicMode.tsx" iframe="650px" title="经典导航样式"/>
+<code src="./demos/classicMode.tsx" iframe="650px" title="经典导航样式"></code>
 
 ### 通过调整页面背景内容调整整体氛围
 
-<code src="./demos/background-context.tsx" iframe="650px" title="通过调整页面背景内容调整整体氛围"/>
+<code src="./demos/background-context.tsx" iframe="650px" title="通过调整页面背景内容调整整体氛围"></code>
 
 ### 定制菜单样式
 
-<code src="./demos/designMenuCss.tsx" iframe="650px" title="定制菜单样式"/>
+<code src="./demos/designMenuCss.tsx" iframe="650px" title="定制菜单样式"></code>
 
 ### 通过设置页背景和卡片样式简化界面层次
 
-<code src="./demos/pageSimplify.tsx" iframe="650px" title="通过设置页背景和卡片样式简化界面层次"/>
+<code src="./demos/pageSimplify.tsx" iframe="650px" title="通过设置页背景和卡片样式简化界面层次"></code>
 
 ### 自定侧栏菜单下方区域
 
-<code src="./demos/customSider.tsx" iframe="650px" title="自定侧栏菜单下方区域"/>
+<code src="./demos/customSider.tsx" iframe="650px" title="自定侧栏菜单下方区域"></code>
 
 ### 菜单展开-站点地图
 
-<code src="./demos/siteMenu.tsx" iframe="650px" title="菜单展开-站点地图"/>
+<code src="./demos/siteMenu.tsx" iframe="650px" title="菜单展开-站点地图"></code>
 
 ### 从服务器加载 menu
 
@@ -89,87 +89,87 @@ ProLayout 提供了强大的菜单功能，但是这样必然会封装很多行�
 
 从服务器加载 menu 主要使用的 API 是 `menuDataRender` 和 `menuRender`,`menuDataRender`可以控制当前的菜单数据，`menuRender`可以控制菜单的 dom 节点。
 
-<code src="./demos/dynamicMenu.tsx" height="500px" iframe="610px" title="从服务器加载 menu"/>
+<code src="./demos/dynamicMenu.tsx" height="500px" iframe="610px" title="从服务器加载 menu"></code>
 
 ### 从服务器加载 menu 并且使用 icon
 
 这里主要是一个演示，我们需要准备一个枚举来进行 icon 的渲染，可以显著的减少打包的大小
 
-<code src="./demos/antd@4MenuIconFormServe.tsx" height="500px" iframe="610px" title="从服务器加载 menu 并且使用 icon"/>
+<code src="./demos/antd@4MenuIconFormServe.tsx" height="500px" iframe="610px" title="从服务器加载 menu 并且使用 icon"></code>
 
 ### 自定义 menu 的内容
 
 通过 `menuItemRender`, `subMenuItemRender`,`title`,`logo`,`menuHeaderRender` 可以非常方便的自定义 menu 的样式。如果实在是不满意，可以使用 `menuRender` 完全的自定义。
 
-<code src="./demos/customizeMenu.tsx" height="500px" iframe="610px" title="自定义 menu 的内容"/>
+<code src="./demos/customizeMenu.tsx" height="500px" iframe="610px" title="自定义 menu 的内容"></code>
 
 ### 自定义页脚
 
 ProLayout 默认不提供页脚，要是和 Pro 官网相同的样式，需要自己引入一下页脚。
 
-<code src="./demos/footer.tsx" height="500px" iframe="610px" title="自定义页脚"/>
+<code src="./demos/footer.tsx" height="500px" iframe="610px" title="自定义页脚"></code>
 
 这里用于展示 ProLayout 的各种应用，如果你觉得你的用法能帮助到别人，欢迎 PR。
 
 ### 搜索菜单
 
-<code src="./demos/searchMenu.tsx" height="500px" iframe="610px" title="搜索菜单"/>
+<code src="./demos/searchMenu.tsx" height="500px" iframe="610px" title="搜索菜单"></code>
 
 ### 多个路由对应一个菜单项
 
-<code src="./demos/MultipleMenuOnePath.tsx" height="500px" iframe="610px" title="多个路由对应一个菜单项"/>
+<code src="./demos/MultipleMenuOnePath.tsx" height="500px" iframe="610px" title="多个路由对应一个菜单项"></code>
 
 ### 默认打开所有菜单
 
 menu 配置 `defaultOpenAll` 可以默认打开所有菜单
 
-<code src="./demos/DefaultOpenAllMenu.tsx" height="500px" iframe="610px" title="默认打开所有菜单"/>
+<code src="./demos/DefaultOpenAllMenu.tsx" height="500px" iframe="610px" title="默认打开所有菜单"></code>
 
 ### 总是打开所有菜单
 
 折叠按钮反复切换后 `defaultOpenAll` 将失效，menu 配置 `ignoreFlatMenu` 可以忽略手动折叠过的菜单，实现总是默认打开所有菜单。因为计算时机在组件渲染前，所以异步菜单不生效。
 
-<code src="./demos/AlwaysDefaultOpenAllMenu.tsx" height="500px" iframe="610px" title="总是默认打开所有菜单"/>
+<code src="./demos/AlwaysDefaultOpenAllMenu.tsx" height="500px" iframe="610px" title="总是默认打开所有菜单"></code>
 
 ### 使用 IconFont
 
-<code src="./demos/IconFont.tsx" height="500px" iframe="610px" title="使用 IconFont"/>
+<code src="./demos/IconFont.tsx" height="500px" iframe="610px" title="使用 IconFont"></code>
 
 ### 吸顶 header
 
 PageContainer 配置 `fixedHeader` 可以将吸顶 header。
 
-<code src="./demos/ghost.tsx" height="500px" iframe="610px" title="ghost 模式"/>
+<code src="./demos/ghost.tsx" height="500px" iframe="610px" title="ghost 模式"></code>
 
 ### 嵌套布局
 
-<code src="./demos/Nested.tsx" height="500px" iframe="610px" title="嵌套布局"/>
+<code src="./demos/Nested.tsx" height="500px" iframe="610px" title="嵌套布局"></code>
 
 ### 自定义的 collapsed
 
-<code src="./demos/customize-collapsed.tsx" height="500px" iframe="610px" title="自定义的 collapsed"/>
+<code src="./demos/customize-collapsed.tsx" height="500px" iframe="610px" title="自定义的 collapsed"></code>
 
 ### 面包屑显示在顶部
 
-<code src="./demos/top-breadcrumb.tsx" height="500px" iframe="610px" title="面包屑显示在顶部"/>
+<code src="./demos/top-breadcrumb.tsx" height="500px" iframe="610px" title="面包屑显示在顶部"></code>
 
 ### 多级站点导航
 
-<code src="./demos/immersive-navigation.tsx" height="500px" iframe="610px" title="多级站点导航"/>
+<code src="./demos/immersive-navigation.tsx" height="500px" iframe="610px" title="多级站点导航"></code>
 
 ### 沉浸式导航
 
-<code src="./demos/immersive-navigation-top.tsx" height="500px" iframe="610px" title="沉浸式导航"/>
+<code src="./demos/immersive-navigation-top.tsx" height="500px" iframe="610px" title="沉浸式导航"></code>
 
 ### 跨站点导航
 
-> 使用默认卡片展示，请确保每一项都有 desc，且值为真；使用分组展示，请确保每一项都有 children，且长度大于 0； <code src="./demos/appList-group.tsx" height="500px" iframe="610px" title="跨站点导航列表 分组模式"/>
+> 使用默认卡片展示，请确保每一项都有 desc，且值为真；使用分组展示，请确保每一项都有 children，且长度大于 0； <code src="./demos/appList-group.tsx" height="500px" iframe="610px" title="跨站点导航列表 分组模式"></code>
 
 ### layout 自带了错误处理功能，防止白屏
 
-<code src="./demos/error-boundaries.tsx" height="500px" iframe="610px" title="沉浸式导航"/>
+<code src="./demos/error-boundaries.tsx" height="500px" iframe="610px" title="沉浸式导航"></code>
 
-<code src="./demos/splitMenus.tsx"  height="500px" iframe="500px" title="沉浸式导航" debug />
+<code src="./demos/splitMenus.tsx" height="500px" iframe="500px" title="沉浸式导航" debug></code>
 
 ## API
 

--- a/packages/list/src/list.en-US.md
+++ b/packages/list/src/list.en-US.md
@@ -18,47 +18,47 @@ Based on ProTable implementation, it can be considered as a special case of ProT
 
 ### Basic usage
 
-<code src="./demos/base.tsx" background="#f5f5f5" title="Basic usage" />
+<code src="./demos/base.tsx" background="#f5f5f5" title="Basic usage"></code>
 
 ### Edit list
 
-<code src="./demos/editable.tsx" background="#f5f5f5" title="Edit list" />
+<code src="./demos/editable.tsx" background="#f5f5f5" title="Edit list"></code>
 
 ### Support for expanded lists
 
-<code src="./demos/expand.tsx" background="#f5f5f5" title="Expandable list" />
+<code src="./demos/expand.tsx" background="#f5f5f5" title="Expandable list"></code>
 
 ### Supports checked list
 
-<code src="./demos/selectedRow.tsx" background="#f5f5f5" title="Support selected list"/>
+<code src="./demos/selectedRow.tsx" background="#f5f5f5" title="Support selected list"></code>
 
 ### Query list
 
-<code src="./demos/search.tsx" background="#f5f5f5" title="Search list" />
+<code src="./demos/search.tsx" background="#f5f5f5" title="Search list"></code>
 
 ### List with filters and asynchronous requests
 
-<code src="./demos/filter.tsx" background="#f5f5f5" title="List with filtering and asynchronous requests" />
+<code src="./demos/filter.tsx" background="#f5f5f5" title="List with filtering and asynchronous requests"></code>
 
 ### Size and dividing line
 
-<code src="./demos/size.tsx" background="#f5f5f5" title="Size and divider" />
+<code src="./demos/size.tsx" background="#f5f5f5" title="Size and divider"></code>
 
 ### Vertical style
 
-<code src="./demos/layout.tsx" background="#f5f5f5" title="vertical style" />
+<code src="./demos/layout.tsx" background="#f5f5f5" title="vertical style"></code>
 
 ### some preset modes
 
-<code src="./demos/special.tsx" background="#f5f5f5" title="Some preset modes" />
+<code src="./demos/special.tsx" background="#f5f5f5" title="Some preset modes"></code>
 
 ### page turn
 
-<code src="./demos/pagination.tsx" background="#f5f5f5" title="Pagination" />
+<code src="./demos/pagination.tsx" background="#f5f5f5" title="Pagination"></code>
 
 ### Card List
 
-<code src="./demos/card-list.tsx" background="#f5f5f5" title="Card list" />
+<code src="./demos/card-list.tsx" background="#f5f5f5" title="Card list"></code>
 
 ##API
 

--- a/packages/list/src/list.md
+++ b/packages/list/src/list.md
@@ -18,51 +18,51 @@ nav:
 
 ### 基本使用
 
-<code src="./demos/base.tsx" background="#f5f5f5" title="基本使用" height="459px"/>
+<code src="./demos/base.tsx" background="#f5f5f5" title="基本使用" height="459px"></code>
 
 ### 编辑列表
 
-<code src="./demos/editable.tsx" background="#f5f5f5" title="编辑列表" height="443px"/>
+<code src="./demos/editable.tsx" background="#f5f5f5" title="编辑列表" height="443px"></code>
 
 ### 带工具栏的列表
 
-<code src="./demos/ToolBar.tsx" background="#f5f5f5" title="带工具栏的列表" height="385px"/>
+<code src="./demos/ToolBar.tsx" background="#f5f5f5" title="带工具栏的列表" height="385px"></code>
 
 ### 支持展开的列表
 
-<code src="./demos/expand.tsx" background="#f5f5f5" title="支持展开的列表" height="371px"/>
+<code src="./demos/expand.tsx" background="#f5f5f5" title="支持展开的列表" height="371px"></code>
 
 ### 支持选中的列表
 
-<code src="./demos/selectedRow.tsx" background="#f5f5f5" title="支持选中的列表" height="545px"/>
+<code src="./demos/selectedRow.tsx" background="#f5f5f5" title="支持选中的列表" height="545px"></code>
 
 ### 查询列表
 
-<code src="./demos/search.tsx" background="#f5f5f5" title="查询列表" height="709px"/>
+<code src="./demos/search.tsx" background="#f5f5f5" title="查询列表" height="709px"></code>
 
 ### 带筛选和异步请求的列表
 
-<code src="./demos/filter.tsx" background="#f5f5f5" title="带筛选和异步请求的列表" height="613px"/>
+<code src="./demos/filter.tsx" background="#f5f5f5" title="带筛选和异步请求的列表" height="613px"></code>
 
 ### 大小和分割线
 
-<code src="./demos/size.tsx" background="#f5f5f5" title="大小和分割线" height="426px"/>
+<code src="./demos/size.tsx" background="#f5f5f5" title="大小和分割线" height="426px"></code>
 
 ### 竖排样式
 
-<code src="./demos/layout.tsx" background="#f5f5f5" title="竖排样式" height="995px"/>
+<code src="./demos/layout.tsx" background="#f5f5f5" title="竖排样式" height="995px"></code>
 
 ### 一些预设的模式
 
-<code src="./demos/special.tsx" background="#f5f5f5" title="一些预设的模式" height="371px"/>
+<code src="./demos/special.tsx" background="#f5f5f5" title="一些预设的模式" height="371px"></code>
 
 ### 翻页
 
-<code src="./demos/pagination.tsx" background="#f5f5f5" title="翻页" height="574px"/>
+<code src="./demos/pagination.tsx" background="#f5f5f5" title="翻页" height="574px"></code>
 
 ### 卡片列表
 
-<code src="./demos/card-list.tsx" background="#f5f5f5" title="卡片列表" height="950px"/>
+<code src="./demos/card-list.tsx" background="#f5f5f5" title="卡片列表" height="950px"></code>
 
 ## API
 

--- a/packages/skeleton/src/skeleton.en-US.md
+++ b/packages/skeleton/src/skeleton.en-US.md
@@ -25,17 +25,17 @@ return <Skeleton type="list" />;
 
 ### List
 
-<code src="./demos/list.tsx" title="List" />
+<code src="./demos/list.tsx" title="List"></code>
 
-<code src="./demos/list.static.tsx" title="List" debug />
+<code src="./demos/list.static.tsx" title="List" debug></code>
 
 ### Results page
 
-<code src="./demos/result.tsx" title="Results page" />
+<code src="./demos/result.tsx" title="Results page"></code>
 
 ### Details page
 
-<code src="./demos/descriptions.tsx" title="Details page" />
+<code src="./demos/descriptions.tsx" title="Details page"></code>
 
 ## API
 

--- a/packages/skeleton/src/skeleton.md
+++ b/packages/skeleton/src/skeleton.md
@@ -25,17 +25,17 @@ return <Skeleton type="list" />;
 
 ### List
 
-<code src="./demos/list.tsx" title="List" height="903px"/>
+<code src="./demos/list.tsx" title="List" height="903px"></code>
 
-<code src="./demos/list.static.tsx" title="List" debug />
+<code src="./demos/list.static.tsx" title="List" debug></code>
 
 ### 结果页
 
-<code src="./demos/result.tsx" title="结果页" />
+<code src="./demos/result.tsx" title="结果页"></code>
 
 ### 详情页
 
-<code src="./demos/descriptions.tsx" title="详情页" />
+<code src="./demos/descriptions.tsx" title="详情页"></code>
 
 ## API
 

--- a/packages/table/src/components/DragSortTable/index.en-US.md
+++ b/packages/table/src/components/DragSortTable/index.en-US.md
@@ -15,11 +15,11 @@ nav:
 
 ### Drag to sort
 
-<code src="./demos/drag.tsx" background="#f5f5f5" height="360px" title="Drag sort" />
+<code src="./demos/drag.tsx" background="#f5f5f5" height="360px" title="Drag sort"></code>
 
 ### Drag and drop to sort and edit the table
 
-<code src="./demos/drag-sort-table.tsx" background="#f5f5f5" height="360px" title="Editable table" />
+<code src="./demos/drag-sort-table.tsx" background="#f5f5f5" height="360px" title="Editable table"></code>
 
 ## API
 

--- a/packages/table/src/components/DragSortTable/index.md
+++ b/packages/table/src/components/DragSortTable/index.md
@@ -15,11 +15,11 @@ nav:
 
 ### 拖拽排序
 
-<code src="./demos/drag.tsx" background="#f5f5f5" height="437px" title="拖拽排序"/>
+<code src="./demos/drag.tsx" background="#f5f5f5" height="437px" title="拖拽排序"></code>
 
 ### 拖拽排序编辑表格
 
-<code src="./demos/drag-sort-table.tsx" background="#f5f5f5" height="697px" title="可编辑表格"/>
+<code src="./demos/drag-sort-table.tsx" background="#f5f5f5" height="697px" title="可编辑表格"></code>
 
 ## API
 

--- a/packages/table/src/components/EditableTable/index.en-US.md
+++ b/packages/table/src/components/EditableTable/index.en-US.md
@@ -15,19 +15,19 @@ EditableProTable is essentially the same as ProTable, with a few presets added t
 
 ### Editable forms
 
-<code src="./demos/basic.tsx" background="#f5f5f5" height="420px" title="Editable Form" />
+<code src="./demos/basic.tsx" background="#f5f5f5" height="420px" title="Editable Form"></code>
 
 ### Link with content outside the edit form
 
-<code src="./demos/form-linkage.tsx" background="#f5f5f5" height="420px" title="Link with content outside the edit form" />
+<code src="./demos/form-linkage.tsx" background="#f5f5f5" height="420px" title="Link with content outside the edit form"></code>
 
 ### Custom Editable Tables
 
-<code src="./demos/custom.tsx" background="#f5f5f5" height="420px" title="Custom Editable Form" />
+<code src="./demos/custom.tsx" background="#f5f5f5" height="420px" title="Custom Editable Form"></code>
 
 ### Live Saved Editable Forms
 
-<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="420px" title="Real-time saved editing form" />
+<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="420px" title="Real-time saved editing form"></code>
 
 ## API
 

--- a/packages/table/src/components/EditableTable/index.md
+++ b/packages/table/src/components/EditableTable/index.md
@@ -15,27 +15,27 @@ nav:
 
 ### 可编辑表格
 
-<code src="./demos/basic.tsx" background="#f5f5f5" height="443px" title="可编辑表格"/>
+<code src="./demos/basic.tsx" background="#f5f5f5" height="443px" title="可编辑表格"></code>
 
 ### 与 FormItem 配合
 
-<code src="./demos/form-item.tsx" background="#f5f5f5" height="499px" title="与 FormItem 配合"/>
+<code src="./demos/form-item.tsx" background="#f5f5f5" height="499px" title="与 FormItem 配合"></code>
 
 ### 与编辑表格外的内容联动
 
-<code src="./demos/form-linkage.tsx" background="#f5f5f5" height="604px" title="与编辑表格外的内容联动"/>
+<code src="./demos/form-linkage.tsx" background="#f5f5f5" height="604px" title="与编辑表格外的内容联动"></code>
 
 ### 有子列的表格增加
 
-<code src="./demos/children.tsx" background="#f5f5f5" height="452px" title="有子列的表格增加"/>
+<code src="./demos/children.tsx" background="#f5f5f5" height="452px" title="有子列的表格增加"></code>
 
 ### 自定义可编辑表格
 
-<code src="./demos/custom.tsx" background="#f5f5f5" height="384px" title="自定义可编辑表格"/>
+<code src="./demos/custom.tsx" background="#f5f5f5" height="384px" title="自定义可编辑表格"></code>
 
 ### 实时保存的编辑表格
 
-<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="1265px" title="实时保存的编辑表格"/>
+<code src="./demos/real-time-editing.tsx" background="#f5f5f5" height="1265px" title="实时保存的编辑表格"></code>
 
 ## API
 

--- a/packages/table/src/table.en-US.md
+++ b/packages/table/src/table.en-US.md
@@ -26,53 +26,53 @@ When your forms need to interact with the server or need multiple cell styles, P
 
 ### Querying a table
 
-<code src="./demos/single.tsx" background="#f5f5f5" height="500px" />
+<code src="./demos/single.tsx" background="#f5f5f5" height="500px"></code>
 
-<code src="./demos/dataSource.tsx" background="#f5f5f5" height="500px" debug/>
+<code src="./demos/dataSource.tsx" background="#f5f5f5" height="500px" debug></code>
 
 ### Downgrade to a normal table
 
-<code src="./demos/normal.tsx" background="#f5f5f5" height="400px"/>
+<code src="./demos/normal.tsx" background="#f5f5f5" height="400px"></code>
 
 ### Lightweight filter replacement query form
 
-<code src="./demos/lightfilter.tsx" background="#f5f5f5" height="400px"/>
+<code src="./demos/lightfilter.tsx" background="#f5f5f5" height="400px"></code>
 
 ### Forms without ToolBar
 
-<code src="./demos/no-title.tsx" height="350px"/>
+<code src="./demos/no-title.tsx" height="350px"></code>
 
 ### Nested tables
 
-<code src="./demos/table-nested.tsx" background="#f5f5f5" height="400px"/>
+<code src="./demos/table-nested.tsx" background="#f5f5f5" height="400px"></code>
 
 ### Left and right structure
 
-<code src="./demos/split.tsx" background="#f5f5f5" height="500px"/>
+<code src="./demos/split.tsx" background="#f5f5f5" height="500px"></code>
 
 ### Batch manipulation of tables
 
-<code src="./demos/batchOption.tsx" background="#f5f5f5" height="420px"/>
+<code src="./demos/batchOption.tsx" background="#f5f5f5" height="420px"></code>
 
 ### Manipulating query forms with formRef
 
-<code src="./demos/form.tsx" background="#f5f5f5" height="320px"/>
+<code src="./demos/form.tsx" background="#f5f5f5" height="320px"></code>
 
 ### RTL (النسخة العربية)
 
 RTL means right-to-left.
 
-<code src="./demos/rtl_table.tsx" background="#f5f5f5" height="500px"/>
+<code src="./demos/rtl_table.tsx" background="#f5f5f5" height="500px"></code>
 
 ### Controlled table settings columns
 
 You can hide some columns by default, but in the action column you can select
 
-<code src="./demos/columnsStateMap.tsx" background="#f5f5f5" height="300px"/>
+<code src="./demos/columnsStateMap.tsx" background="#f5f5f5" height="300px"></code>
 
 ### Tables polling network data
 
-<code src="./demos/pollinga.tsx" background="#f5f5f5" height="360px"/>
+<code src="./demos/pollinga.tsx" background="#f5f5f5" height="360px"></code>
 
 ### Search form customization
 
@@ -111,27 +111,27 @@ The definition of `renderFormItem`, the exact value of which can be seen by open
   ) => JSX.Element | false | null;
 ```
 
-<code src="./demos/linkage_form.tsx" background="#f5f5f5" height="310px"/>
+<code src="./demos/linkage_form.tsx" background="#f5f5f5" height="310px"></code>
 
 ### Form action customization
 
-<code src="./demos/search_option.tsx" background="#f5f5f5" height="310px"/>
+<code src="./demos/search_option.tsx" background="#f5f5f5" height="310px"></code>
 
 ### Toolbar Customization
 
 Configure toolbar rendering using the `toolbar` property extension.
 
-<code src="./demos/listToolBar.tsx" background="#f5f5f5" height="450px"/>
+<code src="./demos/listToolBar.tsx" background="#f5f5f5" height="450px"></code>
 
 ### Required Inquiry Form
 
 Try to use initialValue to solve the problem, required fields are more frustrating
 
-<code src="./demos/open-rules.tsx"  height="350px"/>
+<code src="./demos/open-rules.tsx" height="350px"></code>
 
 ### Form body customization
 
-<code src="./demos/renderTable.tsx" background="#f5f5f5" height="500px"/>
+<code src="./demos/renderTable.tsx" background="#f5f5f5" height="500px"></code>
 
 ### Internationalization-related configuration
 
@@ -187,31 +187,31 @@ import { ConfigProvider } from '@ant-design/pro-provide';
 </ConfigProvider>;
 ```
 
-<code src="./demos/intl.tsx" background="#f5f5f5" height="320px"/>
+<code src="./demos/intl.tsx" background="#f5f5f5" height="320px"></code>
 
 ### Table using self-contained keyWords search
 
-<code src="./demos/search.tsx" background="#f5f5f5" height="200px"/>
+<code src="./demos/search.tsx" background="#f5f5f5" height="200px"></code>
 
 ### Value type examples
 
 #### valueType - Date class
 
-<code src="./demos/valueTypeDate.tsx" background="#f5f5f5" height="350px"/>
+<code src="./demos/valueTypeDate.tsx" background="#f5f5f5" height="350px"></code>
 
 #### valueType - numeric class
 
-<code src="./demos/valueTypeNumber.tsx" background="#f5f5f5" height="350px"/>
+<code src="./demos/valueTypeNumber.tsx" background="#f5f5f5" height="350px"></code>
 
 #### valueType - Style Classes
 
-<code src="./demos/valueType.tsx" background="#f5f5f5" height="680px"/>
+<code src="./demos/valueType.tsx" background="#f5f5f5" height="680px"></code>
 
 #### valueType - Selection Classes
 
-<code src="./demos/valueType_select.tsx" background="#f5f5f5" height="462px"/>
+<code src="./demos/valueType_select.tsx" background="#f5f5f5" height="462px"></code>
 
-<code src="./demos/config-provider.tsx" debug background="#f5f5f5" height="462px"/>
+<code src="./demos/config-provider.tsx" debug background="#f5f5f5" height="462px"></code>
 
 ## API
 
@@ -459,15 +459,15 @@ Toolbar section for customizing forms.
 
 #### Code Demo
 
-<code src="./demos/ListToolBar/basic.tsx" background="#f7f8fa"/>
+<code src="./demos/ListToolBar/basic.tsx" background="#f7f8fa"></code>
 
-<code src="./demos/ListToolBar/no-title.tsx" background="#f7f8fa"/>
+<code src="./demos/ListToolBar/no-title.tsx" background="#f7f8fa"></code>
 
-<code src="./demos/ListToolBar/multipleLine.tsx" background="#f7f8fa"/>
+<code src="./demos/ListToolBar/multipleLine.tsx" background="#f7f8fa"></code>
 
-<code src="./demos/ListToolBar/tabs.tsx" background="#f7f8fa"/>
+<code src="./demos/ListToolBar/tabs.tsx" background="#f7f8fa"></code>
 
-<code src="./demos/ListToolBar/menu.tsx" background="#f7f8fa"/>
+<code src="./demos/ListToolBar/menu.tsx" background="#f7f8fa"></code>
 
 #### ListToolBarProps
 

--- a/packages/table/src/table.md
+++ b/packages/table/src/table.md
@@ -28,73 +28,73 @@ ProTable 的诞生是为了解决项目中需要写很多 table 的样板代码�
 
 ### 查询表格
 
-<code src="./demos/single.tsx" background="#f5f5f5" height="610px" title="查询表格"/>
+<code src="./demos/single.tsx" background="#f5f5f5" height="610px" title="查询表格"></code>
 
 ### 黑色主紧凑主题
 
-<code src="./demos/theme.tsx" background="#141414" height="610px" title="查询表格"/>
+<code src="./demos/theme.tsx" background="#141414" height="610px" title="查询表格"></code>
 
-<code src="./demos/single-test.tsx" debug background="#f5f5f5" height="500px" title="查询表格" />
+<code src="./demos/single-test.tsx" debug background="#f5f5f5" height="500px" title="查询表格"></code>
 
 ### 查询（无按钮）表格
 
-<code src="./demos/no-option.tsx" background="#f5f5f5" height="659px" title="查询（无按钮）表格"/>
+<code src="./demos/no-option.tsx" background="#f5f5f5" height="659px" title="查询（无按钮）表格"></code>
 
-<code src="./demos/dataSource.tsx" background="#f5f5f5" height="500px" title="DataSource" debug />
+<code src="./demos/dataSource.tsx" background="#f5f5f5" height="500px" title="DataSource" debug></code>
 
 ### 无查询表单
 
-<code src="./demos/normal.tsx" background="#f5f5f5" height="507px" title="无查询表单"/>
+<code src="./demos/normal.tsx" background="#f5f5f5" height="507px" title="无查询表单"></code>
 
 ### 轻量筛选替换查询表单
 
-<code src="./demos/lightfilter.tsx" background="#f5f5f5" height="507px" title="轻量筛选替换查询表单"/>
+<code src="./demos/lightfilter.tsx" background="#f5f5f5" height="507px" title="轻量筛选替换查询表单"></code>
 
 ### 无 ToolBar 的表格
 
-<code src="./demos/no-title.tsx" background="#f5f5f5"  height="426px" title="无 ToolBar 的表格"/>
+<code src="./demos/no-title.tsx" background="#f5f5f5" height="426px" title="无 ToolBar 的表格"></code>
 
 ### 必填的查询表单
 
 尽量使用 initialValue 来解决问题，必填项挫败感比较强
 
-<code src="./demos/open-rules.tsx" background="#f5f5f5"  height="718px" title="必填的查询表单"/>
+<code src="./demos/open-rules.tsx" background="#f5f5f5" height="718px" title="必填的查询表单"></code>
 
 ### 嵌套表格
 
-<code src="./demos/table-nested.tsx" background="#f5f5f5" height="510px" title="嵌套表格"/>
+<code src="./demos/table-nested.tsx" background="#f5f5f5" height="510px" title="嵌套表格"></code>
 
 ### 左右结构
 
-<code src="./demos/split.tsx" background="#f5f5f5" height="687px" title="左右结构"/>
+<code src="./demos/split.tsx" background="#f5f5f5" height="687px" title="左右结构"></code>
 
 ### 表格批量操作
 
-<code src="./demos/batchOption.tsx" background="#f5f5f5" height="571px" title="表格批量操作"/>
+<code src="./demos/batchOption.tsx" background="#f5f5f5" height="571px" title="表格批量操作"></code>
 
 ### 通过 formRef 来操作查询表单
 
-<code src="./demos/form.tsx" background="#f5f5f5" height="415px" title="通过 formRef 来操作查询表单"/>
+<code src="./demos/form.tsx" background="#f5f5f5" height="415px" title="通过 formRef 来操作查询表单"></code>
 
 ### RTL (النسخة العربية)
 
 RTL means right-to-left.
 
-<code src="./demos/rtl_table.tsx" background="#f5f5f5" height="606px" title="RTL (النسخة العربية)"/>
+<code src="./demos/rtl_table.tsx" background="#f5f5f5" height="606px" title="RTL (النسخة العربية)"></code>
 
 ### 受控的表格设置栏
 
 可以默认隐藏某些栏，但是在操作栏中可以选择
 
-<code src="./demos/columnsStateMap.tsx" background="#f5f5f5" height="366px" title="受控的表格设置栏"/>
+<code src="./demos/columnsStateMap.tsx" background="#f5f5f5" height="366px" title="受控的表格设置栏"></code>
 
 ### 表格轮询
 
-<code src="./demos/pollinga.tsx" background="#f5f5f5" height="462px" title="表格轮询"/>
+<code src="./demos/pollinga.tsx" background="#f5f5f5" height="462px" title="表格轮询"></code>
 
 ### dateFormatter - 日期格式化
 
-<code src="./demos/dateFormatter.tsx" background="#f5f5f5" height="1099px" title="日期格式化"/>
+<code src="./demos/dateFormatter.tsx" background="#f5f5f5" height="1099px" title="日期格式化"></code>
 
 ### 搜索表单自定义
 
@@ -140,7 +140,7 @@ renderFormItem: (_, { type, defaultRender, formItemProps, fieldProps, ...rest },
   ) => JSX.Element | false | null;
 ```
 
-<code src="./demos/linkage_form.tsx" background="#f5f5f5" height="471px" title="搜索表单自定义"/>
+<code src="./demos/linkage_form.tsx" background="#f5f5f5" height="471px" title="搜索表单自定义"></code>
 
 #### FAQ
 
@@ -160,23 +160,23 @@ renderFormItem: (_, { type, defaultRender, formItemProps, fieldProps, ...rest },
 
 ### 表单操作自定义
 
-<code src="./demos/search_option.tsx" background="#f5f5f5" height="471px" title="表单操作自定义"/>
+<code src="./demos/search_option.tsx" background="#f5f5f5" height="471px" title="表单操作自定义"></code>
 
 ### Toolbar 自定义
 
 使用 `toolbar`属性扩展配置工具栏渲染。
 
-<code src="./demos/listToolBar.tsx" background="#f5f5f5" height="509px" title="Toolbar 自定义"/>
+<code src="./demos/listToolBar.tsx" background="#f5f5f5" height="509px" title="Toolbar 自定义"></code>
 
 ### 表格主体自定义
 
-<code src="./demos/renderTable.tsx" background="#f5f5f5" height="621px" title="表格主体自定义"/>
+<code src="./demos/renderTable.tsx" background="#f5f5f5" height="621px" title="表格主体自定义"></code>
 
 ### 卡片表格
 
 有些业务有自己的定制逻辑，可以不完全遵循 ProTable 的设计规则，但可以利用 ProTable 的 API 实现。如通过 `cardProps` 配置卡片属性，通过 `headTitle` 配置行动点在左侧。
 
-<code src="./demos/card-title.tsx" background="#f7f8fa" title="卡片表格" desc="使用卡片标题，行动点在左侧。" />
+<code src="./demos/card-title.tsx" background="#f7f8fa" title="卡片表格" desc="使用卡片标题，行动点在左侧。"></code>
 
 ### 国际化相关的配置
 
@@ -233,39 +233,39 @@ import { ConfigProvider } from '@ant-design/pro-provide';
 </ConfigProvider>;
 ```
 
-<code src="./demos/intl.tsx" background="#f5f5f5" height="415px" title="国际化相关的配置"/>
+<code src="./demos/intl.tsx" background="#f5f5f5" height="415px" title="国际化相关的配置"></code>
 
 ### 使用自带 keyWords 搜索的 table
 
-<code src="./demos/search.tsx" background="#f5f5f5" height="319px" title="使用自带 keyWords 搜索的 table"/>
+<code src="./demos/search.tsx" background="#f5f5f5" height="319px" title="使用自带 keyWords 搜索的 table"></code>
 
 ### 值类型示例
 
 #### valueType - 日期类
 
-<code src="./demos/valueTypeDate.tsx" background="#f5f5f5" height="490px" title="valueType - 日期类"/>
+<code src="./demos/valueTypeDate.tsx" background="#f5f5f5" height="490px" title="valueType - 日期类"></code>
 
 #### valueType - 数字类
 
-<code src="./demos/valueTypeNumber.tsx" background="#f5f5f5" height="446px" title="valueType - 数字类"/>
+<code src="./demos/valueTypeNumber.tsx" background="#f5f5f5" height="446px" title="valueType - 数字类"></code>
 
 #### valueType - 样式类
 
-<code src="./demos/valueType.tsx" background="#f5f5f5" height="628px" title="valueType - 样式类"/>
+<code src="./demos/valueType.tsx" background="#f5f5f5" height="628px" title="valueType - 样式类"></code>
 
 #### valueType - 选择类
 
-<code src="./demos/valueType_select.tsx" background="#f5f5f5" height="658px" title="valueType - 选择类"/>
+<code src="./demos/valueType_select.tsx" background="#f5f5f5" height="658px" title="valueType - 选择类"></code>
 
-<code src="./demos/customization-value-type.tsx" debug background="#f5f5f5" height="462px" title="自定义 valueType"/>
+<code src="./demos/customization-value-type.tsx" debug background="#f5f5f5" height="462px" title="自定义 valueType"></code>
 
 ### 自定义错误边界
 
-<code src="./demos/error-boundaries.tsx" background="#f5f5f5"  title="自定义错误边界" height="500px" iframe="572px"/>
+<code src="./demos/error-boundaries.tsx" background="#f5f5f5" title="自定义错误边界" height="500px" iframe="572px"></code>
 
-<code src="./demos/error-boundaries-false.tsx" debug title="取消自定义错误边界"  height="500px" iframe="462px" />
+<code src="./demos/error-boundaries-false.tsx" debug title="取消自定义错误边界" height="500px" iframe="462px"></code>
 
-<code src="./demos/config-provider.tsx" debug background="#f5f5f5" height="462px"/>
+<code src="./demos/config-provider.tsx" debug background="#f5f5f5" height="462px"></code>
 
 ## API
 
@@ -527,15 +527,15 @@ Form 的列是根据 `valueType` 来生成不同的类型,详细的值类型请�
 
 #### 代码演示
 
-<code src="./demos/ListToolBar/basic.tsx" background="#f7f8fa" title="列表工具栏-基本使用" />
+<code src="./demos/ListToolBar/basic.tsx" background="#f7f8fa" title="列表工具栏-基本使用"></code>
 
-<code src="./demos/ListToolBar/no-title.tsx" background="#f7f8fa" title="无标题" desc="列表工具栏-没有标题的情况下搜索框会前置。" />
+<code src="./demos/ListToolBar/no-title.tsx" background="#f7f8fa" title="无标题" desc="列表工具栏-没有标题的情况下搜索框会前置。"></code>
 
-<code src="./demos/ListToolBar/multipleLine.tsx" background="#f7f8fa" title="双行布局" desc="列表工具栏-双行的情况下会有双行的布局形式。" />
+<code src="./demos/ListToolBar/multipleLine.tsx" background="#f7f8fa" title="双行布局" desc="列表工具栏-双行的情况下会有双行的布局形式。"></code>
 
-<code src="./demos/ListToolBar/tabs.tsx" background="#f7f8fa"  title="带标签" desc="列表工具栏-标签需配合 `multipleLine` 为 `true` 时使用。" />
+<code src="./demos/ListToolBar/tabs.tsx" background="#f7f8fa" title="带标签" desc="列表工具栏-标签需配合 `multipleLine` 为 `true` 时使用。"></code>
 
-<code src="./demos/ListToolBar/menu.tsx" background="#f7f8fa" title="列表工具栏-标题下拉菜单"/>
+<code src="./demos/ListToolBar/menu.tsx" background="#f7f8fa" title="列表工具栏-标题下拉菜单"></code>
 
 #### ListToolBarProps
 


### PR DESCRIPTION
1、code单标签改为双标签，单标签 code 不是合法的 HTML,不被dumi 2 支持
2、TechUI 的文档升级到 dumi2,为确保 TechUI 的文档在同步 pre-components 文档时能正常渲染 demo