### PR TITLE
修复因为Sider折叠导致菜单展开状态丢失的bug

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -552,7 +552,11 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         [`${baseClassName}-collapsed`]: props.collapsed,
       })}
       items={menuUtils.getNavMenuItems(finallyData, 0)}
-      onOpenChange={setOpenKeys}
+      onOpenChange={(_openKeys: boolean)=> {
+        if (!props.collapsed) {
+          setOpenKeys(_openKeys)
+        }
+      }}
       {...props.menuProps}
     />,
   );

--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -552,7 +552,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         [`${baseClassName}-collapsed`]: props.collapsed,
       })}
       items={menuUtils.getNavMenuItems(finallyData, 0)}
-      onOpenChange={(_openKeys: boolean)=> {
+      onOpenChange={(_openKeys: string[])=> {
         if (!props.collapsed) {
           setOpenKeys(_openKeys)
         }


### PR DESCRIPTION
Sider关闭后（collapsed=true）会将展开的菜单收起，当Sider再次打开时（collapsed=false）会丢失原本的菜单展开状态