### PR TITLE
fix(layout): 修复因为Sider折叠导致菜单展开状态丢失的bug

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -552,7 +552,11 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         [`${baseClassName}-collapsed`]: props.collapsed,
       })}
       items={menuUtils.getNavMenuItems(finallyData, 0)}
-      onOpenChange={setOpenKeys}
+      onOpenChange={(_openKeys: boolean)=> {
+        if (!props.collapsed) {
+          setOpenKeys(_openKeys)
+        }
+      }}
       {...props.menuProps}
     />,
   );

--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -552,7 +552,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         [`${baseClassName}-collapsed`]: props.collapsed,
       })}
       items={menuUtils.getNavMenuItems(finallyData, 0)}
-      onOpenChange={(_openKeys: string[])=> {
+      onOpenChange={(_openKeys: React.Key[])=> {
         if (!props.collapsed) {
           setOpenKeys(_openKeys)
         }

--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -552,7 +552,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
         [`${baseClassName}-collapsed`]: props.collapsed,
       })}
       items={menuUtils.getNavMenuItems(finallyData, 0)}
-      onOpenChange={(_openKeys: boolean)=> {
+      onOpenChange={(_openKeys: string[])=> {
         if (!props.collapsed) {
           setOpenKeys(_openKeys)
         }

--- a/tests/layout/index.test.tsx
+++ b/tests/layout/index.test.tsx
@@ -1632,4 +1632,42 @@ describe('BasicLayout', () => {
       'Login',
     );
   });
+
+  it('🥩 siderMenu should restore openKeys when collapsed is false', async () => {
+    const onCollapse = jest.fn();
+    const html = render(
+      <ProLayout
+        {...bigDefaultProps}
+        location={{ pathname: '/list/sub-page/sub-sub-page1' }}
+        onCollapse={onCollapse}
+        defaultCollapsed={false}
+      >
+        <div>Hello World</div>
+      </ProLayout>,
+    );
+    await waitForComponentToPaint(html, 1000);
+
+    expect(html.baseElement.querySelectorAll('li.ant-menu-submenu-open').length).toBe(2);
+
+    act(() => {
+      Array.from(
+        html.baseElement.querySelectorAll<HTMLDivElement>('div.ant-pro-sider-collapsed-button'),
+      ).map((item) => item?.click());
+    });
+
+    await waitForComponentToPaint(html, 1000);
+
+    expect(html.baseElement.querySelectorAll('li.ant-menu-submenu-open').length).toBe(0);
+
+    act(() => {
+      Array.from(
+        html.baseElement.querySelectorAll<HTMLDivElement>('div.ant-pro-sider-collapsed-button'),
+      ).map((item) => item?.click());
+    });
+
+    await waitForComponentToPaint(html, 1000);
+
+    expect(onCollapse).toBeCalledTimes(2);
+    expect(html.baseElement.querySelectorAll('li.ant-menu-submenu-open').length).toBe(2);
+  });
 });


### PR DESCRIPTION
Sider关闭后（collapsed=true）会将展开的菜单收起，当Sider再次打开时（collapsed=false）会丢失原本的菜单展开状态
![屏幕录制2023-01-06-16 36 02](https://user-images.githubusercontent.com/10275774/210965894-f6ef81e7-71b4-4cb0-a6f5-ffa41b1027ad.gif)
