### PR TITLE
fix(Table): 列配置子项 disable 时，“固定”按钮点击无效

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -47,8 +47,6 @@ const ToolTipIcon: React.FC<{
           e.stopPropagation();
           e.preventDefault();
           const config = columnsMap[columnKey] || {};
-          const disableIcon = typeof config.disable === 'boolean' && config.disable;
-          if (disableIcon) return;
           const columnKeyMap = {
             ...columnsMap,
             [columnKey]: { ...config, fixed } as ColumnsState,


### PR DESCRIPTION
fix  https://github.com/ant-design/pro-components/issues/6474

<img width="299" alt="image" src="https://user-images.githubusercontent.com/29817353/211008681-b577a4c1-1775-4eb8-8561-70e292e1fd67.png">

子项 disable 时，“固定”按钮点击有效
