### PR TITLE
fix(Table): 列配置子项 disable 时，无法拖动调整顺序

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -253,7 +253,9 @@ const CheckboxList: React.FC<{
         );
       }}
       height={listHeight}
-      treeData={treeDataConfig.list?.map(({ disabled, ...restProps }) => restProps)}
+      treeData={treeDataConfig.list?.map(
+        ({ disabled /* 不透传 disabled，使子节点禁用时也可以拖动调整顺序 */, ...config }) => config,
+      )}
     />
   );
   return (

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -253,11 +253,7 @@ const CheckboxList: React.FC<{
         );
       }}
       height={listHeight}
-      treeData={
-        !!treeDataConfig.list?.length && treeDataConfig.list?.length > 1
-          ? treeDataConfig.list.map(({ disabled, ...restProps }) => restProps)
-          : treeDataConfig.list
-      }
+      treeData={treeDataConfig.list?.map(({ disabled, ...restProps }) => restProps)}
     />
   );
   return (

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -253,7 +253,11 @@ const CheckboxList: React.FC<{
         );
       }}
       height={listHeight}
-      treeData={treeDataConfig.list}
+      treeData={
+        !!treeDataConfig.list?.length && treeDataConfig.list?.length > 1
+          ? treeDataConfig.list.map(({ disabled, ...restProps }) => restProps)
+          : treeDataConfig.list
+      }
     />
   );
   return (


### PR DESCRIPTION
close https://github.com/ant-design/pro-components/issues/6474

<img width="232" alt="image" src="https://user-images.githubusercontent.com/29817353/211008480-6e577dc3-f494-4c1b-940a-eeb4098affb2.png">

子项 disable 时，可以拖动调整顺序