### PR TITLE
fix(Table): 列配置点击“列展示”全选操作时，顺序排列和 disable 状态异常

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -366,6 +366,7 @@ function ColumnSetting<T>(props: ColumnSettingProps<T>) {
         const columnKey = genColumnKey(key, index);
         if (columnKey) {
           columnKeyMap[columnKey] = {
+            // 子节点 disable 时，不修改节点显示状态
             show: disable ? columnsMap[columnKey]?.show : show,
             fixed,
             disable,

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -362,12 +362,14 @@ function ColumnSetting<T>(props: ColumnSettingProps<T>) {
   const setAllSelectAction = useRefFunction((show: boolean = true) => {
     const columnKeyMap = {};
     const loopColumns = (columns: any) => {
-      columns.forEach(({ key, fixed, index, children }: any) => {
+      columns.forEach(({ key, fixed, index, children, disable }: any) => {
         const columnKey = genColumnKey(key, index);
         if (columnKey) {
           columnKeyMap[columnKey] = {
-            show,
+            show: disable ? columnsMap[columnKey]?.show : show,
             fixed,
+            disable,
+            order: columnsMap[columnKey]?.order,
           };
         }
         if (children) {


### PR DESCRIPTION
close https://github.com/ant-design/pro-components/issues/6474

点击“列展示”全选操作时，列配置子项的顺序不应该被重置，列配置的 disable 状态不应该发生改变