### PR TITLE
fix(form): slove form list label defalut mode show problem

### DIFF
--- a/packages/form/src/components/List/ListItem.tsx
+++ b/packages/form/src/components/List/ListItem.tsx
@@ -442,9 +442,9 @@ const ProFormListItem: React.FC<
     options,
   ) || (
     <div
-      className={`${prefixCls}-item ${hashId} ${
-        alwaysShowItemLabel ? `${prefixCls}-item-show-label` : ''
-      }`}
+      className={`${prefixCls}-item ${hashId} 
+      ${alwaysShowItemLabel === undefined && `${prefixCls}-item-default`}
+      ${alwaysShowItemLabel ? `${prefixCls}-item-show-label` : ''}`}
       style={{
         display: 'flex',
         alignItems: 'flex-end',

--- a/packages/form/src/components/List/style.ts
+++ b/packages/form/src/components/List/style.ts
@@ -39,7 +39,7 @@ const genProStyle: GenerateStyle<ProToken> = (token) => {
           'div:first-of-type': {
             [`${token.antCls}-form-item`]: {
               [`${token.antCls}-form-item-label`]: {
-                display: 'nont',
+                display: 'none',
               },
             },
           },

--- a/packages/form/src/components/List/style.ts
+++ b/packages/form/src/components/List/style.ts
@@ -26,11 +26,20 @@ const genProStyle: GenerateStyle<ProToken> = (token) => {
             display: 'inline-block',
           },
         },
-        '&:first-of-type': {
+        '&&-default:first-child': {
           'div:first-of-type': {
             [`${token.antCls}-form-item`]: {
               [`${token.antCls}-form-item-label`]: {
                 display: 'inline-block',
+              },
+            },
+          },
+        },
+        '&&-default:not(:first-child)': {
+          'div:first-of-type': {
+            [`${token.antCls}-form-item`]: {
+              [`${token.antCls}-form-item-label`]: {
+                display: 'nont',
               },
             },
           },

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -140,7 +140,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Dependency/demos
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  ant-pro-form-list-item-show-label"
+                      class="ant-pro-form-list-item  
+      false
+      ant-pro-form-list-item-show-label"
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -985,7 +987,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Dependency/demos
                                     style="max-width: 100%; min-width: 100%;"
                                   >
                                     <div
-                                      class="ant-pro-form-list-item  "
+                                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                       style="display: flex; align-items: flex-end;"
                                     >
                                       <div
@@ -1356,7 +1360,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Dependency/demos
                                     style="max-width: 100%; min-width: 100%;"
                                   >
                                     <div
-                                      class="ant-pro-form-list-item  "
+                                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                       style="display: flex; align-items: flex-end;"
                                     >
                                       <div
@@ -9320,7 +9326,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/base
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  ant-pro-form-list-item-show-label"
+                      class="ant-pro-form-list-item  
+      false
+      ant-pro-form-list-item-show-label"
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -9772,7 +9780,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/coun
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  "
+                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -10020,7 +10030,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/cust
                               style="max-width: 100%; min-width: 100%;"
                             >
                               <div
-                                class="ant-pro-form-list-item  "
+                                class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                 style="display: flex; align-items: flex-end;"
                               >
                                 <div
@@ -11507,7 +11519,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/depe
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  "
+                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -12722,7 +12736,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/list
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  "
+                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -13573,7 +13589,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/list
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  "
+                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -14274,7 +14292,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/Group/demos/nest
                                         style="max-width: 100%; min-width: 100%;"
                                       >
                                         <div
-                                          class="ant-pro-form-list-item  "
+                                          class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                           style="display: flex; align-items: flex-end;"
                                         >
                                           <div
@@ -31426,7 +31446,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/SchemaForm/demos
                           style="max-width: 100%; min-width: 100%;"
                         >
                           <div
-                            class="ant-pro-form-list-item  "
+                            class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                             style="display: flex; align-items: flex-end;"
                           >
                             <div
@@ -32920,7 +32942,9 @@ exports[`form demos 📸 renders ./packages/form/src/components/SchemaForm/demos
                               style="max-width: 100%; min-width: 100%;"
                             >
                               <div
-                                class="ant-pro-form-list-item  "
+                                class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                 style="display: flex; align-items: flex-end;"
                               >
                                 <div
@@ -41338,7 +41362,9 @@ exports[`form demos 📸 renders ./packages/form/src/demos/base-test.tsx correct
                     style="max-width: 100%; min-width: 100%;"
                   >
                     <div
-                      class="ant-pro-form-list-item  "
+                      class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                       style="display: flex; align-items: flex-end;"
                     >
                       <div
@@ -51030,7 +51056,9 @@ exports[`form demos 📸 renders ./packages/form/src/demos/pro-form-dependency.d
                                         style="max-width: 100%; min-width: 100%;"
                                       >
                                         <div
-                                          class="ant-pro-form-list-item  "
+                                          class="ant-pro-form-list-item  
+      ant-pro-form-list-item-default
+      "
                                           style="display: flex; align-items: flex-end;"
                                         >
                                           <div


### PR DESCRIPTION
修复因为 https://github.com/ant-design/pro-components/issues/6392
导致默认模式下ProFormList 第一排的label 被强制关闭不生效的问题