### PR TITLE
fix(docs): codesandbox link missing antd dependency  #6626

### DIFF
--- a/.dumi/theme/DemoReactTechStack.ts
+++ b/.dumi/theme/DemoReactTechStack.ts
@@ -1,0 +1,26 @@
+import ReactTechStack from 'dumi/dist/techStacks/react';
+import { IDumiTechStack } from 'dumi/dist/types';
+
+export default class DemoReactTechStack extends ReactTechStack implements IDumiTechStack {
+  readonly antdVersion: string;
+
+  constructor() {
+    super();
+    this.antdVersion = this.getAntdVersion();
+  }
+  generateMetadata(asset: any) {
+    if (asset.type === 'BLOCK' && !asset.dependencies?.antd) {
+      asset.dependencies.antd = {
+        type: 'NPM',
+        value: this.antdVersion,
+      };
+    }
+    return asset;
+  }
+
+  getAntdVersion() {
+    const pkgJson = require('antd/package.json');
+    debugger;
+    return pkgJson.version || '5.2.0';
+  }
+}

--- a/.dumi/theme/plugin.ts
+++ b/.dumi/theme/plugin.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import type { IApi } from 'dumi';
 import { extractStyle } from '@ant-design/cssinjs';
+import DemoReactTechStack from './DemoReactTechStack';
 
 const RoutesPlugin = (api: IApi) => {
   const ssrCssFileName = `ssr-${Date.now()}.css`;
@@ -52,6 +53,8 @@ const RoutesPlugin = (api: IApi) => {
       .replace(/<\/style>/g, '');
     fs.writeFileSync(`./dist/${ssrCssFileName}`, styleTextWithoutStyleTag, 'utf8');
   });
+
+  api.registerTechStack(() => new DemoReactTechStack());
 };
 
 export default RoutesPlugin;


### PR DESCRIPTION
fix: issue #6626

### 原因分析：

`dumi`框架在生成`codesandbox`链接时会分析当前`tsx`文件中的所有`import`语句，并将相关依赖的元数据信息(asset)注入为`props`，然后直接根据依赖项生成`codesandbox`链接。由于部分`pro-components`的`demo`代码没有在示例代码中显式引入`antd`，所以生成的`codesandbox`项目没有把`antd`作为依赖，导致预览失败。

### 解决方案

利用`dumi`提供的插件能力，在每一个`code`关联的示例代码中自动引入`antd`依赖。

[相关文档](https://d.umijs.org/plugin/api#registertechstack)

