### PR TITLE
fix(form): textarea read-mode error

### DIFF
--- a/packages/field/src/components/TextArea/index.tsx
+++ b/packages/field/src/components/TextArea/index.tsx
@@ -24,6 +24,7 @@ const FieldTextArea: ProFieldFC<{
           display: 'inline-block',
           padding: '4px 11px',
           lineHeight: '1.5715',
+          width: '100%',
           whiteSpace: 'pre-wrap',
         }}
       >

--- a/packages/field/src/components/TextArea/index.tsx
+++ b/packages/field/src/components/TextArea/index.tsx
@@ -24,7 +24,7 @@ const FieldTextArea: ProFieldFC<{
           display: 'inline-block',
           padding: '4px 11px',
           lineHeight: '1.5715',
-          width: '100%',
+          maxWidth: '100%',
           whiteSpace: 'pre-wrap',
         }}
       >


### PR DESCRIPTION
fix #6619

原因分析：

`Textarea`组件为只读模式时，没有限制最大宽度。

调整后的示例代码如下：

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/37829041/219936982-ee1bb7b1-fa7b-462a-be91-3cd3800578aa.png">
