### PR TITLE
fix: iframe height set failed

### DIFF
--- a/docs/playground/index.en-US.md
+++ b/docs/playground/index.en-US.md
@@ -11,4 +11,4 @@ ProTable，ProDescriptions，ProForm 都是基于 ProField 来进行封装。Pro
 
 使用同样的底层实现为 ProTable，ProDescriptions，ProForm 打通带来了便利。ProForm 可以很方便的实现只读模式，ProTable 可以快速实现查询表单和可编辑表格。ProDescriptions 可以实现节点编辑，以下有个例子可以切换三个组件。
 
-<code src="../../packages/table/src/demos/crud.tsx" iframe="650px"></code>
+<code src="../../packages/table/src/demos/crud.tsx" iframe="650"></code>

--- a/docs/playground/index.md
+++ b/docs/playground/index.md
@@ -11,4 +11,4 @@ ProTable，ProDescriptions，ProForm 都是基于 ProField 来进行封装。Pro
 
 使用同样的底层实现为 ProTable，ProDescriptions，ProForm 打通带来了便利。ProForm 可以很方便的实现只读模式，ProTable 可以快速实现查询表单和可编辑表格。ProDescriptions 可以实现节点编辑，以下有个例子可以切换三个组件。
 
-<code src="../../packages/table/src/demos/crud.tsx" iframe="650px"></code>
+<code src="../../packages/table/src/demos/crud.tsx" iframe="650"></code>

--- a/packages/form/src/components/LoginForm/index.md
+++ b/packages/form/src/components/LoginForm/index.md
@@ -13,7 +13,7 @@ LoginForm 和 LoginFormPage 是 ProForm 的变体，两者是为了适应常见�
 
 ## 页面级别的登录表单
 
-<code src="./demos/login-form-page.tsx" background="hsl(220,23%,97%)" iframe="887px" title="页面级别的表单"></code>
+<code src="./demos/login-form-page.tsx" background="hsl(220,23%,97%)" iframe="887" title="页面级别的表单"></code>
 
 ## API
 

--- a/packages/form/src/components/form.en-US.md
+++ b/packages/form/src/components/form.en-US.md
@@ -169,7 +169,7 @@ supported in `ProForm`, `SchemaForm`, `ModalForm`, `DrawerForm`, `StepsForm`
 
 ### Fixed footer
 
-<code src="../demos/layout-footer.tsx" iframe="580px"></code>
+<code src="../demos/layout-footer.tsx" iframe="580"></code>
 
 ### Money
 

--- a/packages/form/src/components/form.md
+++ b/packages/form/src/components/form.md
@@ -180,7 +180,7 @@ formRef 内置了几个方法来获取转化之后的值，这也是相比 antd 
 
 <code src="../demos/money.tsx" title="金额"></code>
 
-<code src="../demos/layout-footer.tsx" iframe="580px" title="固定页脚"></code>
+<code src="../demos/layout-footer.tsx" iframe="580" title="固定页脚"></code>
 
 <code src="../demos/pro-form-editableTable.tsx" title="ProForm 和 EditableTable 同时使用"></code>
 

--- a/packages/layout/src/components/layout.en-US.md
+++ b/packages/layout/src/components/layout.en-US.md
@@ -60,7 +60,7 @@ ProLayout will automatically select the menu based on `location.pathname` and au
 
 ### Basic usage
 
-<code src="../demos/base.tsx" iframe="650px"></code>
+<code src="../demos/base.tsx" iframe="650"></code>
 
 ### Load menu from server
 
@@ -68,53 +68,53 @@ ProLayout provides a powerful menu, but this necessarily encapsulates a lot of b
 
 The main APIs used to load menu from the server are `menuDataRender` and `menuRender`, `menuDataRender` controls the current menu data and `menuRender` controls the menu's dom node.
 
-<code src="../demos/dynamicMenu.tsx" iframe="580px"></code>
+<code src="../demos/dynamicMenu.tsx" iframe="580"></code>
 
 ### Load the menu from the server and use the icon
 
 Here is mainly a demo where we need to prepare an enumeration for icon rendering, which can significantly reduce the size of the package
 
-<code src="../demos/antd@4MenuIconFormServe.tsx" iframe="580px"></code>
+<code src="../demos/antd@4MenuIconFormServe.tsx" iframe="580"></code>
 
 ### Customize the content of the menu
 
 With `menuItemRender`, `subMenuItemRender`, `title`, `logo`, `menuHeaderRender` you can customize the menu style very easily. If you are really not satisfied, you can use `menuRender` to fully customize it.
 
-<code src="../demos/customizeMenu.tsx" iframe="580px"></code>
+<code src="../demos/customizeMenu.tsx" iframe="580"></code>
 
 ### Custom footer
 
 ProLayout does not provide footer by default, if you want to have the same style as Pro official website, you need to introduce a footer by yourself.
 
-<code src="../demos/footer.tsx" iframe="580px"></code>
+<code src="../demos/footer.tsx" iframe="580"></code>
 
 This is used to show various applications of ProLayout, if you think your usage can help others, feel free to PR.
 
 ### Search menu
 
-<code src="../demos/searchMenu.tsx" iframe="580px"></code>
+<code src="../demos/searchMenu.tsx" iframe="580"></code>
 
 ### Multiple routes correspond to one menu item
 
-<code src="../demos/MultipleMenuOnePath.tsx" iframe="580px"></code>
+<code src="../demos/MultipleMenuOnePath.tsx" iframe="580"></code>
 
 ### Open all menus by default
 
-<code src="../demos/DefaultOpenAllMenu.tsx" iframe="580px"></code>
+<code src="../demos/DefaultOpenAllMenu.tsx" iframe="580"></code>
 
 ### Using IconFont
 
-<code src="../demos/IconFont.tsx" iframe="580px"></code>
+<code src="../demos/IconFont.tsx" iframe="580"></code>
 
 ### ghost mode
 
 PageContainer configuration `ghost` can switch the page header to transparent mode.
 
-<code src="../demos/ghost.tsx" iframe="580px"></code>
+<code src="../demos/ghost.tsx" iframe="580"></code>
 
 ### Nested Layout
 
-<code src="../demos/Nested.tsx" iframe="580px"></code>
+<code src="../demos/Nested.tsx" iframe="580"></code>
 
 ### Customized collapsed
 

--- a/packages/layout/src/components/layout.md
+++ b/packages/layout/src/components/layout.md
@@ -13,37 +13,37 @@ ProLayout 可以提供一个标准又不失灵活的中后台标准布局，同�
 
 ## 代码演示
 
-<code src="../demos/base.tsx"  iframe="650px" title="基础使用"></code>
+<code src="../demos/base.tsx"  iframe="650" title="基础使用"></code>
 
-<code src="../demos/theme.tsx" iframe="650px" title="通过 token 修改样式"></code>
+<code src="../demos/theme.tsx" iframe="650" title="通过 token 修改样式"></code>
 
-<code src="../demos/dark.tsx" iframe="650px" title="黑色主题"></code>
+<code src="../demos/dark.tsx" iframe="650" title="黑色主题"></code>
 
-<code src="../demos/siderMode.tsx" iframe="650px" title="侧栏导航 中后台产品默认推荐"></code>
+<code src="../demos/siderMode.tsx" iframe="650" title="侧栏导航 中后台产品默认推荐"></code>
 
-<code src="../demos/mixMode.tsx" iframe="650px" title="混合导航"></code>
+<code src="../demos/mixMode.tsx" iframe="650" title="混合导航"></code>
 
-<code src="../demos/topMode.tsx" iframe="650px" title="顶部导航"></code>
+<code src="../demos/topMode.tsx" iframe="650" title="顶部导航"></code>
 
-<code src="../demos/designSiderMenu.tsx" iframe="650px" title="侧栏导航宽度256px"></code>
+<code src="../demos/designSiderMenu.tsx" iframe="650" title="侧栏导航宽度256px"></code>
 
-<code src="../demos/footer-global-tools.tsx" iframe="650px" title="页脚工具栏和全局公告"></code>
+<code src="../demos/footer-global-tools.tsx" iframe="650" title="页脚工具栏和全局公告"></code>
 
-<code src="../demos/collapsedShowTitle.tsx" iframe="650px" title=" 收起时展示 title"></code>
+<code src="../demos/collapsedShowTitle.tsx" iframe="650" title=" 收起时展示 title"></code>
 
-<code src="../demos/menu-group.tsx" iframe="650px" title="不分组菜单样式"></code>
+<code src="../demos/menu-group.tsx" iframe="650" title="不分组菜单样式"></code>
 
-<code src="../demos/classicMode.tsx" iframe="650px" title="经典导航样式"></code>
+<code src="../demos/classicMode.tsx" iframe="650" title="经典导航样式"></code>
 
-<code src="../demos/background-context.tsx" iframe="650px" title="通过调整页面背景内容调整整体氛围"></code>
+<code src="../demos/background-context.tsx" iframe="650" title="通过调整页面背景内容调整整体氛围"></code>
 
-<code src="../demos/designMenuCss.tsx" iframe="650px" title="定制菜单样式"></code>
+<code src="../demos/designMenuCss.tsx" iframe="650" title="定制菜单样式"></code>
 
-<code src="../demos/pageSimplify.tsx" iframe="650px" title="通过设置页背景和卡片样式简化界面层次"></code>
+<code src="../demos/pageSimplify.tsx" iframe="650" title="通过设置页背景和卡片样式简化界面层次"></code>
 
-<code src="../demos/customSider.tsx" iframe="650px" title="自定侧栏菜单下方区域"></code>
+<code src="../demos/customSider.tsx" iframe="650" title="自定侧栏菜单下方区域"></code>
 
-<code src="../demos/siteMenu.tsx" iframe="650px" title="菜单展开-站点地图"></code>
+<code src="../demos/siteMenu.tsx" iframe="650" title="菜单展开-站点地图"></code>
 
 ### 从服务器加载 menu
 
@@ -51,71 +51,71 @@ ProLayout 提供了强大的菜单功能，但是这样必然会封装很多行�
 
 从服务器加载 menu 主要使用的 API 是 `menuDataRender` 和 `menuRender`,`menuDataRender`可以控制当前的菜单数据，`menuRender`可以控制菜单的 dom 节点。
 
-<code src="../demos/dynamicMenu.tsx" iframe="650px"></code>
+<code src="../demos/dynamicMenu.tsx" iframe="650"></code>
 
 ### 从服务器加载 menu 并且使用 icon
 
 这里主要是一个演示，我们需要准备一个枚举来进行 icon 的渲染，可以显著的减少打包的大小
 
-<code src="../demos/antd@4MenuIconFormServe.tsx" iframe="610px"></code>
+<code src="../demos/antd@4MenuIconFormServe.tsx" iframe="610"></code>
 
 ### 自定义 menu 的内容
 
 通过 `menuItemRender`, `subMenuItemRender`,`title`,`logo`,`menuHeaderRender` 可以非常方便的自定义 menu 的样式。如果实在是不满意，可以使用 `menuRender` 完全的自定义。
 
-<code src="../demos/customizeMenu.tsx" iframe="650px"></code>
+<code src="../demos/customizeMenu.tsx" iframe="650"></code>
 
 ### 自定义页脚
 
 ProLayout 默认不提供页脚，要是和 Pro 官网相同的样式，需要自己引入一下页脚。
 
-<code src="../demos/footer.tsx" iframe="650px"></code>
+<code src="../demos/footer.tsx" iframe="650"></code>
 
 这里用于展示 ProLayout 的各种应用，如果你觉得你的用法能帮助到别人，欢迎 PR。
 
-<code src="../demos/searchMenu.tsx" title="搜索菜单" iframe="650px"></code>
+<code src="../demos/searchMenu.tsx" title="搜索菜单" iframe="650"></code>
 
-<code src="../demos/MultipleMenuOnePath.tsx" title="多个路由对应一个菜单项" iframe="650px"></code>
+<code src="../demos/MultipleMenuOnePath.tsx" title="多个路由对应一个菜单项" iframe="650"></code>
 
 ### 默认打开所有菜单
 
 menu 配置 `defaultOpenAll` 可以默认打开所有菜单
 
-<code src="../demos/DefaultOpenAllMenu.tsx" iframe="650px"></code>
+<code src="../demos/DefaultOpenAllMenu.tsx" iframe="650"></code>
 
 ### 总是打开所有菜单
 
 折叠按钮反复切换后 `defaultOpenAll` 将失效，menu 配置 `ignoreFlatMenu` 可以忽略手动折叠过的菜单，实现总是默认打开所有菜单。因为计算时机在组件渲染前，所以异步菜单不生效。
 
-<code src="../demos/AlwaysDefaultOpenAllMenu.tsx" iframe="650px"></code>
+<code src="../demos/AlwaysDefaultOpenAllMenu.tsx" iframe="650"></code>
 
-<code src="../demos/IconFont.tsx" title="使用 IconFont" iframe="650px"></code>
+<code src="../demos/IconFont.tsx" title="使用 IconFont" iframe="650"></code>
 
 ### 吸顶 header
 
 PageContainer 配置 `fixedHeader` 可以将吸顶 header。
 
-<code src="../demos/ghost.tsx" title="ghost 模式" iframe="650px"></code>
+<code src="../demos/ghost.tsx" title="ghost 模式" iframe="650"></code>
 
-<code src="../demos/Nested.tsx" title="嵌套布局" iframe="650px"></code>
+<code src="../demos/Nested.tsx" title="嵌套布局" iframe="650"></code>
 
-<code src="../demos/customize-collapsed.tsx" title="自定义的 collapse" iframe="650px"></code>
+<code src="../demos/customize-collapsed.tsx" title="自定义的 collapse" iframe="650"></code>
 
-<code src="../demos/top-breadcrumb.tsx" title="面包屑显示在顶部" iframe="650px"></code>
+<code src="../demos/top-breadcrumb.tsx" title="面包屑显示在顶部" iframe="650"></code>
 
-<code src="../demos/immersive-navigation.tsx" title="多级站点导航" iframe="650px"></code>
+<code src="../demos/immersive-navigation.tsx" title="多级站点导航" iframe="650"></code>
 
-<code src="../demos/immersive-navigation-top.tsx" title="沉浸式导航" iframe="650px"></code>
+<code src="../demos/immersive-navigation-top.tsx" title="沉浸式导航" iframe="650"></code>
 
 ### 跨站点导航 - simple 分组
 
 > 使用默认卡片展示，请确保每一项都有 desc，且值为真；使用分组展示，请确保每一项都有 children，且长度大于 0；
 
-<code src="../demos/appList-group.tsx" title="跨站点导航列表 分组模式" iframe="650px"></code>
+<code src="../demos/appList-group.tsx" title="跨站点导航列表 分组模式" iframe="650"></code>
 
-<code src="../demos/error-boundaries.tsx" title="layout 自带了错误处理功能，防止白屏" iframe="650px"></code>
+<code src="../demos/error-boundaries.tsx" title="layout 自带了错误处理功能，防止白屏" iframe="650"></code>
 
-<code src="../demos/splitMenus.tsx" title="沉浸式导航" debug iframe="650px"></code>
+<code src="../demos/splitMenus.tsx" title="沉浸式导航" debug iframe="650"></code>
 
 ## API
 

--- a/packages/table/src/components/table.md
+++ b/packages/table/src/components/table.md
@@ -230,9 +230,9 @@ import { ConfigProvider } from '@ant-design/pro-provide';
 
 ### 自定义错误边界
 
-<code src="../demos/error-boundaries.tsx" background="hsl(220,23%,97%)" iframe="572px"></code>
+<code src="../demos/error-boundaries.tsx" background="hsl(220,23%,97%)" iframe="572"></code>
 
-<code src="../demos/error-boundaries-false.tsx" title="取消自定义错误边界" iframe="462px"></code>
+<code src="../demos/error-boundaries-false.tsx" title="取消自定义错误边界" iframe="462"></code>
 
 <code src="../demos/config-provider.tsx" debug background="hsl(220,23%,97%)" ></code>
 


### PR DESCRIPTION
针对下面的代码，`580px`设置其实是失效的

```js
<code src="../demos/layout-footer.tsx" iframe="580px" title="固定页脚"></code>
```
可以参照[dumi中iframe相关设置的源码](https://github.com/umijs/dumi/blob/master/src/client/theme-default/builtins/Previewer/index.tsx#L26-#L37)。

iframe参数如果是字符串的话必须能经过`Number`来转换为数字

之前：
![image](https://user-images.githubusercontent.com/37829041/219998797-23b74d3c-eebd-405e-b9c0-642cb5dc6cf6.png)

调整后：
![image](https://user-images.githubusercontent.com/37829041/219998823-dd0c484a-b976-404c-aa93-a6d01b3dd763.png)
