### PR TITLE
feat(form): ProFormTreeSelect support fetchDataOnSearch

### DIFF
--- a/packages/field/src/components/TreeSelect/index.tsx
+++ b/packages/field/src/components/TreeSelect/index.tsx
@@ -17,6 +17,13 @@ import { useIntl } from '@ant-design/pro-provider';
 export type GroupProps = {
   options?: RadioGroupProps['options'];
   radioType?: 'button' | 'radio';
+
+  /**
+   * 当搜索关键词发生变化时是否请求远程数据
+   *
+   * @default true
+   */
+  fetchDataOnSearch?: boolean;
 } & FieldSelectProps;
 
 /**
@@ -25,7 +32,7 @@ export type GroupProps = {
  * @param ref
  */
 const FieldTreeSelect: ProFieldFC<GroupProps> = (
-  { radioType, renderFormItem, mode, light, label, render, ...rest },
+  { radioType, renderFormItem, mode, light, label, render, fetchDataOnSearch = true, ...rest },
   ref,
 ) => {
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
@@ -158,7 +165,9 @@ const FieldTreeSelect: ProFieldFC<GroupProps> = (
           }}
           onChange={onChange}
           onSearch={(value) => {
-            fetchData(value);
+            if (fetchDataOnSearch) {
+              fetchData(value);
+            }
             setSearchValue(value);
           }}
           onBlur={(event) => {

--- a/packages/form/src/components/TreeSelect/index.tsx
+++ b/packages/form/src/components/TreeSelect/index.tsx
@@ -4,15 +4,28 @@ import React from 'react';
 import type { ProFormFieldItemProps, ProFormFieldRemoteProps } from '../../typing';
 import ProFormField from '../Field';
 
+export type ProFormTreeSelectProps<T = any> = ProFormFieldItemProps<
+  TreeSelectProps<T> & {
+    /**
+     * 当搜索关键词发生变化时是否请求远程数据
+     *
+     * @default true
+     */
+    fetchDataOnSearch?: boolean;
+  },
+  RefSelectProps
+> &
+  ProFormFieldRemoteProps;
+
 /**
  * 级联选择框
  *
  * @param
  */
-const ProFormTreeSelect: React.ForwardRefRenderFunction<
-  any,
-  ProFormFieldItemProps<TreeSelectProps<any>, RefSelectProps> & ProFormFieldRemoteProps
-> = ({ fieldProps, request, params, proFieldProps, ...rest }, ref) => {
+const ProFormTreeSelect: React.ForwardRefRenderFunction<any, ProFormTreeSelectProps<any>> = (
+  { fieldProps, request, params, proFieldProps, ...rest },
+  ref,
+) => {
   return (
     <ProFormField
       valueType="treeSelect"
@@ -27,8 +40,6 @@ const ProFormTreeSelect: React.ForwardRefRenderFunction<
   );
 };
 
-const WarpProFormTreeSelect: React.FC<
-  ProFormFieldItemProps<TreeSelectProps<any>, RefSelectProps> & ProFormFieldRemoteProps
-> = React.forwardRef(ProFormTreeSelect);
+const WarpProFormTreeSelect: React.FC<ProFormTreeSelectProps> = React.forwardRef(ProFormTreeSelect);
 
 export default WarpProFormTreeSelect;

--- a/tests/form/base.test.tsx
+++ b/tests/form/base.test.tsx
@@ -11,6 +11,7 @@ import ProForm, {
   ProFormField,
   ProFormSelect,
   ProFormText,
+  ProFormTreeSelect,
 } from '@ant-design/pro-form';
 import { act, fireEvent, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -2715,5 +2716,139 @@ describe('ProForm', () => {
     expect(dom.value).toBe('22');
     expect(fn).toBeCalledWith(22);
     expect(html.asFragment()).toMatchSnapshot();
+  });
+
+  it('📦 ProFormTreeSelect support fetchDataOnSearch: false', async () => {
+    const onRequest = jest.fn();
+    const wrapper = render(
+      <ProForm>
+        <ProFormTreeSelect
+          name="userQuery"
+          label="查询选择器"
+          fieldProps={{
+            showSearch: true,
+            fetchDataOnSearch: false,
+          }}
+          request={async () => {
+            onRequest();
+            return [
+              {
+                value: 'parent 1',
+                title: 'parent 1',
+                children: [
+                  {
+                    value: 'parent 1-0',
+                    title: 'parent 1-0',
+                    children: [
+                      {
+                        value: 'leaf1',
+                        title: 'leaf1',
+                      },
+                      {
+                        value: 'leaf2',
+                        title: 'leaf2',
+                      },
+                    ],
+                  },
+                  {
+                    value: 'parent 1-1',
+                    title: 'parent 1-1',
+                    children: [
+                      {
+                        value: 'leaf3',
+                        title: <b style={{ color: '#08c' }}>leaf3</b>,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ];
+          }}
+        />
+      </ProForm>,
+    );
+
+    act(() => {
+      fireEvent.change(wrapper.baseElement.querySelector('.ant-select-selection-search-input')!, {
+        target: {
+          value: 'p',
+        },
+      });
+    });
+
+    expect(onRequest.mock.calls.length).toBe(1);
+  });
+
+  it('📦 ProFormTreeSelect support fetchDataOnSearch: true', async () => {
+    const onRequest = jest.fn();
+    const wrapper = render(
+      <ProForm>
+        <ProFormTreeSelect
+          name="userQuery"
+          label="查询选择器"
+          fieldProps={{
+            showSearch: true,
+            fetchDataOnSearch: true,
+          }}
+          request={async () => {
+            onRequest();
+            return [
+              {
+                value: 'parent 1',
+                title: 'parent 1',
+                children: [
+                  {
+                    value: 'parent 1-0',
+                    title: 'parent 1-0',
+                    children: [
+                      {
+                        value: 'leaf1',
+                        title: 'leaf1',
+                      },
+                      {
+                        value: 'leaf2',
+                        title: 'leaf2',
+                      },
+                    ],
+                  },
+                  {
+                    value: 'parent 1-1',
+                    title: 'parent 1-1',
+                    children: [
+                      {
+                        value: 'leaf3',
+                        title: <b style={{ color: '#08c' }}>leaf3</b>,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ];
+          }}
+        />
+      </ProForm>,
+    );
+
+    act(() => {
+      fireEvent.change(wrapper.baseElement.querySelector('.ant-select-selection-search-input')!, {
+        target: {
+          value: 'l',
+        },
+      });
+    });
+
+    await act(async () => {
+      await waitTime(200);
+    });
+    act(() => {
+      fireEvent.mouseDown(wrapper.baseElement.querySelectorAll('.ant-select-selector')[0], {});
+    });
+
+    await act(async () => {
+      await waitTime(200);
+    });
+
+    expect(onRequest.mock.calls.length).toBe(3);
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
有时需要只在第一次request远程数据，之后在本地筛选