### PR TITLE
fix(table): ProTable组件toolbar menu属性为tab时抖动问题(#6584)

### DIFF
--- a/packages/table/src/components/ListToolBar/style.ts
+++ b/packages/table/src/components/ListToolBar/style.ts
@@ -47,6 +47,8 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
         gap: 8,
         justifyContent: 'flex-start',
         maxWidth: 'calc(100% - 200px)',
+        width: '100%',
+        overflow: 'auto',
         [`${token.antCls}-tabs`]: {
           width: '100%',
         },


### PR DESCRIPTION
tabs父级没有给一个宽度，在flex布局下会出现奇奇怪怪的抖动或者无限延伸的情况，100%会自动撑开多余的空间，并不会挤兑剩余右侧内容。