### PR TITLE
fix(layout): the actionsRender props doesn't take effect when avatarProps is null

### DIFF
--- a/packages/layout/src/components/SiderMenu/SiderMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/SiderMenu.tsx
@@ -320,7 +320,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
 
   /** 操作区域的dom */
   const actionAreaDom = useMemo(() => {
-    if (!avatarDom) return null;
+    if (!avatarDom && !actionsDom) return null;
 
     return (
       <div


### PR DESCRIPTION
if layout's avatarProps doesn't exist, the actionsRender props should also take effect