### PR TITLE
💥 feat(layout): layout提供在菜单为空时隐藏Sider的功能

### DIFF
--- a/packages/layout/src/ProLayout.tsx
+++ b/packages/layout/src/ProLayout.tsx
@@ -258,7 +258,15 @@ const footerRender = (props: ProLayoutProps): React.ReactNode => {
 };
 
 const renderSiderMenu = (props: ProLayoutProps, matchMenuKeys: string[]): React.ReactNode => {
-  const { layout, isMobile, selectedKeys, openKeys, splitMenus, menuRender } = props;
+  const {
+    layout,
+    isMobile,
+    selectedKeys,
+    openKeys,
+    splitMenus,
+    suppressSiderWhenMenuEmpty,
+    menuRender,
+  } = props;
   if (props.menuRender === false || props.pure) {
     return null;
   }
@@ -275,8 +283,7 @@ const renderSiderMenu = (props: ProLayoutProps, matchMenuKeys: string[]): React.
   }
   // 这里走了可以少一次循环
   const clearMenuData = clearMenuItem(menuData || []);
-
-  if (clearMenuData && clearMenuData?.length < 1 && splitMenus) {
+  if (clearMenuData && clearMenuData?.length < 1 && (splitMenus || suppressSiderWhenMenuEmpty)) {
     return null;
   }
   if (layout === 'top' && !isMobile) {

--- a/packages/layout/src/components/layout.en-US.md
+++ b/packages/layout/src/components/layout.en-US.md
@@ -150,6 +150,7 @@ PageContainer configuration `ghost` can switch the page header to transparent mo
 | locale | Language settings for the current layout | `zh-CN` \| `zh-TW` \| `en-US` | navigator.language |
 | settings | settings for layout | [`Settings`](#Settings) | - |
 | siderWidth | width of the side menu | `number` | 208 |
+| suppressSiderWhenMenuEmpty | Hide Sider when menu is empty | `boolean` | - |
 | defaultCollapsed | The default collapsed and expanded menus, will be affected by `breakpoint`, `breakpoint=false` work | `boolean` | - |
 | collapsed | Controls the collapse and expansion of the menu | `boolean` | - |
 | onCollapse | The collapsed event of the menu | `(collapsed: boolean) => void` | - |

--- a/packages/layout/src/components/layout.md
+++ b/packages/layout/src/components/layout.md
@@ -148,6 +148,7 @@ PageContainer 配置 `fixedHeader` 可以将吸顶 header。
 | locale | 当前 layout 的语言设置 | `zh-CN` \| `zh-TW` \| `en-US` | navigator.language |
 | settings | layout 的设置 | [`Settings`](#Settings) | - |
 | siderWidth | 侧边菜单宽度 | `number` | 208 |
+| suppressSiderWhenMenuEmpty | 在菜单为空时隐藏 Sider | `boolean` | - |
 | defaultCollapsed | 默认的菜单的收起和展开，会受到 `breakpoint` 的影响，`breakpoint=false` 生效 | `boolean` | - |
 | collapsed | 控制菜单的收起和展开 | `boolean` | - |
 | onCollapse | 菜单的折叠收起事件 | `(collapsed: boolean) => void` | - |

--- a/packages/layout/src/defaultSettings.ts
+++ b/packages/layout/src/defaultSettings.ts
@@ -119,6 +119,10 @@ export type PureSettings = {
    */
   splitMenus?: boolean;
   /**
+   * @name 在菜单为空时隐藏Sider
+   */
+  suppressSiderWhenMenuEmpty?: boolean;
+  /**
    * 侧边菜单模式
    */
   siderMenuType?: 'sub' | 'group';

--- a/packages/layout/src/demos/dynamicMenu.tsx
+++ b/packages/layout/src/demos/dynamicMenu.tsx
@@ -1,6 +1,6 @@
 import { PageContainer, ProLayout } from '@ant-design/pro-components';
-import { Button } from 'antd';
-import { useRef } from 'react';
+import { Button, Switch } from 'antd';
+import { useRef, useState } from 'react';
 import customMenuDate from './customMenu';
 
 const waitTime = (time: number = 100) => {
@@ -11,10 +11,13 @@ const waitTime = (time: number = 100) => {
   });
 };
 
+let serviceData: any[] = customMenuDate;
+
 export default () => {
   const actionRef = useRef<{
     reload: () => void;
   }>();
+  const [toggle, setToggle] = useState(false);
   return (
     <>
       <ProLayout
@@ -22,10 +25,11 @@ export default () => {
           height: '100vh',
         }}
         actionRef={actionRef}
+        suppressSiderWhenMenuEmpty={toggle}
         menu={{
           request: async () => {
             await waitTime(2000);
-            return customMenuDate;
+            return serviceData;
           },
         }}
         location={{
@@ -33,16 +37,32 @@ export default () => {
         }}
       >
         <PageContainer content="欢迎使用">
+          <div>
+            当从服务器获取的菜单为空时隐藏Sider：
+            <Switch checked={toggle} onChange={setToggle} />
+          </div>
           Hello World
           <Button
             style={{
               margin: 8,
             }}
             onClick={() => {
+              serviceData = customMenuDate;
               actionRef.current?.reload();
             }}
           >
             刷新菜单
+          </Button>
+          <Button
+            style={{
+              margin: 8,
+            }}
+            onClick={() => {
+              serviceData = [];
+              actionRef.current?.reload();
+            }}
+          >
+            刷新菜单（空数据）
           </Button>
         </PageContainer>
       </ProLayout>

--- a/tests/layout/index.test.tsx
+++ b/tests/layout/index.test.tsx
@@ -2,7 +2,7 @@ import { GithubFilled, InfoCircleFilled, QuestionCircleFilled } from '@ant-desig
 import { ProLayout } from '@ant-design/pro-components';
 import { LoginForm, ProFormText } from '@ant-design/pro-form';
 import { render } from '@testing-library/react';
-import { ConfigProvider } from 'antd';
+import { Button, ConfigProvider } from 'antd';
 import en_US from 'antd/es/locale/en_US';
 import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
@@ -1668,5 +1668,69 @@ describe('BasicLayout', () => {
 
     expect(onCollapse).toBeCalledTimes(2);
     expect(html.baseElement.querySelectorAll('li.ant-menu-submenu-open').length).toBe(2);
+  });
+
+  it('🥩 ProLayout support suppressSiderWhenMenuEmpty', async () => {
+    const handleClick = jest.fn();
+    let serviceData = [
+      {
+        path: '/',
+        name: '欢迎',
+        routes: [
+          {
+            path: '/welcome',
+            name: 'one',
+            routes: [
+              {
+                path: '/welcome/welcome',
+                name: 'two',
+                exact: true,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        path: '/demo',
+        name: '例子',
+      },
+    ];
+    const actionRef = React.createRef<{
+      reload: () => void;
+    }>();
+    const html = render(
+      <ProLayout
+        // @ts-ignore
+        actionRef={actionRef}
+        suppressSiderWhenMenuEmpty
+        location={{ pathname: '/' }}
+        menu={{
+          request: async () => {
+            return serviceData;
+          },
+        }}
+      >
+        <Button
+          id="test_btn"
+          onClick={() => {
+            handleClick();
+            serviceData = [];
+            actionRef.current?.reload();
+          }}
+        >
+          刷新菜单
+        </Button>
+      </ProLayout>,
+    );
+
+    await waitForComponentToPaint(html, 1000);
+    expect(html.baseElement.querySelectorAll('.ant-layout-sider').length).toBe(1);
+    act(() => {
+      html.baseElement.querySelector<HTMLDivElement>('#test_btn')?.click();
+    });
+
+    await waitForComponentToPaint(html, 1000);
+    expect(handleClick).toHaveBeenCalled();
+    expect(html.baseElement.querySelectorAll('.ant-layout-sider').length).toBe(0);
   });
 });


### PR DESCRIPTION
原代码只在开启了自动切割菜单（splitMenus=true）时，提供了当左侧菜单为空隐藏Sider的逻辑，当未开启自动切割菜单（splitMenus=false）时，根据不同条件获取服务器菜单且菜单为空的情况下，Sider显示空白且占用空间。