### PR TITLE
fix: menuHeaderRender not work

### DIFF
--- a/packages/layout/src/components/SiderMenu/SiderMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/SiderMenu.tsx
@@ -18,6 +18,8 @@ import { useStylish } from './style/stylish';
 
 const { Sider } = Layout;
 
+export type HeaderRenderKey = 'menuHeaderRender' | 'headerTitleRender';
+
 /**
  * 渲染 title 和 logo
  *
@@ -27,7 +29,7 @@ const { Sider } = Layout;
  */
 export const renderLogoAndTitle = (
   props: SiderMenuProps,
-  renderKey: string = 'menuHeaderRender',
+  renderKey: HeaderRenderKey = 'menuHeaderRender',
 ): React.ReactNode => {
   const { logo, title, layout } = props;
   const renderFunction = props[renderKey || ''];

--- a/packages/layout/src/components/TopNavHeader/index.tsx
+++ b/packages/layout/src/components/TopNavHeader/index.tsx
@@ -6,13 +6,13 @@ import { AppsLogoComponents } from '../AppsLogoComponents';
 import type { GlobalHeaderProps } from '../GlobalHeader';
 import { ActionsContent } from '../GlobalHeader/ActionsContent';
 import { BaseMenu } from '../SiderMenu/BaseMenu';
-import type { PrivateSiderMenuProps, SiderMenuProps } from '../SiderMenu/SiderMenu';
+import type { HeaderRenderKey, PrivateSiderMenuProps, SiderMenuProps } from '../SiderMenu/SiderMenu';
 import { renderLogoAndTitle } from '../SiderMenu/SiderMenu';
 import { useStyle } from './style';
 
 export type TopNavHeaderProps = SiderMenuProps & GlobalHeaderProps & PrivateSiderMenuProps;
 
-const TopNavHeader: React.FC<TopNavHeaderProps> = (props) => {
+const TopNavHeader: React.FC<TopNavHeaderProps> = (props: TopNavHeaderProps) => {
   const ref = useRef(null);
   const {
     onMenuHeaderClick,
@@ -30,9 +30,15 @@ const TopNavHeader: React.FC<TopNavHeaderProps> = (props) => {
   const prefixCls = `${props.prefixCls || getPrefixCls('pro')}-top-nav-header`;
 
   const { wrapSSR, hashId } = useStyle(prefixCls);
+  let renderKey: HeaderRenderKey | undefined = undefined;
+  if (props['menuHeaderRender'] !== undefined) {
+    renderKey = 'menuHeaderRender';
+  } else if (layout === 'mix' || layout === 'top') {
+    renderKey = 'headerTitleRender';
+  }
   const headerDom = renderLogoAndTitle(
     { ...props, collapsed: false },
-    layout === 'mix' || layout == 'top' ? 'headerTitleRender' : undefined,
+    renderKey,
   );
   const contentDom = useMemo(() => {
     const defaultDom = (

--- a/packages/layout/src/components/layout.en-US.md
+++ b/packages/layout/src/components/layout.en-US.md
@@ -133,7 +133,7 @@ PageContainer configuration `ghost` can switch the page header to transparent mo
 | pure | Whether to remove all self-contained interfaces | `boolean` | - |
 | loading | The loading state of the layout | `boolean` | - |
 | location | The location information of the current application session. If your application creates a custom history, you will need to display the location attribute as described in [issue](https://github.com/ant-design/pro-components/issues/327) | [history.location](https://reactrouter.com/web/api/history) | isBrowser ? window.location : undefined |
-| menuHeaderRender | render logo and title | `ReactNode` \| `(logo,title)=>ReactNode` | - |
+| menuHeaderRender | render logo and title, has a higher priority than `headerTitleRender` | `ReactNode` \| `(logo,title)=>ReactNode` | - |
 | menuFooterRender | Render a block at the bottom of the layout | `(menuProps)=>ReactNode` | - |
 | onMenuHeaderClick | menu menu menu's header click event | `(e: React.MouseEvent<HTMLDivElement>) => void` | - |
 | menuExtraRender | Renders a region below the menu header | `(menuProps)=>ReactNode` | - |

--- a/packages/layout/src/components/layout.md
+++ b/packages/layout/src/components/layout.md
@@ -131,7 +131,7 @@ PageContainer 配置 `fixedHeader` 可以将吸顶 header。
 | loading | layout 的加载态 | `boolean` | - |
 | location | 当前应用会话的位置信息。如果你的应用创建了自定义的 history，则需要显示指定 location 属性，详见 [issue](https://github.com/ant-design/pro-components/issues/327) | [history.location](https://reactrouter.com/web/api/history) | isBrowser ? window.location : undefined |
 | appList | 跨站点导航列表 | `{ icon, title, desc, url, target, children }[]` | - |
-| menuHeaderRender | 渲染 logo 和 title | `ReactNode` \| `(logo,title)=>ReactNode` | - |
+| menuHeaderRender | 渲染 logo 和 title, 优先级比 `headerTitleRender` 更高 | `ReactNode` \| `(logo,title)=>ReactNode` | - |
 | menuFooterRender | 在 layout 底部渲染一个块 | `(menuProps)=>ReactNode` | - |
 | onMenuHeaderClick | menu 菜单的头部点击事件 | `(e: React.MouseEvent<HTMLDivElement>) => void` | - |
 | menuExtraRender | 在菜单标题的下面渲染一个区域 | `(menuProps)=>ReactNode` | - |


### PR DESCRIPTION
> 修复 top 模式下，`menuHeaderRender` 不生效的问题，系 https://github.com/ant-design/pro-components/pull/6560 引入的 breaking Change

* 判断未设置 `menuHeaderRender` 时，才配置默认值

--------

> Fix the `menuHeaderRender` doesn't work in top mode, it's a breaking change in https://github.com/ant-design/pro-components/pull/6560

* Configure default value only when `menuHeaderRender` is undefined.


