### PR TITLE
fix: remove useless code

### DIFF
--- a/packages/table/src/utils/index.ts
+++ b/packages/table/src/utils/index.ts
@@ -85,7 +85,7 @@ export function useActionType<T>(
     reload: async (resetPageIndex?: boolean) => {
       // 如果为 true，回到第一页
       if (resetPageIndex) {
-        await action.setPageInfo({
+        action.setPageInfo({
           current: 1,
         });
       }
@@ -94,14 +94,14 @@ export function useActionType<T>(
     reloadAndRest: async () => {
       // reload 之后大概率会切换数据，清空一下选择。
       props.onCleanSelected();
-      await action.setPageInfo({
+      action.setPageInfo({
         current: 1,
       });
       await action?.reload();
     },
     reset: async () => {
-      await props.resetAll();
-      await action?.reset?.();
+      props.resetAll();
+      action?.reset?.();
       await action?.reload();
     },
     fullScreen: () => props.fullScreen(),


### PR DESCRIPTION
<img width="595" alt="export type UseFetchDataAction≤T" src="https://user-images.githubusercontent.com/117748716/222311042-0c6b595e-283c-4f2e-863c-f6b9253b8347.png">

![image](https://user-images.githubusercontent.com/117748716/222311557-a9331a49-7af6-4731-9dfe-ac566798e428.png)

Aciton的方法中，似乎只有reload是promise，resetAll和reset的方法其实最后都是调用hook去set数据，useState 返回的值是一个状态值和一个更新该状态值的函数，这个更新函数是异步的，但是它并不返回一个 Promise 对象，而是直接更新状态值。因此，似乎无法使用 await 关键字等待更新状态的完成。

