### PR TITLE
fix(layout): siderMenu 中的 subMenu 在 Dark 主题下显示不正常

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -396,7 +396,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
     openKeys: propsOpenKeys,
   } = props;
 
-  const { token: designToken } = useContext(ProProvider);
+  const { dark, token: designToken } = useContext(ProProvider);
 
   const baseClassName = `${prefixCls}-base-menu`;
   // 用于减少 defaultOpenKeys 计算的组件
@@ -536,7 +536,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
       mode={mode}
       inlineIndent={16}
       defaultOpenKeys={defaultOpenKeysRef.current}
-      theme="light"
+      theme={dark ? 'dark' : 'light'}
       selectedKeys={selectedKeys}
       style={{
         backgroundColor: 'transparent',

--- a/packages/layout/src/components/SiderMenu/SiderMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/SiderMenu.tsx
@@ -395,7 +395,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
             className={`${baseClassName}-link-menu ${hashId}`}
             selectedKeys={[]}
             openKeys={[]}
-            theme="light"
+            theme={theme}
             mode="inline"
             items={linksMenuItems}
           />
@@ -457,7 +457,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
         }}
         collapsedWidth={collapsedWidth}
         style={style}
-        theme="light"
+        theme={theme}
         width={siderWidth}
         className={classNames(siderClassName, hashId, hideMenuWhenCollapsedClassName)}
       >

--- a/packages/layout/src/components/TopNavHeader/index.tsx
+++ b/packages/layout/src/components/TopNavHeader/index.tsx
@@ -29,7 +29,7 @@ const TopNavHeader: React.FC<TopNavHeaderProps> = (props: TopNavHeaderProps) => 
     actionsRender,
   } = props;
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
-  const { token } = useContext(ProProvider);
+  const { dark, token } = useContext(ProProvider);
 
   const prefixCls = `${props.prefixCls || getPrefixCls('pro')}-top-nav-header`;
 
@@ -69,7 +69,7 @@ const TopNavHeader: React.FC<TopNavHeaderProps> = (props: TopNavHeaderProps) => 
         }}
       >
         <BaseMenu
-          theme="light"
+          theme={dark ? 'dark' : 'light'}
           {...props}
           className={`${prefixCls}-base-menu ${hashId}`}
           {...props.menuProps}


### PR DESCRIPTION
`Layout` 组件的 `SiderMenu` 在 Dark 主题并折叠的情况下，`SubMenu` 的主题色不正常。官网的示例可复现 https://procomponents.ant.design/components/layout#packages-layout-src-components-layout-demo-dark

![image](https://user-images.githubusercontent.com/2209055/223068902-be68ce5d-59a9-40d0-ac4f-3d5a1e261489.png)

定位到是 `theme` 没有正确传递，尝试修复了下，辛苦 review