### PR TITLE
Update index.md

### DIFF
--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -61,7 +61,7 @@ PageContainer 封装了 antd 的 PageHeader 组件，增加了 tabList 和 conte
 
 ## API
 
-PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和 content。 根据当前的路由填入 title 和 breadcrumb。它依赖 Layout 的 route 属性。当然你可以传入参数来复写默认值。 PageContainer 支持 [Tabs](https://ant.design/components/tabs-cn/) 和 [PageHeader](https://ant.design/components/page-header-cn/) 的所有属性。
+PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和 content。 根据当前的路由填入 title 和 breadcrumb。它依赖 Layout 的 route 属性。当然你可以传入参数来复写默认值。 PageContainer 支持 [Tabs](https://ant.design/components/tabs-cn/) 和 [PageHeader](https://4x.ant.design/components/page-header-cn/) 的所有属性。
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |


### PR DESCRIPTION
链接已失效，PageHeader从antd5移除，https://ant.design/docs/react/migration-v5-cn#%E7%BB%84%E4%BB%B6%E9%87%8D%E6%9E%84%E4%B8%8E%E7%A7%BB%E9%99%A4