### PR TITLE
fix: 修复在浏览器环境下hashed必为false的bug

### DIFF
--- a/packages/provider/src/index.tsx
+++ b/packages/provider/src/index.tsx
@@ -256,8 +256,7 @@ const ConfigProviderContainer: React.FC<{
     }
     if (proProvide.hashed === false) return '';
 
-    if (typeof process !== 'undefined' && process.env.NODE_ENV?.toLowerCase() !== 'test')
-      return nativeHashId;
+    if (process?.env.NODE_ENV?.toLowerCase() !== 'test') return nativeHashId;
     return '';
   }, [nativeHashId, proProvide.hashed, props.hashed]);
 
@@ -266,8 +265,7 @@ const ConfigProviderContainer: React.FC<{
       ...restConfig.theme,
       hashId: hashId,
       hashed:
-        typeof process !== 'undefined' &&
-        process.env.NODE_ENV?.toLowerCase() !== 'test' &&
+        process?.env?.NODE_ENV?.toLowerCase() !== 'test' &&
         props.hashed !== false &&
         proProvide.hashed !== false,
     };


### PR DESCRIPTION
修复在浏览器环境下,typeof process !== 'undefined'的值始终为false,导致hashed始终为false的bug.
该问题会导致#6733
因为hashed为false,导致生成的样式没有:where选择器
![image](https://user-images.githubusercontent.com/129489442/230389531-72c18a4c-63af-48e2-a4f1-c8d091cfe4cd.png)
导致样式被覆盖
![image](https://user-images.githubusercontent.com/129489442/230389315-4d9d714b-371b-4e45-92b5-d0c7e736b29f.png)
