### PR TITLE
fix(form): 当 StepForm 只有一个子项的时候按钮的渲染

### DIFF
--- a/packages/form/src/layouts/StepsForm/index.tsx
+++ b/packages/form/src/layouts/StepsForm/index.tsx
@@ -345,7 +345,12 @@ function StepsForm<T = Record<string, any>>(
     let buttons: (React.ReactElement | false)[] = [];
     const index = step || 0;
     if (index < 1) {
-      buttons.push(next);
+        // 如果有且只有一个 StepForm 第一步就应该是提交按钮
+        if (formArray.length === 1){
+            buttons.push(submit);
+        }else{
+            buttons.push(next);
+        }
     } else if (index + 1 === formArray.length) {
       buttons.push(pre, submit);
     } else {


### PR DESCRIPTION
当且仅当StepForm 只有一个子项的时候，第一个步骤就应该是提交按钮而非下一步按钮