### PR TITLE
fix(form): fix  parsed NaN value not display in readonly mode

### DIFF
--- a/packages/field/src/components/Money/index.tsx
+++ b/packages/field/src/components/Money/index.tsx
@@ -146,7 +146,10 @@ const getTextByLocale = (
 ) => {
   let moneyText: number | string | undefined = paramsText?.toString().replaceAll(',', '');
   if (typeof moneyText === 'string') {
-    moneyText = Number(moneyText);
+    const parsedNum = Number(moneyText);
+    // 转换数字为NaN时，返回原始值展示
+    if (Number.isNaN(parsedNum)) return moneyText;
+    moneyText = parsedNum;
   }
 
   if (!moneyText && moneyText !== 0) return '';


### PR DESCRIPTION
fix: https://github.com/ant-design/pro-components/issues/6931

ProFormMoney：当string类型的值无法正常转换成正常的数字时，比如  '****'  隐藏的值，直接展示，由开发者自行处理