### PR TITLE
fix(table): 修复当loading为对象时,pro-table无法接管loading状态,必须手动控制的问题

### DIFF
--- a/packages/table/src/useFetchData.tsx
+++ b/packages/table/src/useFetchData.tsx
@@ -88,8 +88,8 @@ const useFetchData = <DataSource extends RequestData<any>>(
   /**
    * 表格的加载状态
    */
-  const [tableLoading, setTableLoading] = useMountMergeState<UseFetchDataAction['loading']>(false, {
-    value: options?.loading,
+  const [tableLoading, setTableLoading] = useMountMergeState<boolean>(false, {
+    value: typeof options?.loading === 'object' ? options?.loading?.spinning : options?.loading,
     onChange: options?.onLoadingChange,
   });
 
@@ -158,11 +158,7 @@ const useFetchData = <DataSource extends RequestData<any>>(
    * https://github.com/ant-design/pro-components/issues/4390
    */
   const requestFinally = useRefFunction(() => {
-    if (typeof tableLoading === 'object') {
-      setTableLoading({ ...tableLoading, spinning: false });
-    } else {
-      setTableLoading(false);
-    }
+    setTableLoading(false);
     setPollingLoading(false);
   });
   /** 请求数据 */
@@ -173,11 +169,7 @@ const useFetchData = <DataSource extends RequestData<any>>(
       return;
     }
     if (!isPolling) {
-      if (typeof tableLoading === 'object') {
-        setTableLoading({ ...tableLoading, spinning: true });
-      } else {
-        setTableLoading(true);
-      }
+      setTableLoading(true);
     } else {
       setPollingLoading(true);
     }
@@ -369,7 +361,10 @@ const useFetchData = <DataSource extends RequestData<any>>(
      * 表示表格是否正在加载数据的标志。
      * @type {boolean}
      */
-    loading: tableLoading,
+    loading:
+      typeof options?.loading === 'object'
+        ? { ...options?.loading, spinning: tableLoading }
+        : tableLoading,
     /**
      * 重新加载表格数据的函数。
      * @type {function}


### PR DESCRIPTION
🐛 bug 描述
当loading为对象时,pro-table无法接管loading状态,必须手动控制

💻 复现代码
https://codesandbox.io/p/sandbox/loadingding-zhi-wu-xiao-wen-ti-rim9k5?file=%2Fsrc%2FApp.tsx

🏞 期望结果
无需手动控制,pro-table接管loading,加载数据时自动loading

解决方案
![image](https://user-images.githubusercontent.com/129489442/232797465-7d3173e0-755b-4311-94dc-3459ab682f54.png)
经过排查,是useMountMergeState方法,当入参value为undefined时,才会为非受控模式,setTableLoading才能生效.
所以只需要当loading为对象时,取出loading.spinning作为useMountMergeState的value入参,最后返回是再合并即可