### PR TITLE
fix: modal form init error

### DIFF
--- a/packages/form/src/layouts/ModalForm/index.tsx
+++ b/packages/form/src/layouts/ModalForm/index.tsx
@@ -257,21 +257,23 @@ function ModalForm<T = Record<string, any>>({
           ) : null
         }
       >
-        <BaseForm
-          formComponentType="ModalForm"
-          layout="vertical"
-          {...rest}
-          formRef={formRef}
-          submitter={submitterConfig}
-          onFinish={async (values) => {
-            const result = await onFinishHandle(values);
-            // fix: #6006 如果 result 为 true,那么必然会触发弹窗关闭，我们无需在 此处重置表单，只需在弹窗关闭时重置即可
-            return result;
-          }}
-          contentRender={contentRender}
-        >
-          {children}
-        </BaseForm>
+        {open && (
+          <BaseForm
+            formComponentType="ModalForm"
+            layout="vertical"
+            {...rest}
+            formRef={formRef}
+            submitter={submitterConfig}
+            onFinish={async (values) => {
+              const result = await onFinishHandle(values);
+              // fix: #6006 如果 result 为 true,那么必然会触发弹窗关闭，我们无需在 此处重置表单，只需在弹窗关闭时重置即可
+              return result;
+            }}
+            contentRender={contentRender}
+          >
+            {children}
+          </BaseForm>
+        )}
       </Modal>
       {triggerDom}
     </>


### PR DESCRIPTION
## 背景

使用 pro-component 的 ModalForm 编辑后回显值依然停留在编辑前。

## 排除情况

protable 中的render会在刷新渲染两次，一次是loading，一次是data，loading这次的值是之前的data，所以表单初始化值停留在之前了。

## 解决方案

ModalForm打开弹窗时才去渲染表单，这样就能让初始化值拿到正确的值