### PR TITLE
fix(layout): 修复因为 menu 不存在 icon 时候，收起的 tooltip 会多展示一个字的问题

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -336,7 +336,6 @@ class MenuUtil {
           `${baseClassName}-icon ${this.props?.hashId}`,
         );
     const defaultIcon = collapsed && hasIcon ? getMenuTitleSymbol(name) : null;
-    console.log('name', name);
     let defaultItem = (
       <div
         key={itemPath}
@@ -351,15 +350,13 @@ class MenuUtil {
         )}
       >
         <span
-          className={`${
-            icon
-              ? `${baseClassName}-item-icon`
-              : `${baseClassName}-item-hidden-icon`
-          } ${this.props?.hashId}`}
+          className={`${baseClassName}-item-icon ${this.props?.hashId}`}
+          style={{
+            display: defaultIcon === null && !icon ? 'none' : '',
+          }}
         >
-          {icon || defaultIcon}
+          {icon || <span className="anticon">{defaultIcon}</span>}
         </span>
-
         <span
           className={classNames(
             `${baseClassName}-item-text`,
@@ -395,15 +392,14 @@ class MenuUtil {
             },
           )}
         >
-          {icon ? (
-            <span
-              className={`${baseClassName}-item-icon ${this.props?.hashId}`}
-            >
-              {icon}
-            </span>
-          ) : (
-            defaultIcon
-          )}
+          <span
+            className={`${baseClassName}-item-icon ${this.props?.hashId}`}
+            style={{
+              display: defaultIcon === null && !icon ? 'none' : '',
+            }}
+          >
+            {icon || <span className="anticon">{defaultIcon}</span>}
+          </span>
           <span
             className={classNames(
               `${baseClassName}-item-text`,

--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -336,6 +336,7 @@ class MenuUtil {
           `${baseClassName}-icon ${this.props?.hashId}`,
         );
     const defaultIcon = collapsed && hasIcon ? getMenuTitleSymbol(name) : null;
+    console.log('name', name);
     let defaultItem = (
       <div
         key={itemPath}
@@ -349,13 +350,16 @@ class MenuUtil {
           },
         )}
       >
-        {icon ? (
-          <span className={`${baseClassName}-item-icon ${this.props?.hashId}`}>
-            {icon}
-          </span>
-        ) : (
-          defaultIcon
-        )}
+        <span
+          className={`${
+            icon
+              ? `${baseClassName}-item-icon`
+              : `${baseClassName}-item-hidden-icon`
+          } ${this.props?.hashId}`}
+        >
+          {icon || defaultIcon}
+        </span>
+
         <span
           className={classNames(
             `${baseClassName}-item-text`,

--- a/packages/layout/src/components/SiderMenu/style/menu.ts
+++ b/packages/layout/src/components/SiderMenu/style/menu.ts
@@ -14,6 +14,11 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
     ? token.layout?.header
     : token.layout?.sider;
   return {
+    [`${token.antCls}-tooltip`]: {
+      [`${token.componentCls}-item-hidden-icon`]: {
+        display: 'none !important',
+      },
+    },
     [`${token.componentCls}`]: {
       background: 'transparent',
       color: menuToken?.colorTextMenu,

--- a/packages/layout/src/components/SiderMenu/style/menu.ts
+++ b/packages/layout/src/components/SiderMenu/style/menu.ts
@@ -14,11 +14,6 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
     ? token.layout?.header
     : token.layout?.sider;
   return {
-    [`${token.antCls}-tooltip`]: {
-      [`${token.componentCls}-item-hidden-icon`]: {
-        display: 'none !important',
-      },
-    },
     [`${token.componentCls}`]: {
       background: 'transparent',
       color: menuToken?.colorTextMenu,


### PR DESCRIPTION
![image](https://github.com/ant-design/pro-components/assets/52664827/2b669917-8da8-495d-93d8-1429e6621f74)
如图所示，欢迎 会变成 欢欢迎