### PR TITLE
fix(table): Edit to make defaultValue become higher priority to reset column setting

### DIFF
--- a/packages/layout/src/components/TopNavHeader/index.tsx
+++ b/packages/layout/src/components/TopNavHeader/index.tsx
@@ -34,7 +34,7 @@ const TopNavHeader: React.FC<TopNavHeaderProps> = (
     actionsRender,
   } = props;
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
-  const { dark, token } = useContext(ProProvider);
+  const { dark } = useContext(ProProvider);
 
   const prefixCls = `${props.prefixCls || getPrefixCls('pro')}-top-nav-header`;
 

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -418,8 +418,8 @@ function ColumnSetting<T>(props: ColumnSettingProps<T>) {
   const clearClick = useRefFunction(() => {
     clearPersistenceStorage?.();
     setColumnsMap(
-      columnRef.current ||
-        counter.propsRef.current?.columnsState?.defaultValue ||
+      counter.propsRef.current?.columnsState?.defaultValue ||
+        columnRef.current ||
         counter.defaultColumnKeyMap!,
     );
   });

--- a/packages/table/src/components/table.en-US.md
+++ b/packages/table/src/components/table.en-US.md
@@ -112,7 +112,7 @@ ProTable puts a layer of wrapping on top of antd's Table, supports some presets,
 
 | Property | Description | Type | Default |
 | --- | --- | --- | --- |
-| defaultValue | The default value of the column status, only for the first time | `Record <string, ColumnsState>;` |
+| defaultValue | The default value of the column status, only for the first time. Used for resetting value | `Record <string, ColumnsState>;` |
 | value | Column status, support controlled mode | `Record <string, ColumnsState>;` |
 | onChange | Column status After changing | `(value: Record <string, ColumnsState>) => void` |
 | PersistenceKey | The key of the persistence column is used to determine if it is the same table | `string \| Number` |

--- a/packages/table/src/components/table.md
+++ b/packages/table/src/components/table.md
@@ -115,7 +115,7 @@ ProTable 在 antd 的 Table 上进行了一层封装，支持了一些预设，�
 
 | 属性 | 描述 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| defaultValue | 列状态的默认值，只有初次生效 | `Record<string, ColumnsState>;` | - |
+| defaultValue | 列状态的默认值，只有初次生效，並用于重置使用 | `Record<string, ColumnsState>;` | - |
 | value | 列状态的值，支持受控模式 | `Record<string, ColumnsState>;` | - |
 | onChange | 列状态的值发生改变之后触发 | `(value:Record<string, ColumnsState>)=>void` | - |
 | persistenceKey | 持久化列的 key，用于判断是否是同一个 table | `string \| number` | - |

--- a/tests/table/columnSetting.test.tsx
+++ b/tests/table/columnSetting.test.tsx
@@ -734,6 +734,96 @@ describe('Table ColumnSetting', () => {
     });
   });
 
+  it('🎏 columnSetting click Reset and reset when columnsState.value and columnsState.defaultValue also exist', async () => {
+    const onChange = jest.fn();
+    const html = render(
+      <ProTable
+        size="small"
+        columnsState={{
+          value: {
+            age: { show: true },
+            name: { show: true },
+            option: { show: true },
+          },
+          onChange,
+          defaultValue: {
+            age: { show: false },
+            name: { show: false },
+            option: { show: true },
+          },
+        }}
+        columns={[
+          {
+            title: 'Name',
+            key: 'name',
+            dataIndex: 'name',
+          },
+          {
+            title: 'age',
+            key: 'age',
+            dataIndex: 'age',
+          },
+          {
+            title: 'option',
+            key: 'option',
+            dataIndex: 'option',
+          },
+        ]}
+        request={async () => {
+          return {
+            data: [
+              {
+                key: 1,
+                name: `TradeCode ${1}`,
+                createdAt: 1602572994055,
+              },
+            ],
+            success: true,
+          };
+        }}
+        rowKey="key"
+      />,
+    );
+
+    await waitTime(200);
+    act(() => {
+      html.baseElement
+        .querySelector<HTMLDivElement>(
+          '.ant-pro-table-list-toolbar-setting-item .anticon-setting',
+        )
+        ?.click();
+    });
+    await waitTime(100);
+    expect(
+      html.baseElement.querySelectorAll<HTMLDivElement>(
+        'span.ant-tree-checkbox.ant-tree-checkbox-checked',
+      ).length,
+    ).toBe(3);
+
+    act(() => {
+      html.baseElement
+        .querySelector<HTMLDivElement>(
+          `.ant-pro-table-column-setting-action-rest-button`,
+        )
+        ?.click();
+    });
+
+    expect(onChange).toBeCalledTimes(1);
+    expect((onChange.mock as any).lastCall[0]).toMatchInlineSnapshot(`
+      {
+        "age": {
+          "show": false,
+        },
+        "name": {
+          "show": false,
+        },
+        "option": {
+          "show": true,
+        },
+      }
+    `);
+  });
+
   it('🎏 columnsState use the column key or dataIndex as index name', async () => {
     const onChange = jest.fn();
     const html = render(


### PR DESCRIPTION
## Background:
When user click reset button on column setting dropDown. `clearClick` function will execute and set column value.
But the reset value can not be controlled. 
```
  /** 重置项目 */
  const clearClick = useRefFunction(() => {
    clearPersistenceStorage?.();
    setColumnsMap(
      columnRef.current ||
        counter.propsRef.current?.columnsState?.defaultValue ||
        counter.defaultColumnKeyMap!,
    );
  });
```

If i change the code order be selected `defaultValue` first. Developer can use defaultValue with value to control reset value.
```
      counter.propsRef.current?.columnsState?.defaultValue ||
        columnRef.current ||
```

I think defaultValue should follow the literal meaning  as `default`.
