### PR TITLE
fix(list): 修复 ProFormList 使用 className 无效问题

### DIFF
--- a/packages/form/src/components/List/index.tsx
+++ b/packages/form/src/components/List/index.tsx
@@ -217,6 +217,8 @@ function ProFormList<T>(props: ProFormListProps<T>) {
           tooltip={tooltip}
           style={style}
           required={rules?.some((rule) => rule.required)}
+          wrapperCol={wrapperCol}
+          className={className}
           {...rest}
           name={isValidateList ? name : undefined}
           rules={


### PR DESCRIPTION
fix https://github.com/ant-design/pro-components/issues/7127