### PR TITLE
fix(form): 修复 ProTable 的 columns.proFieldProps 不生效

### DIFF
--- a/packages/form/src/layouts/LightFilter/index.tsx
+++ b/packages/form/src/layouts/LightFilter/index.tsx
@@ -164,6 +164,7 @@ const LightFilterContainer: React.FC<{
                 },
                 // proFieldProps 会直接作为 ProField 的 props 传递过去
                 proFieldProps: {
+                  ...child.props.proFieldProps,
                   light: true,
                   label: child.props.label,
                   bordered,


### PR DESCRIPTION
ProTable 开启 lightFilter 时，有需求在 columns 里配置 proFieldProps，但是不生效