### PR TITLE
修复 ProDescriptions.Item valueType={'textarea'} 只读模式样式问题

### DIFF
--- a/packages/field/src/components/TextArea/index.tsx
+++ b/packages/field/src/components/TextArea/index.tsx
@@ -22,7 +22,6 @@ const FieldTextArea: ProFieldFC<{
         ref={ref}
         style={{
           display: 'inline-block',
-          padding: '4px 11px',
           lineHeight: '1.5715',
           maxWidth: '100%',
           whiteSpace: 'pre-wrap',


### PR DESCRIPTION
fix https://github.com/ant-design/pro-components/issues/7237