### PR TITLE
feat(table): add support of custom render serch form

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -886,7 +886,7 @@ const ProTable = <
     search,
     searchFormRender,
     type,
-  ])
+  ]);
 
   const selectedRows = useMemo(
     () => selectedRowKeys?.map((key) => preserveRecordsRef.current?.get(key)),

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -449,6 +449,7 @@ const ProTable = <
     polling,
     tooltip,
     revalidateOnFocus = false,
+    searchFormRender,
     ...rest
   } = props;
   const { wrapSSR, hashId } = useStyle(props.defaultClassName);
@@ -843,8 +844,8 @@ const ProTable = <
     return action.loading;
   }, [action.loading]);
 
-  const searchNode =
-    search === false && type !== 'form' ? null : (
+  const searchNode = useMemo(() => {
+    const node = search === false && type !== 'form' ? null : (
       <FormRender<T, U>
         pagination={pagination}
         beforeSearchSubmit={beforeSearchSubmit}
@@ -866,6 +867,26 @@ const ProTable = <
         dateFormatter={props.dateFormatter}
       />
     );
+
+    if (searchFormRender && node) {
+      return <>{searchFormRender(props, node)}</>;
+    } else {
+      return node;
+    }
+  }, [
+    beforeSearchSubmit,
+    formRef,
+    ghost,
+    loading,
+    manualRequest,
+    onFormSearchSubmit,
+    pagination,
+    props,
+    propsColumns,
+    search,
+    searchFormRender,
+    type,
+  ])
 
   const selectedRows = useMemo(
     () => selectedRowKeys?.map((key) => preserveRecordsRef.current?.get(key)),

--- a/packages/table/src/typing.ts
+++ b/packages/table/src/typing.ts
@@ -276,6 +276,14 @@ export type ProTableProps<DataSource, U, ValueType = 'text'> = {
     dataSource: DataSource[],
   ) => React.ReactNode;
 
+  /**
+   * @name 渲染搜索表单
+   */
+  searchFormRender?: (
+    props: ProTableProps<DataSource, U, ValueType>,
+    defaultDom: JSX.Element,
+  ) => React.ReactNode;
+
   /** @name 一个获得 dataSource 的方法 */
   request?: (
     params: U & {


### PR DESCRIPTION
新增自定义搜索表单渲染支持。

我的业务需求是在 search form 外面套一层 provider，类似用  tableRender  可以在  table  外面套一层 wrapper 那样。