### PR TITLE
fix(form): update ReturnType<SearchConvertKeyFn>

### DIFF
--- a/packages/form/src/components/form.en-US.md
+++ b/packages/form/src/components/form.en-US.md
@@ -70,7 +70,7 @@ Many times there is no exact match between the data required by the component an
 convertValue occurs before the component obtains data, usually the data directly sent from the backend to the frontend, and sometimes needs to be refined.
 
 ```tsx | pure
-   export type SearchConvertKeyFn = (value: any, field: NamePath) => string | Record<string, any>;
+   export type SearchConvertKeyFn = (value: any, field: NamePath) => string | boolean | Record<string, any>;
   /**
    * @name Converts the value when getting it, generally used to format the data into the format received by the component
    * @param value field value

--- a/packages/form/src/components/form.md
+++ b/packages/form/src/components/form.md
@@ -83,7 +83,7 @@ convertValue 发生在组件获得数据之前，一般是后端直接给前端�
 
 ```tsx | pure
    export type SearchConvertKeyFn =
-    (value: any, field: NamePath)=>string | Record<string, any>;
+    (value: any, field: NamePath)=>string | boolean | Record<string, any>;
   /**
    * @name 获取时转化值，一般用于将数据格式化为组件接收的格式
    * @param value 字段的值

--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -419,7 +419,7 @@ export type SearchTransformKeyFn = (
 export type SearchConvertKeyFn = (
   value: any,
   field: NamePath,
-) => string | Record<string, any>;
+) => string | boolean | Record<string, any>;
 
 export type ProTableEditableFnType<T> = (
   value: any,


### PR DESCRIPTION
ProFormField的前置转化prop`convertValue` 的类型`SearchConvertKeyFn`支持返回boolean类型。
因为`ProFormCheckbox`组件的value值是boolean类型，所以convertValue 返回的值按理来说应该要支持boolean值。
![image](https://github.com/ant-design/pro-components/assets/76635711/1be29bd6-2695-42da-95fa-aa4de3eab606)
