### PR TITLE
fix: 菜单折叠后icon的样式问题 #7461

### DIFF
--- a/packages/layout/src/components/SiderMenu/style/menu.ts
+++ b/packages/layout/src/components/SiderMenu/style/menu.ts
@@ -76,9 +76,9 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
           minWidth: 40,
           height: 40,
           [`${token.componentCls}-item-icon`]: {
-            height: '16px',
+            height: '40px',
             width: '16px',
-            lineHeight: '16px !important',
+            lineHeight: '40px !important',
             '.anticon': {
               lineHeight: '16px',
               height: '16px',


### PR DESCRIPTION
看了antd的menu组件其实也是有这个line-height:40 的，所以感觉问题并不是这个。

![image](https://github.com/ant-design/pro-components/assets/117748716/4ea0faae-cb07-4143-bd6c-1f8f1d3a7f55)


![image](https://github.com/ant-design/pro-components/assets/117748716/31e0f411-293d-40ef-8d50-a481d821d81a)
