### PR TITLE
fix(form): textarea 只读状态样式不统一

### DIFF
--- a/packages/field/src/components/TextArea/index.tsx
+++ b/packages/field/src/components/TextArea/index.tsx
@@ -2,6 +2,7 @@ import { useIntl } from '@ant-design/pro-provider';
 import { Input } from 'antd';
 import React from 'react';
 import type { ProFieldFC } from '../../index';
+import FieldTextAreaReadonly from './readonly';
 
 // 兼容代码-----------
 import 'antd/lib/input/style';
@@ -13,24 +14,12 @@ import 'antd/lib/input/style';
  */
 const FieldTextArea: ProFieldFC<{
   text: string;
-}> = ({ text, mode, render, renderFormItem, fieldProps }, ref) => {
+}> = (props, ref) => {
+  const { text, mode, render, renderFormItem, fieldProps } = props;
   const intl = useIntl();
 
   if (mode === 'read') {
-    const dom = (
-      <span
-        ref={ref}
-        style={{
-          display: 'inline-block',
-          padding: '4px 11px',
-          lineHeight: '1.5715',
-          maxWidth: '100%',
-          whiteSpace: 'pre-wrap',
-        }}
-      >
-        {text ?? '-'}
-      </span>
-    );
+    const dom = <FieldTextAreaReadonly {...props} ref={ref} />;
     if (render) {
       return render(text, { mode, ...fieldProps }, dom);
     }

--- a/packages/field/src/components/TextArea/readonly.tsx
+++ b/packages/field/src/components/TextArea/readonly.tsx
@@ -1,0 +1,46 @@
+import { useStyle } from '@ant-design/pro-utils';
+import { ConfigProvider } from 'antd';
+import classNames from 'classnames';
+import React, { useContext } from 'react';
+import type { ProFieldFC } from '../../index';
+
+// 兼容代码-----------
+import 'antd/lib/input/style';
+//------------
+
+/**
+ * Input.TextArea 只读模式时渲染的组件
+ *
+ * @param
+ */
+const FieldTextAreaReadonly: ProFieldFC<{
+  text: string;
+}> = ({ text }, ref) => {
+  const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
+  const readonlyClassName = getPrefixCls('pro-field-readonly');
+  const compClassName = `${readonlyClassName}-textarea`;
+
+  const { wrapSSR, hashId } = useStyle('TextArea', () => {
+    return {
+      [`.${compClassName}`]: {
+        display: 'inline-block',
+        // padding: '4px 11px',
+        lineHeight: '1.5715',
+        maxWidth: '100%',
+        whiteSpace: 'pre-wrap',
+      },
+    };
+  });
+
+  return wrapSSR(
+    <span
+      ref={ref}
+      className={classNames(hashId, readonlyClassName, compClassName)}
+      style={{}}
+    >
+      {text ?? '-'}
+    </span>,
+  );
+};
+
+export default React.forwardRef(FieldTextAreaReadonly);


### PR DESCRIPTION
## 修改内容

- 为只读状态的 textarea 组件添加 `.ant-pro-field-readonly` 和 `.ant-pro-field-readonly-textarea` 样式类
- 将原先只读 textarea 的样式转移至 `.ant-pro-field-readonly-textarea` 样式类下
- 移除了 `padding: '4px 11px'` 样式

## 后续内容

我认为可以把所有只读状态的表单项都统一包裹 span 标签并添加  `.ant-pro-field-readonly`，便于开发者进行修改，这么做是否合适需要各位给一些意见。

fix #7578 
fix #6618