### PR TITLE
fix(type): ValueTypeWithFieldPropsBase 泛型参数失效

### DIFF
--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -276,9 +276,7 @@ type ValueTypeWithFieldPropsBase<
     Entity,
     ComponentsType,
     ExtraProps,
-    ValueType extends any
-      ? ProFieldValueTypeWithFieldProps['text']
-      : ValueType extends ProFieldValueType
+    ValueType extends ProFieldValueType
       ? ProFieldValueTypeWithFieldProps[ValueType]
       : ProFieldValueTypeWithFieldProps['text']
   >;


### PR DESCRIPTION
https://github.com/ant-design/pro-components/commit/f6215e98eaeb46fa979c1ca4ac40ceaa0828f9f3#diff-c085eaf1db2f2058548f56b8ebba89098f79abb6593952091cc3ebee47d8c847R170

这个 commit 中给未定义的 ValueType 做了兜底，然而第一层用的是 `ValueType extends any`，事实上导致了永远走 true 的分支（ValueType 视为 text），失去了自动推断的效果

old:
<img width="601" alt="image" src="https://github.com/ant-design/pro-components/assets/34739463/5ed72cef-c642-43bf-871a-730d4e4e082d">

new:
<img width="1057" alt="image" src="https://github.com/ant-design/pro-components/assets/34739463/e69dfb41-c212-407f-a329-f09a257c9236">

