### PR TITLE
fix: Datepicker does not support arrays in read-only mode

### DIFF
--- a/packages/field/src/components/DatePicker/index.tsx
+++ b/packages/field/src/components/DatePicker/index.tsx
@@ -18,7 +18,7 @@ const formatDate = (text: any, format: any) => {
   if (typeof format === 'function') {
     return format(dayjs(text));
   } else {
-    return dayjs(text).format(format || 'YYYY-MM-DD');
+    return dayjs(text).format((format instanceof Array ? format[0] : format) || 'YYYY-MM-DD');
   }
 };
 

--- a/tests/field/datePick.test.tsx
+++ b/tests/field/datePick.test.tsx
@@ -164,4 +164,40 @@ describe('Field', () => {
       '<div><div><div>2016-11-22 15:22:44</div><div>2016-11-23 15:22:44</div></div></div>',
     );
   });
+
+  it(`📅  DatePicker support format is Array`, async () => {
+    const fn = jest.fn();
+    const html = render(
+      <Field
+        mode="read"
+        fieldProps={{
+          format: ['YYYY-MM-DD', 'YYYYMMDD'],
+        }}
+        onChange={fn}
+        text={dayjs()}
+        light
+        valueType="date"
+      />,
+    );
+
+    expect(html.baseElement.innerHTML).toBe('<div><div>2016-11-22</div></div>');
+  });
+
+  it(`📅  DatePicker support format is Array`, async () => {
+    const fn = jest.fn();
+    const html = render(
+      <Field
+        mode="read"
+        fieldProps={{
+          format: ['YYYYMMDD', 'YYYY-MM-DD'],
+        }}
+        onChange={fn}
+        text={dayjs()}
+        light
+        valueType="date"
+      />,
+    );
+
+    expect(html.baseElement.innerHTML).toBe('<div><div>20161122</div></div>');
+  });
 });


### PR DESCRIPTION
Datepicker does not support arrays in read-only mode #7593 