### PR TITLE
fix(table): sortConfig值为undefined时与默认值{}不一致，会导致翻页时再次触发request请求

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -963,7 +963,7 @@ const ProTable = <
       toolbarDom={toolbarDom}
       onSortChange={(sortConfig) => {
         if (proSort === sortConfig) return;
-        setProSort(sortConfig);
+        setProSort(sortConfig ?? {});
       }}
       onFilterChange={(filterConfig) => {
         if (filterConfig === proFilter) return;


### PR DESCRIPTION
具体表现：
1. 假设：请求数据100条，总数100条，每页5条；（预期本地翻页）
2. 初始通过request请求服务端数据100条；
3. 点击第2页，预期本地翻页，但实际发起了request请求 因此列表始终会有两次request请求。

原因：
setProSort(sortConfig)时，sortConfig值为undefined，与原初始值{}不相同，触发effect，从而发起了request请求。