### PR TITLE
fix(treeSelect): 修复treeSelect组件bordered属性无法生效

### DIFF
--- a/packages/field/src/components/TreeSelect/index.tsx
+++ b/packages/field/src/components/TreeSelect/index.tsx
@@ -173,8 +173,8 @@ const FieldTreeSelect: ProFieldFC<GroupProps> = (
                 }
               : undefined
           }
-          {...fieldProps}
           bordered={!light}
+          {...fieldProps}
           treeData={options as TreeSelectProps['treeData']}
           showSearch={showSearch}
           style={{


### PR DESCRIPTION
treeSelect组件，fieldProps中的bordered无法生效