### PR TITLE
chore: 修复 eslint 插件报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "dumi-theme-antd-style": "0.25.1",
     "esbuild": "^0.15.18",
     "eslint": "^8.49.0",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-unicorn": "^47.0.0",


### PR DESCRIPTION
vscode 中使用 pnpm install 依赖后，eslint 插件报如下错误，eslint 插件无法正常运行

```
Uncaught exception received.
Error: Failed to load plugin 'jest' declared in '.eslintrc.js » /Users/xliez/Github/pro-components/node_modules/.pnpm/@umijs+fabric@4.0.1/node_modules/@umijs/fabric/dist/eslint.js': Cannot find module 'eslint-plugin-jest'
```

环境: 
MacOS 13
vscode: 1.82.2
pnpm: 8.6.3