### PR TITLE
fix(table): 修复editableFormRef hooks 未正确传递 deps 依赖导致 value 取值不是最新

### DIFF
--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -19,6 +19,7 @@ import useMergedState from 'rc-util/lib/hooks/useMergedState';
 import get from 'rc-util/lib/utils/get';
 import set from 'rc-util/lib/utils/set';
 import React, {
+  useCallback,
   useContext,
   useEffect,
   useImperativeHandle,
@@ -200,32 +201,35 @@ function EditableTable<
    * @param finlayRowKey
    * @returns string | number
    */
-  const coverRowKey = (finlayRowKey: number | string): string | number => {
-    /**
-     * 如果是 prop.name 的模式，就需要把行号转化成具体的rowKey。
-     */
-    if (typeof finlayRowKey === 'number' && !props.name) {
-      if (finlayRowKey >= value.length) return finlayRowKey;
-      const rowData = value && value[finlayRowKey];
-      return getRowKey?.(rowData!, finlayRowKey);
-    }
+  const coverRowKey = useCallback(
+    (finlayRowKey: number | string): string | number => {
+      /**
+       * 如果是 prop.name 的模式，就需要把行号转化成具体的rowKey。
+       */
+      if (typeof finlayRowKey === 'number' && !props.name) {
+        if (finlayRowKey >= value.length) return finlayRowKey;
+        const rowData = value && value[finlayRowKey];
+        return getRowKey?.(rowData!, finlayRowKey);
+      }
 
-    /**
-     * 如果是 prop.name 的模式，就直接返回行号
-     */
-    if (
-      (typeof finlayRowKey === 'string' || finlayRowKey >= value.length) &&
-      props.name
-    ) {
-      const rowIndex = value.findIndex((item, index) => {
-        return (
-          getRowKey?.(item, index)?.toString() === finlayRowKey?.toString()
-        );
-      });
-      if (rowIndex !== -1) return rowIndex;
-    }
-    return finlayRowKey;
-  };
+      /**
+       * 如果是 prop.name 的模式，就直接返回行号
+       */
+      if (
+        (typeof finlayRowKey === 'string' || finlayRowKey >= value.length) &&
+        props.name
+      ) {
+        const rowIndex = value.findIndex((item, index) => {
+          return (
+            getRowKey?.(item, index)?.toString() === finlayRowKey?.toString()
+          );
+        });
+        if (rowIndex !== -1) return rowIndex;
+      }
+      return finlayRowKey;
+    },
+    [getRowKey, props.name, value],
+  );
 
   // 设置 editableFormRef
   useImperativeHandle(
@@ -297,7 +301,7 @@ function EditableTable<
         },
       } as EditableFormInstance<DataType>;
     },
-    [props.name, formRef.current],
+    [coverRowKey, props.name],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Why:
editableFormRef.current.setRowData 这个 API 用了 coverRowKey 方法，而 coverRowKey 又用到了 value，但是没有加入到 hooks deps 中，导致 value 取值不是最新的