### PR TITLE
fix(Table): 修改 search transform 类型

### DIFF
--- a/packages/utils/src/typing.ts
+++ b/packages/utils/src/typing.ts
@@ -501,7 +501,7 @@ export type SearchTransformKeyFn = (
   value: any,
   namePath: string,
   allValues: any,
-) => string | Record<string, any>;
+) => any;
 export type SearchConvertKeyFn = (
   value: any,
   field: NamePath,


### PR DESCRIPTION
不返回对象类型时，应该支持 undefined 或 null 或其它格式，不应该只支持 string 类型
```
// 现在这样会报错
transform: (value) => value ? moment(value).valueOf : undefined
```