### PR TITLE
fix(form): 首次同步到 url 参数时也执行 syncToUrl

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -642,10 +642,10 @@ function BaseForm<T = Record<string, any>, U = Record<string, any>>(
 
   useEffect(() => {
     if (!syncToUrl) return;
-    setUrlSearch({
+    setUrlSearch(genParams(syncToUrl, {
       ...urlSearch,
       ...extraUrlParams,
-    });
+    }, 'set'));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [extraUrlParams, syncToUrl]);
 


### PR DESCRIPTION
**现状**
现有 syncToUrl 如果是函数，在组件初始化的时候并不会执行。而初始化时参数一定会带上翻页参数 current 和 pageSize。基于现有实现这俩参数将永远出现在 url 参数中（即使 syncToUrl 中配置为 undefined 也无效）。

**解决方法**
组件初始化同步 url 参数时也执行 syncToUrl 函数