### PR TITLE
fix(table): 修复 EditableProTable 实时编辑表格存在 name 属性且有分页的时候，渲染的数据总是为第一页

### DIFF
--- a/packages/table/src/utils/cellRenderToFromItem.tsx
+++ b/packages/table/src/utils/cellRenderToFromItem.tsx
@@ -76,15 +76,16 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
     recordKey,
     subName,
     proFieldProps,
-    editableUtils
+    editableUtils,
   } = props;
 
   const editableForm = ProForm.useFormInstance();
 
   const key = recordKey || index;
   const realIndex = useMemo(
-      () => editableUtils?.getRealIndex?.(rowData) ?? index, [editableUtils, index, rowData]
-  )
+    () => editableUtils?.getRealIndex?.(rowData) ?? index,
+    [editableUtils, index, rowData],
+  );
   const [formItemName, setName] = useState<React.Key[]>(() =>
     spellNamePath(
       prefixName,
@@ -106,7 +107,17 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
       columnProps?.key ?? columnProps?.dataIndex ?? index,
     );
     if (value.join('-') !== formItemName.join('-')) setName(value);
-  }, [columnProps?.dataIndex, columnProps?.key, index, recordKey, prefixName, key, subName, formItemName, realIndex]);
+  }, [
+    columnProps?.dataIndex,
+    columnProps?.key,
+    index,
+    recordKey,
+    prefixName,
+    key,
+    subName,
+    formItemName,
+    realIndex,
+  ]);
 
   const needProps = useMemo(
     () =>

--- a/packages/table/src/utils/cellRenderToFromItem.tsx
+++ b/packages/table/src/utils/cellRenderToFromItem.tsx
@@ -76,16 +76,20 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
     recordKey,
     subName,
     proFieldProps,
+    editableUtils
   } = props;
 
   const editableForm = ProForm.useFormInstance();
 
   const key = recordKey || index;
+  const realIndex = useMemo(
+      () => editableUtils?.getRealIndex?.(rowData) ?? index, [editableUtils, index, rowData]
+  )
   const [formItemName, setName] = useState<React.Key[]>(() =>
     spellNamePath(
       prefixName,
       prefixName ? subName : [],
-      prefixName ? index : key,
+      prefixName ? realIndex : key,
       columnProps?.key ?? columnProps?.dataIndex ?? index,
     ),
   );
@@ -98,20 +102,11 @@ const CellRenderFromItem = <T,>(props: CellRenderFromItemProps<T>) => {
     const value = spellNamePath(
       prefixName,
       prefixName ? subName : [],
-      prefixName ? index : key,
+      prefixName ? realIndex : key,
       columnProps?.key ?? columnProps?.dataIndex ?? index,
     );
     if (value.join('-') !== formItemName.join('-')) setName(value);
-  }, [
-    columnProps?.dataIndex,
-    columnProps?.key,
-    index,
-    recordKey,
-    prefixName,
-    key,
-    subName,
-    formItemName,
-  ]);
+  }, [columnProps?.dataIndex, columnProps?.key, index, recordKey, prefixName, key, subName, formItemName, realIndex]);
 
   const needProps = useMemo(
     () =>

--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -137,6 +137,11 @@ export type RowEditableConfig<DataType> = {
   cancelText?: React.ReactNode;
   /** 删除一行的文字 */
   deleteText?: React.ReactNode;
+  /**
+   * 解决分页带来的 FormItem namePath 使用错误的 index 作为路径
+   * @link https://github.com/ant-design/pro-components/issues/7790
+   */
+  getRealIndex?: (record: DataType) => number;
 };
 export type ActionTypeText<T> = {
   deleteText?: React.ReactNode;
@@ -1057,6 +1062,7 @@ export function useEditableArray<RecordType>(
     newLineRecord: newLineRecordCache,
     preEditableKeys: editableKeysRef,
     onValuesChange,
+    getRealIndex: props.getRealIndex
   };
 }
 


### PR DESCRIPTION
fix: https://github.com/ant-design/pro-components/issues/7790

我的方案是类似 rowKey ，用户可以给 dataSource 每项配置个 index 的属性，设置了 editable.getRealIndex 方法就去取这个 index 的值来生成 Item.name ，这样分页后的 表单就和真正的 index 对应上