### PR TITLE
fix(layout): add `title` property to `ProHelp` component

### DIFF
--- a/packages/layout/src/components/Help/ProHelpDrawer.tsx
+++ b/packages/layout/src/components/Help/ProHelpDrawer.tsx
@@ -28,8 +28,14 @@ export const ProHelpDrawer: React.FC<ProHelpDrawerProps> = ({
     <Drawer
       width={720}
       closeIcon={null}
-      headerStyle={{ display: 'none' }}
-      bodyStyle={{ padding: 0 }}
+      styles={{
+        header: {
+          display: 'none'
+        },
+        body: {
+          padding: 0,
+        },
+      }}
       maskClosable
       {...drawerProps}
       open={drawerOpen}

--- a/packages/layout/src/components/Help/ProHelpModal.tsx
+++ b/packages/layout/src/components/Help/ProHelpModal.tsx
@@ -28,8 +28,10 @@ export const ProHelpModal: React.FC<ProHelpModalProps> = ({
       onCancel={() => {
         setModalOpen(false);
       }}
-      bodyStyle={{
-        margin: -24,
+      styles={{
+        body: {
+          margin: -24,
+        },
       }}
       centered
       closable={false}

--- a/packages/layout/src/components/Help/ProHelpPanel.tsx
+++ b/packages/layout/src/components/Help/ProHelpPanel.tsx
@@ -20,6 +20,10 @@ export const SelectKeyProvide = React.createContext<{
 
 export type ProHelpPanelProps = {
   /**
+   * 帮助面板的标题
+   */
+  title?: string;
+  /**
    * 帮助面板首次打开时的默认选中文档的键名
    */
   defaultSelectedKey?: string;
@@ -87,6 +91,7 @@ export type ProHelpPanelProps = {
  * @returns
  */
 export const ProHelpPanel: React.FC<ProHelpPanelProps> = ({
+  title = '帮助中心',
   bordered = true,
   onClose,
   footer,
@@ -200,7 +205,7 @@ export const ProHelpPanel: React.FC<ProHelpPanelProps> = ({
     >
       <Card
         bordered={bordered}
-        title="帮助中心"
+        title={title}
         bodyStyle={{
           display: 'flex',
           padding: 0,


### PR DESCRIPTION
1. Add `title` property to `ProHelp` component to allow rename card title
2. Remove deprecated `bodyStyle`, `headerStyle` property