### PR TITLE
revert(layout): 回滚 Layout Menu 的获取逻辑

### DIFF
--- a/packages/layout/src/components/SiderMenu/BaseMenu.tsx
+++ b/packages/layout/src/components/SiderMenu/BaseMenu.tsx
@@ -289,7 +289,7 @@ class MenuUtil {
 
       const childrenList = this.getNavMenuItems(
         children,
-        isGroup && level === 0 ? level : level + 1,
+        isGroup && level === 0 && this.props.collapsed ? level : level + 1,
       );
 
       return [


### PR DESCRIPTION
revert：https://github.com/ant-design/pro-components/commit/24cf79956f5078f5c68320036c2af01f5cb36fe9
会导致 Layout 的 siderMenuType 为 Group 时候的默认逻辑变动。
左侧为老版本
![image](https://github.com/ant-design/pro-components/assets/52664827/69b8469a-9d5c-4603-a445-8f458f4afe89)
