### PR TITLE
fix(FieldOptions): 修复 FieldOptions 中子元素换行问题

### DIFF
--- a/packages/field/src/components/Options/index.tsx
+++ b/packages/field/src/components/Options/index.tsx
@@ -18,7 +18,6 @@ const addArrayKeys = (doms: React.ReactNode[]) =>
       key: index,
       ...dom?.props,
       style: {
-        flex: 1,
         // @ts-ignore
         ...dom?.props?.style,
       },


### PR DESCRIPTION
原来FieldOptions组件样式有问题，子元素默认都设置了 `flex: 1` ，当子元素宽度不一致是，样式会错乱。效果如官网 playground 中所示：
![image](https://github.com/ant-design/pro-components/assets/3387572/3ebbbabc-cecd-4e2c-92ce-5e63f52a92bf)