### PR TITLE
fix(SiderMenu): [antd: Drawer] `bodyStyle` is deprecated waring

### DIFF
--- a/packages/layout/src/components/SiderMenu/index.tsx
+++ b/packages/layout/src/components/SiderMenu/index.tsx
@@ -66,12 +66,14 @@ const SiderMenuWrapper: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (
         maskClosable
         closable={false}
         width={siderWidth}
-        bodyStyle={{
-          height: '100vh',
-          padding: 0,
-          display: 'flex',
-          flexDirection: 'row',
-          backgroundColor: token.layout?.sider?.colorMenuBackground,
+        styles={{
+          body: {
+            height: '100vh',
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'row',
+            backgroundColor: token.layout?.sider?.colorMenuBackground,
+          }
         }}
       >
         <SiderMenu


### PR DESCRIPTION
![image](https://github.com/ant-design/pro-components/assets/1464298/556c5eb2-4aaf-4d90-830a-d2020be8a1d4)
![image](https://github.com/ant-design/pro-components/assets/1464298/6f790859-8023-408b-93ac-ceee988aa9dd)

[Drawer 抽屉](https://ant.design/components/drawer-cn#api)