### PR TITLE
fix(field): remove useDeepCompareMemo which causing renderFormItem not updated

### DIFF
--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -629,55 +629,42 @@ const ProFieldComponent: React.ForwardRefRenderFunction<
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, restFieldProps, onChangeCallBack]);
 
-  const renderedDom = useDeepCompareMemo(() => {
-    return defaultRenderText(
-      mode === 'edit'
-        ? fieldProps?.value ?? text ?? ''
-        : text ?? fieldProps?.value ?? '',
-      valueType || 'text',
-      omitUndefined({
-        ref,
-        ...rest,
-        mode: readonly ? 'read' : mode,
-        renderFormItem: renderFormItem
-          ? (curText: any, props: ProFieldFCRenderProps, dom: JSX.Element) => {
-              const { placeholder: _placeholder, ...restProps } = props;
-              const newDom = renderFormItem(curText, restProps, dom);
-              // renderFormItem 之后的dom可能没有props，这里会帮忙注入一下
-              if (React.isValidElement(newDom))
-                return React.cloneElement(newDom, {
-                  ...fieldProps,
-                  ...((newDom.props as any) || {}),
-                });
-              return newDom;
-            }
-          : undefined,
-        placeholder: renderFormItem
-          ? undefined
-          : rest?.placeholder ?? fieldProps?.placeholder,
-        fieldProps: pickProProps(
-          omitUndefined({
-            ...fieldProps,
-            placeholder: renderFormItem
-              ? undefined
-              : rest?.placeholder ?? fieldProps?.placeholder,
-          }),
-        ),
-      }),
-      context.valueTypeMap || {},
-    );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    context.valueTypeMap,
-    fieldProps,
-    mode,
-    readonly,
-    ref,
-    renderFormItem,
-    rest,
-    text,
-    valueType,
-  ]);
+  const renderedDom = defaultRenderText(
+    mode === 'edit'
+      ? fieldProps?.value ?? text ?? ''
+      : text ?? fieldProps?.value ?? '',
+    valueType || 'text',
+    omitUndefined({
+      ref,
+      ...rest,
+      mode: readonly ? 'read' : mode,
+      renderFormItem: renderFormItem
+        ? (curText: any, props: ProFieldFCRenderProps, dom: JSX.Element) => {
+            const { placeholder: _placeholder, ...restProps } = props;
+            const newDom = renderFormItem(curText, restProps, dom);
+            // renderFormItem 之后的dom可能没有props，这里会帮忙注入一下
+            if (React.isValidElement(newDom))
+              return React.cloneElement(newDom, {
+                ...fieldProps,
+                ...((newDom.props as any) || {}),
+              });
+            return newDom;
+          }
+        : undefined,
+      placeholder: renderFormItem
+        ? undefined
+        : rest?.placeholder ?? fieldProps?.placeholder,
+      fieldProps: pickProProps(
+        omitUndefined({
+          ...fieldProps,
+          placeholder: renderFormItem
+            ? undefined
+            : rest?.placeholder ?? fieldProps?.placeholder,
+        }),
+      ),
+    }),
+    context.valueTypeMap || {},
+  );
 
   return <React.Fragment>{renderedDom}</React.Fragment>;
 };


### PR DESCRIPTION
Fix issue https://github.com/ant-design/pro-components/issues/7801.

### Root cause

以7801中的例子来解释，form item按antd联动的方式定义
```
{
    title: "标签",
    dataIndex: "labels",
    valueType: "text",
    formItemProps: {
      dependencies: ["state"]
    },
    renderFormItem: (_, config, form) => {
      return form.getFieldValue("state") === "open" ? (
        <Input />
      ) : (
        <Select></Select>
      );
    }
  }
```
那么这个FormItem会在`state`值更改的时候重新渲染，但是重新渲染时props的内容用deep compare比较时并未改变，所以diff中的`useDeepCompareMemo`会导致本来可以渲染出的更新丢失掉。

2.6.20以及之前版本是正常的，是因为之前用的是 `useMemo`，`useMemo`生效是因为`rest`在每次渲染的时候都会生成一个新的，应该是没有意义的，这里我直接去掉了。