### PR TITLE
bug fix for the 7631 ticket : DragSortTable --- Reorder columns by dragging and dropping columns will have issues when the table has fixed columns first #7631

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -189,7 +189,7 @@ const CheckboxList: React.FC<{
       const targetIndex = newColumns.findIndex(
         (columnKey) => columnKey === targetId,
       );
-      const isDownWard = dropPosition > findIndex;
+      const isDownWard = dropPosition >= findIndex;
       if (findIndex < 0) return;
       const targetItem = newColumns[findIndex];
       newColumns.splice(findIndex, 1);


### PR DESCRIPTION
Please help to validate and merge this update asap. 