### PR TITLE
fix(field): remove cjs require statement which invalidates tree-shaking of antd

### DIFF
--- a/packages/field/src/components/ColorPicker/index.tsx
+++ b/packages/field/src/components/ColorPicker/index.tsx
@@ -1,6 +1,6 @@
 ﻿import { compareVersions } from '@ant-design/pro-utils';
 import type { ColorPickerProps } from 'antd';
-import { ConfigProvider, version } from 'antd';
+import { ColorPicker as ColorPickerV5, ConfigProvider, version } from 'antd';
 import classNames from 'classnames';
 import React, { useContext, useMemo } from 'react';
 import type { ProFieldFC } from '../../index';
@@ -45,8 +45,7 @@ function IsIt_Render_V5() {
  */
 function getColorPicker(old: boolean = false) {
   if ((typeof old === 'undefined' || old === false) && IsIt_Render_V5()) {
-    const { ColorPicker } = require('antd');
-    return ColorPicker;
+    return ColorPickerV5;
   }
   return ColorPickerV4;
 }


### PR DESCRIPTION
The CommonJS style require statement to 'antd' breaks antd's tree-shaking. Should use esm import statement instead or only require the specific ColorPicker component.