### PR TITLE
feat: 添加FormItemRender组件

### DIFF
--- a/packages/form/src/components/FormItemRender/index.tsx
+++ b/packages/form/src/components/FormItemRender/index.tsx
@@ -1,0 +1,219 @@
+import { Form } from 'antd';
+import React from 'react';
+import ProFormItem from '../FormItem';
+
+interface ControlPropsType {
+  id: string;
+  value: any;
+  onChange: (value: any, ...args: any[]) => void;
+}
+
+export type WithControlPropsType<T = object> = T & Partial<ControlPropsType>;
+
+interface ControlModelType {
+  value: any;
+  onChange: (value: any) => void;
+}
+interface FormControlProps {
+  valuePropName?: string;
+  trigger?: string;
+}
+interface FormControlMultiProps extends FormControlProps {
+  name: string;
+}
+type GetArrayFieldType<T extends readonly { name: string }[]> =
+  T[number]['name'];
+
+function getControlConfigProps(props = {} as any): {
+  valuePropName: string;
+  trigger: string;
+  name: string;
+} {
+  const valuePropName = props.valuePropName || 'value';
+  const trigger = props.trigger || 'onChange';
+  const name = props.name;
+  return {
+    valuePropName,
+    trigger,
+    name,
+  };
+}
+
+export function useControlModel<T extends FormControlProps>(
+  { value, onChange, id }: WithControlPropsType,
+  model?: T,
+): ControlModelType;
+export function useControlModel<const T extends readonly string[]>(
+  { value, onChange, id }: WithControlPropsType,
+  model?: T,
+): { [P in T[number]]: ControlModelType };
+export function useControlModel<
+  const T extends readonly FormControlMultiProps[],
+>(
+  { value, onChange, id }: WithControlPropsType,
+  model?: T,
+): { [P in GetArrayFieldType<T>]: ControlModelType };
+export function useControlModel<
+  T extends
+    | FormControlProps
+    | (string | FormControlMultiProps)[] = FormControlProps,
+>({ value, onChange }: WithControlPropsType, model?: T): unknown {
+  if (!Array.isArray(model)) {
+    const p = getControlConfigProps(model);
+    return {
+      [p.valuePropName]: value,
+      [p.trigger]: (e: any) => {
+        onChange?.(e?.target ? e.target[p.valuePropName] : e);
+      },
+    };
+  }
+
+  return model.reduce((acc, k) => {
+    const p = getControlConfigProps(k);
+    const name = p.name || (k as string);
+    acc[name] = {
+      [p.valuePropName]: value?.[name],
+      [p.trigger]: (v: any) => {
+        onChange?.({
+          ...value,
+          [name]: v?.target ? v.target[p.valuePropName] : v,
+        });
+      },
+    };
+    return acc;
+  }, {} as Record<string, unknown>) as unknown;
+}
+
+export type FormControlFC<P> = (
+  props: WithControlPropsType<P>,
+) => React.ReactNode;
+
+type FormControlInjectProps = ReturnType<typeof Form.Item.useStatus> & {
+  id: string;
+  value: any;
+  onChange: (value: any) => void;
+  [x: string]: any;
+};
+
+/**
+ * 用在 ProForm.Item 或 Form.Item 于 表单项之间的，用于劫持渲染的函数
+ * ``` tsx
+ * <Form.Item name='name' label='名称'>
+ *   <FormControlRender>
+ *   {
+ *     formItemProps => (
+ *       <div>
+ *         <span>prefix</span>
+ *         <Input {...formItemProps} />
+ *       </div>
+ *     )
+ *   }
+ *   </FormControlRender>
+ * </Form.Item>
+ * ```
+ */
+export function FormControlRender(
+  props: WithControlPropsType<{
+    children: (props: FormControlInjectProps) => React.ReactElement;
+  }>,
+) {
+  const { children, ...restProps } = props;
+  const { status, errors, warnings } = Form.Item.useStatus();
+  return children({
+    status,
+    errors,
+    warnings,
+    ...(restProps as ControlPropsType),
+  });
+}
+
+/**
+ * 提取props中的 value 和 onChange 属性
+ */
+export function pickControlProps(props: FormControlInjectProps) {
+  return {
+    value: props.value,
+    onChange: (value: any) =>
+      props.onChange(value?.target ? value.target.value : value),
+  };
+}
+
+/**
+ * 提取props中的 value、onChange 和 id 属性
+ */
+export function pickControlPropsWithId(props: FormControlInjectProps) {
+  return {
+    ...pickControlProps(props),
+    id: props.id,
+  };
+}
+
+/**
+ * 用于包裹ProForm.Item Form.Item，使其可以使用render props的形式
+ * @description 用法
+ * const FormItem = withFormItemRender(用于包裹ProForm.Item)
+ * ``` tsx
+ * <FormItem name='name' label='名称'>
+ *   {
+ *     formItemProps => (
+ *       <div>
+ *         <span>prefix</span>
+ *         <Input {...formItemProps} />
+ *       </div>
+ *     )
+ *   }
+ * </FormItem>
+ * ```
+ */
+export function withFormItemRender<T extends React.FC<any>>(
+  Comp: T,
+): React.FC<
+  Omit<React.ComponentProps<T>, 'children'> & {
+    children: (formItemProps: FormControlInjectProps) => React.ReactNode;
+  }
+> {
+  return function (props: React.PropsWithChildren<any>) {
+    const { children, ...restProps } = props;
+
+    return (
+      <Comp {...restProps}>
+        <FormControlRender>{children}</FormControlRender>
+      </Comp>
+    );
+  };
+}
+
+/**
+ * 用 withFormItemRender 加工Form.Item，使其拥有render props能力，同时暴露出 status 属性方便自定义组件校验使用
+ *
+ * ``` tsx
+ *   <FormItemRender name='name' label='名称'>
+ *   {
+ *     formItemProps => (
+ *       <div>
+ *         <h3>prefix</h3>
+ *         <textarea {...formItemProps} style={{ borderColor: formItemProps.status === 'error' ? 'red' : undefined }} />
+ *       </div>
+ *     )
+ *   }
+ *   </FormItemRender>
+ * ```
+ */
+export const FormItemRender = withFormItemRender(Form.Item);
+
+/**
+ * 用 withFormItemRender 加工 ProForm.Item，使其拥有render props能力，同时暴露出 status 属性方便自定义组件校验使用
+ * ``` tsx
+ *   <ProFormItemRender name='name' label='名称'>
+ *   {
+ *     formItemProps => (
+ *       <div>
+ *         <h3>prefix</h3>
+ *         <textarea {...formItemProps} style={{ borderColor: formItemProps.status === 'error' ? 'red' : undefined }} />
+ *       </div>
+ *     )
+ *   }
+ *   </ProFormItemRender>
+ * ```
+ */
+export const ProFormItemRender = withFormItemRender(ProFormItem);

--- a/packages/form/src/components/form.md
+++ b/packages/form/src/components/form.md
@@ -63,13 +63,13 @@ ProForm 在原来的 Form 的基础上增加了一些语法糖和更多的布局
 
 ProForm 是基于 antd Form 的可降级封装，与 antd 功能完全对齐，但是在其之上还增加一些预设行为和多种布局。这些布局之间可以无缝切换，并且拥有公共的 API。
 
-| 布局                                              | 使用场景                                                           |
-| ----------------------------------------------- | -------------------------------------------------------------- |
-| [ProForm](/components/form#proform)             | 标准 Form，增加了 `onFinish` 中自动 `loading` 和根据 `request` 自动获取默认值的功能。 |
-| [ModalForm\|DrawerForm](/components/modal-form) | 在 ProForm 的基础上增加了 `trigger` ，无需维护 `visible` 状态。                |
-| [QueryFilter](/components/query-filter)         | 一般用于作为筛选表单，需要配合其他数据展示组件使用。                                     |
-| [LightFilter](/components/query-filter)         | 一般用于作为行内内置的筛选，比如卡片操作栏和表格操作栏。                                   |
-| [StepsForm](/components/steps-form)             | 分步表单，需要配置 StepForm 使用。                                         |
+| 布局 | 使用场景 |
+| --- | --- |
+| [ProForm](/components/form#proform) | 标准 Form，增加了 `onFinish` 中自动 `loading` 和根据 `request` 自动获取默认值的功能。 |
+| [ModalForm\|DrawerForm](/components/modal-form) | 在 ProForm 的基础上增加了 `trigger` ，无需维护 `visible` 状态。 |
+| [QueryFilter](/components/query-filter) | 一般用于作为筛选表单，需要配合其他数据展示组件使用。 |
+| [LightFilter](/components/query-filter) | 一般用于作为行内内置的筛选，比如卡片操作栏和表格操作栏。 |
+| [StepsForm](/components/steps-form) | 分步表单，需要配置 StepForm 使用。 |
 
 <code src="../demos/layout-change.tsx" title="Form 的 layout 切换"></code>
 
@@ -196,6 +196,38 @@ formRef 内置了几个方法来获取转化之后的值，这也是相比 antd 
 
 <code src="../demos/pro-form-editableTable.tsx" title="ProForm 和 EditableTable 同时使用"></code>
 
+## 劫持渲染函数的组件
+
+FormItemRender 用来专门处理，采用 render props 的方式来组织代码，更好的聚合带请求的业务代码，也更好的完成自定义表单项的功能
+
+在中后台项目表单是必不可少的，通常还伴随着一些非标准控件、复杂的表单项，此时需要借助自定义表单项，而完成一个自定义表单项至少需要完成 value 和 onChange 的实现。而如果该组件只被使用一次且需要的上下文参数很多，那么封装起来就是很不讨好，因此就有了该组件。
+
+- 使用 useControlModel 来快速的创建一个自定义表单项，同时支持单实例或多实例（适用于封装自定义表单组件，在多个地方使用的场景）
+- 使用 withFormItemRender 来生成一个 FormItemRender，可以以内联的方式去组织代码（适用于只被使用一次或需要的上下文参数很多的场景）
+- 使用 FormControlRender 来把一个 form 组件转换成 render props 的形式，在特定情况下是很有用的（例如@alipay/techui-rule-tree 组件的一些设计缺陷，render 里面的组件不能调用 onChange 方法，这个时候包裹一下就可以解决）
+
+> 当然，也不一定非要用 withFormItemRender，Form.Item 是可以嵌套使用，也可以 Form.Item 嵌套外层设置 noStyle 的方式来组织你的代码，这样会多一些 div 的元素包裹，如果对你样式没有影响也可以使用
+
+### 使用 useControlModel
+
+从一个官网例子开始[自定义表单项](https://ant.design/components/form-cn#components-form-demo-customized-form-controls)
+
+<code src="../demos/antd.tsx" description="官网例子"></code> <code src="../demos/antd.modify.tsx" description="使用和hooks改造"></code> <code src="../demos/antd.nest.tsx" description="嵌套使用"></code>
+
+### FormControlRender
+
+使用 FormControlRender 既可以内联的书写代码，又可以更灵活的编写逻辑，适用于一些组件外层包裹了 ProForm.Item 或者 Form.Item。
+
+有的时候需要使用 Form.Item.useStatus，但必须满足 hooks 的使用规范，这使得开发就必须提取成单独的组件来使用，没办法内联使用，而 FormControlRender 很好的解决这种情况
+
+<code src="../demos/form-control-render.tsx"></code>
+
+### FormItemRender & ProFormItemRender
+
+使用 FormItemRender 或者 ProFormItemRender 可以更方便的在 Form 里书写表单项
+
+<code src="../demos/form-item-render.tsx"></code>
+
 <code src="../demos/linkage-customization.tsx" debug></code>
 
 <code src="../demos/pro-form-dependency.debug.tsx"  debug></code>
@@ -208,23 +240,23 @@ ProForm 是对 antd Form 的再封装，如果你想要自定义表单元素，P
 
 > antd 的 Form api 查看[这里](https://ant.design/components/form-cn/)，initialValues 相关知识查看[这里](https://procomponents.ant.design/docs/faq)
 
-| 参数                                              | 说明                                                                                                                  | 类型                                                                                     | 默认值           |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------- |
-| onFinish                                        | 提交表单且数据验证成功后回调事件，同 antd 4 `Form` 组件 API                                                                             | `(values)=>Promise<void>`                                                              | -             |
-| onReset                                         | 点击重置按钮的回调                                                                                                           | `(e)=>void`                                                                            | -             |
-| submitter                                       | 提交按钮相关配置                                                                                                            | `boolean` \| `SubmitterProps`                                                          | `true`        |
-| syncToUrl                                       | 同步参数到 url 上，url 只支持 string，在使用之前最好读一下[url 中的参数类型](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) | `true` \| `(values,type)=>values`                                                      | -             |
-| syncToInitialValues                             | 同步结果到 initialValues，默认为 true，如果为 false，form.reset 的时候将会忽略从 url 上获取的数据                                               | `boolean`                                                                              | `true`        |
-| dateFormatter                                   | 自动格式化数据，主要是 moment 的表单，支持 string 和 number 两种模式，此外还支持指定函数进行格式化。                                                      | `string\| number \| ((value: Moment, valueType: string) => string \| number) \| false` | string        |
-| omitNil                                         | ProForm 会自动清空 null 和 undefined 的数数据，如果你约定了 nil 代表某种数据，可以设置为 false 关闭此功能                                             | `boolean`                                                                              | true          |
-| params                                          | 发起网络请求的参数，与 request 配合使用                                                                                            | `Record`                                                                               | -             |
-| request                                         | 发起网络请求的参数，返回值会覆盖给 initialValues                                                                                     | `(params)=>Promise<data>`                                                              | -             |
-| isKeyPressSubmit                                | 是否使用回车提交                                                                                                            | `boolean`                                                                              | -             |
-| formRef                                         | 获取表单所使用的 form                                                                                                       | `MutableRefObject<Instance<T>>`                                                        | -             |
-| autoFocusFirstInput                             | 自动 focus 表单第一个输入框                                                                                                   | `boolean`                                                                              | -             |
-| `grid`                                          | 开启栅格化模式，宽度默认百分比，请使用 `colProps` 控制宽度 [查看示例](/components/form#栅格化布局)                                                  | `boolean`                                                                              | -             |
-| rowProps                                        | 开启 `grid` 模式时传递给 `Row`, 仅在`ProFormGroup`, `ProFormList`, `ProFormFieldSet` 中有效                                      | [RowProps](https://ant.design/components/grid/#Row)                                    | { gutter: 8 } |
-| [(...)](https://ant.design/components/form-cn/) | 注意 `LightFilter` 和 `QueryFilter` 仅支持除 `wrapperCol` \| `labelCol` \| `layout` 外的其他 antd `Form` 组件参数                  | -                                                                                      | -             |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| onFinish | 提交表单且数据验证成功后回调事件，同 antd 4 `Form` 组件 API | `(values)=>Promise<void>` | - |
+| onReset | 点击重置按钮的回调 | `(e)=>void` | - |
+| submitter | 提交按钮相关配置 | `boolean` \| `SubmitterProps` | `true` |
+| syncToUrl | 同步参数到 url 上，url 只支持 string，在使用之前最好读一下[url 中的参数类型](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) | `true` \| `(values,type)=>values` | - |
+| syncToInitialValues | 同步结果到 initialValues，默认为 true，如果为 false，form.reset 的时候将会忽略从 url 上获取的数据 | `boolean` | `true` |
+| dateFormatter | 自动格式化数据，主要是 moment 的表单，支持 string 和 number 两种模式，此外还支持指定函数进行格式化。 | `string\| number \| ((value: Moment, valueType: string) => string \| number) \| false` | string |
+| omitNil | ProForm 会自动清空 null 和 undefined 的数数据，如果你约定了 nil 代表某种数据，可以设置为 false 关闭此功能 | `boolean` | true |
+| params | 发起网络请求的参数，与 request 配合使用 | `Record` | - |
+| request | 发起网络请求的参数，返回值会覆盖给 initialValues | `(params)=>Promise<data>` | - |
+| isKeyPressSubmit | 是否使用回车提交 | `boolean` | - |
+| formRef | 获取表单所使用的 form | `MutableRefObject<Instance<T>>` | - |
+| autoFocusFirstInput | 自动 focus 表单第一个输入框 | `boolean` | - |
+| `grid` | 开启栅格化模式，宽度默认百分比，请使用 `colProps` 控制宽度 [查看示例](/components/form#栅格化布局) | `boolean` | - |
+| rowProps | 开启 `grid` 模式时传递给 `Row`, 仅在`ProFormGroup`, `ProFormList`, `ProFormFieldSet` 中有效 | [RowProps](https://ant.design/components/grid/#Row) | { gutter: 8 } |
+| [(...)](https://ant.design/components/form-cn/) | 注意 `LightFilter` 和 `QueryFilter` 仅支持除 `wrapperCol` \| `labelCol` \| `layout` 外的其他 antd `Form` 组件参数 | - | - |
 
 ### ProFormInstance
 
@@ -268,23 +300,23 @@ ProFormInstance 与 antd 的 form 相比增加了一些能力。
 
 ### ProForm.Group
 
-| 参数       | 说明         | 类型                | 默认值 |
-| -------- | ---------- | ----------------- | --- |
-| title    | 标题         | `string`          | -   |
-| children | 表单控件或者其他元素 | `React.ReactNode` | -   |
+| 参数     | 说明                 | 类型              | 默认值 |
+| -------- | -------------------- | ----------------- | ------ |
+| title    | 标题                 | `string`          | -      |
+| children | 表单控件或者其他元素 | `React.ReactNode` | -      |
 
 #### submitter
 
 虽然我们希望不要对 submitter 进行修改，但在使用中修改是很常见的需求，ProForm 的各个组件都使用了同样的 API 来支持需求。
 
-| 参数                | 说明             | 类型                                                      | 默认值 |
-| ----------------- | -------------- | ------------------------------------------------------- | --- |
-| onSubmit          | 提交方法           | `()=>void`                                              | -   |
-| onReset           | 重置方法           | `()=>void`                                              | -   |
-| searchConfig      | 搜索的配置，一般用来配置文本 | `{resetText,submitText}`                                | -   |
-| submitButtonProps | 提交按钮的 props    | [ButtonProps](https://ant.design/components/button-cn/) | -   |
-| resetButtonProps  | 重置按钮的 props    | [ButtonProps](https://ant.design/components/button-cn/) | -   |
-| render            | 自定义操作的渲染       | `false`\|`(props,dom:JSX[])=>ReactNode[]`               | -   |
+| 参数 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| onSubmit | 提交方法 | `()=>void` | - |
+| onReset | 重置方法 | `()=>void` | - |
+| searchConfig | 搜索的配置，一般用来配置文本 | `{resetText,submitText}` | - |
+| submitButtonProps | 提交按钮的 props | [ButtonProps](https://ant.design/components/button-cn/) | - |
+| resetButtonProps | 重置按钮的 props | [ButtonProps](https://ant.design/components/button-cn/) | - |
+| render | 自定义操作的渲染 | `false`\|`(props,dom:JSX[])=>ReactNode[]` | - |
 
 > render 的第二个参数是默认的 dom 数组，第一个是重置按钮，第二个是提交按钮。
 
@@ -437,11 +469,11 @@ export default () => {
 
 `ProFormInstance` 在原先 `FormInstance` 的基础上增加了如下方法：
 
-|                方法名                |                              使用描述                              |  备注 |
-| :-------------------------------: | :------------------------------------------------------------: | :-: |
-|       `getFieldsFormatValue`      |    使用方法与 `FormInstance` 的 `getFieldsValue` 方法相同，将返回格式化后的所有数据   |     |
-|       `getFieldFormatValue`       |    使用方法与 `FormInstance` 的 `getFieldValue` 方法相同，将返回格式化后的指定数据    |     |
-| `validateFieldsReturnFormatValue` | 使用方法与 `FormInstance` 的 `validateFields` 方法相同，验证通过后将返回格式化后的所有数据 |     |
+| 方法名 | 使用描述 | 备注 |
+| :-: | :-: | :-: |
+| `getFieldsFormatValue` | 使用方法与 `FormInstance` 的 `getFieldsValue` 方法相同，将返回格式化后的所有数据 |  |
+| `getFieldFormatValue` | 使用方法与 `FormInstance` 的 `getFieldValue` 方法相同，将返回格式化后的指定数据 |  |
+| `validateFieldsReturnFormatValue` | 使用方法与 `FormInstance` 的 `validateFields` 方法相同，验证通过后将返回格式化后的所有数据 |  |
 
 <code src="../demos/modalform-test.tsx"  debug></code>
 

--- a/packages/form/src/components/index.ts
+++ b/packages/form/src/components/index.ts
@@ -25,6 +25,15 @@ export { default as ProFormFieldSet } from './FieldSet';
 export type { ProFormFieldSetProps } from './FieldSet';
 export { FormItemProvide, default as ProFormItem } from './FormItem';
 export type { ProFormItemProps } from './FormItem';
+export {
+  FormControlRender,
+  FormItemRender,
+  ProFormItemRender,
+  pickControlProps,
+  pickControlPropsWithId,
+  useControlModel,
+} from './FormItemRender';
+export type { FormControlFC, WithControlPropsType } from './FormItemRender';
 export { default as Group } from './Group';
 export { ProFormList } from './List';
 export type { FormListActionType, ProFormListProps } from './List';

--- a/packages/form/src/demos/antd.modify.tsx
+++ b/packages/form/src/demos/antd.modify.tsx
@@ -1,0 +1,62 @@
+import {
+  WithControlPropsType,
+  useControlModel,
+} from '@ant-design/pro-components';
+import { Button, Form, Input, Select } from 'antd';
+import React from 'react';
+
+export function PriceInput(
+  props: WithControlPropsType<{
+    // other props...
+  }>,
+) {
+  const model = useControlModel(props, ['number', 'currency']);
+
+  return (
+    <span>
+      <Input type="text" {...model.number} style={{ width: 100 }} />
+      <Select {...model.currency} style={{ width: 80, margin: '0 8px' }}>
+        <Select.Option value="rmb">RMB</Select.Option>
+        <Select.Option value="dollar">Dollar</Select.Option>
+      </Select>
+    </span>
+  );
+}
+
+const App: React.FC = () => {
+  const onFinish = (values: any) => {
+    console.log('Received values from form: ', values);
+  };
+
+  const checkPrice = (_: any, value: { number: number }) => {
+    if (value.number > 0) {
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error('Price must be greater than zero!'));
+  };
+
+  return (
+    <Form
+      name="customized_form_controls"
+      layout="inline"
+      onFinish={onFinish}
+      initialValues={{
+        price: {
+          number: 0,
+          currency: 'rmb',
+        },
+      }}
+    >
+      <Form.Item name="price" label="Price" rules={[{ validator: checkPrice }]}>
+        <PriceInput />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;

--- a/packages/form/src/demos/antd.nest.tsx
+++ b/packages/form/src/demos/antd.nest.tsx
@@ -1,0 +1,56 @@
+import { Button, Form, Input, Select, Space } from 'antd';
+import React from 'react';
+
+export function PriceInput() {
+  return (
+    <Space size={0}>
+      <Form.Item noStyle name={['price', 'number']}>
+        <Input type="text" style={{ width: 100 }} />
+      </Form.Item>
+      <Form.Item noStyle name={['price', 'currency']}>
+        <Select style={{ width: 80, margin: '0 8px' }}>
+          <Select.Option value="rmb">RMB</Select.Option>
+          <Select.Option value="dollar">Dollar</Select.Option>
+        </Select>
+      </Form.Item>
+    </Space>
+  );
+}
+
+const App: React.FC = () => {
+  const onFinish = (values: any) => {
+    console.log('Received values from form: ', values);
+  };
+
+  const checkPrice = (_: any, value: { number: number }) => {
+    if (value.number > 0) {
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error('Price must be greater than zero!'));
+  };
+
+  return (
+    <Form
+      name="customized_form_controls"
+      layout="inline"
+      onFinish={onFinish}
+      initialValues={{
+        price: {
+          number: 0,
+          currency: 'rmb',
+        },
+      }}
+    >
+      <Form.Item name="price" label="Price" rules={[{ validator: checkPrice }]}>
+        <PriceInput />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;

--- a/packages/form/src/demos/antd.tsx
+++ b/packages/form/src/demos/antd.tsx
@@ -1,0 +1,103 @@
+import { Button, Form, Input, Select } from 'antd';
+import React, { useState } from 'react';
+
+const { Option } = Select;
+
+type Currency = 'rmb' | 'dollar';
+
+interface PriceValue {
+  number?: number;
+  currency?: Currency;
+}
+
+interface PriceInputProps {
+  value?: PriceValue;
+  onChange?: (value: PriceValue) => void;
+}
+
+const PriceInput: React.FC<PriceInputProps> = ({ value = {}, onChange }) => {
+  const [number, setNumber] = useState(0);
+  const [currency, setCurrency] = useState<Currency>('rmb');
+
+  const triggerChange = (changedValue: {
+    number?: number;
+    currency?: Currency;
+  }) => {
+    onChange?.({ number, currency, ...value, ...changedValue });
+  };
+
+  const onNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newNumber = parseInt(e.target.value || '0', 10);
+    if (Number.isNaN(number)) {
+      return;
+    }
+    if (!('number' in value)) {
+      setNumber(newNumber);
+    }
+    triggerChange({ number: newNumber });
+  };
+
+  const onCurrencyChange = (newCurrency: Currency) => {
+    if (!('currency' in value)) {
+      setCurrency(newCurrency);
+    }
+    triggerChange({ currency: newCurrency });
+  };
+
+  return (
+    <span>
+      <Input
+        type="text"
+        value={value.number || number}
+        onChange={onNumberChange}
+        style={{ width: 100 }}
+      />
+      <Select
+        value={value.currency || currency}
+        style={{ width: 80, margin: '0 8px' }}
+        onChange={onCurrencyChange}
+      >
+        <Option value="rmb">RMB</Option>
+        <Option value="dollar">Dollar</Option>
+      </Select>
+    </span>
+  );
+};
+
+const App: React.FC = () => {
+  const onFinish = (values: any) => {
+    console.log('Received values from form: ', values);
+  };
+
+  const checkPrice = (_: any, value: { number: number }) => {
+    if (value.number > 0) {
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error('Price must be greater than zero!'));
+  };
+
+  return (
+    <Form
+      name="customized_form_controls"
+      layout="inline"
+      onFinish={onFinish}
+      initialValues={{
+        price: {
+          number: 0,
+          currency: 'rmb',
+        },
+      }}
+    >
+      <Form.Item name="price" label="Price" rules={[{ validator: checkPrice }]}>
+        <PriceInput />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;

--- a/packages/form/src/demos/form-control-render.tsx
+++ b/packages/form/src/demos/form-control-render.tsx
@@ -1,0 +1,81 @@
+import {
+  FormControlRender,
+  pickControlPropsWithId,
+} from '@ant-design/pro-components';
+import { Button, Checkbox, Form } from 'antd';
+import React, { useEffect } from 'react';
+
+const App: React.FC = () => {
+  const [form] = Form.useForm();
+
+  useEffect(() => {
+    form.validateFields();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <Form form={form} onFinish={console.log}>
+      <Form.Item
+        name={'text1'}
+        label="文本框（没错误边框）"
+        rules={[{ required: true }]}
+      >
+        <textarea />
+      </Form.Item>
+      <Form.Item
+        name="text2"
+        label="文本框（添加自定义的错误边框）"
+        rules={[{ required: true }]}
+      >
+        <FormControlRender>
+          {(itemProps) => {
+            return (
+              <textarea
+                style={{
+                  borderColor: itemProps.status === 'error' ? 'red' : undefined,
+                }}
+                {...pickControlPropsWithId(itemProps)}
+              />
+            );
+          }}
+        </FormControlRender>
+      </Form.Item>
+      <Form.Item
+        valuePropName="checked"
+        name="check"
+        label="复选框"
+        rules={[{ required: true }]}
+      >
+        <Checkbox>是否</Checkbox>
+      </Form.Item>
+      <Form.Item
+        valuePropName="checked"
+        name="check2"
+        label="复选框"
+        rules={[{ required: true }]}
+      >
+        <FormControlRender>
+          {(itemProps) => {
+            return (
+              <Checkbox
+                {...itemProps}
+                style={{
+                  color: itemProps.status === 'error' ? 'red' : undefined,
+                }}
+              >
+                是否
+              </Checkbox>
+            );
+          }}
+        </FormControlRender>
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">
+          Submit
+        </Button>
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default App;

--- a/packages/form/src/demos/form-item-render.tsx
+++ b/packages/form/src/demos/form-item-render.tsx
@@ -1,0 +1,164 @@
+import {
+  FormControlFC,
+  FormItemRender,
+  ProForm,
+  ProFormItemRender,
+  WithControlPropsType,
+  pickControlProps,
+  pickControlPropsWithId,
+  useControlModel,
+} from '@ant-design/pro-components';
+import { Checkbox, Input, Select } from 'antd';
+
+const SingletonA = (
+  props: WithControlPropsType<{
+    title: string;
+  }>,
+) => {
+  const model = useControlModel(props);
+  return (
+    <>
+      <span>{props.title}</span>
+      <Input {...model} placeholder="直接使用useControlModel" />
+    </>
+  );
+};
+const SingletonB = (
+  props: WithControlPropsType<{
+    title: string;
+  }>,
+) => {
+  const model = useControlModel(props);
+  return (
+    <>
+      <span>{props.title}</span>
+      <Select
+        {...model}
+        options={[
+          { label: 'A', value: 'a' },
+          { label: 'B', value: 'b' },
+        ]}
+      />
+    </>
+  );
+};
+
+const CustomInput = (
+  props: WithControlPropsType<{
+    title: string;
+    description: string;
+  }>,
+) => {
+  const model = useControlModel(props, [
+    {
+      name: 'a',
+      valuePropName: 'checked',
+    },
+    {
+      name: 'b',
+    },
+  ]);
+
+  return (
+    <div>
+      <div>title: {props.title}</div>
+      <Checkbox {...model.a} />
+      <div>description: {props.description}</div>
+      <Input
+        {...model.b}
+        placeholder="可以通过第二个参数达到使用多个实例的情况"
+      />
+    </div>
+  );
+};
+
+const CustomInput2: FormControlFC<{
+  title: string;
+}> = (props) => {
+  const model = useControlModel(props, ['a', 'b']);
+  return (
+    <div>
+      <div>{props.title}</div>
+      <Input {...model.a} />
+    </div>
+  );
+};
+
+export default () => {
+  const [form] = ProForm.useForm();
+
+  return (
+    <div>
+      <ProForm
+        form={form}
+        onValuesChange={console.log}
+        onFinish={async (values) => {
+          console.log(values);
+          return;
+        }}
+      >
+        <ProForm.Item name={'SingletonA'}>
+          <SingletonA title="单实例A" />
+        </ProForm.Item>
+        <ProForm.Item name={'SingletonB'}>
+          <SingletonB title="单实例B" />
+        </ProForm.Item>
+        <ProForm.Item name={'customInput'} label="多实例">
+          <CustomInput
+            title="customInput-title"
+            description="customInput-desc"
+          />
+        </ProForm.Item>
+        <ProForm.Item name={'FormControlFC'} label="使用FormControlFC类型定义">
+          <CustomInput2 title="FormControlFC title" />
+        </ProForm.Item>
+        <ProFormItemRender name={'inputA'}>
+          {(itemProps) => {
+            return (
+              <div id={itemProps.id}>
+                <h3>使用pickControlProps提取表单项属性</h3>
+                <Input {...pickControlProps(itemProps)} />
+              </div>
+            );
+          }}
+        </ProFormItemRender>
+        <ProFormItemRender name={'inputB'}>
+          {(itemProps) => {
+            return (
+              <div>
+                <h3>使用pickControlPropsWithId提取表单项属性（包括id）</h3>
+                <Input {...pickControlPropsWithId(itemProps)} />
+              </div>
+            );
+          }}
+        </ProFormItemRender>
+        <ProFormItemRender name={'selectA'}>
+          {(itemProps) => {
+            return (
+              <div>
+                <h3>自定义标题：</h3>
+                <Select
+                  {...pickControlProps(itemProps)}
+                  options={[{ label: 'A', value: 'a' }]}
+                />
+              </div>
+            );
+          }}
+        </ProFormItemRender>
+        <FormItemRender
+          label="FormItemRender"
+          name={'selectB'}
+          initialValue={'xxx'}
+        >
+          {(itemProps) => {
+            return (
+              <div>
+                <Input {...pickControlPropsWithId(itemProps)} />
+              </div>
+            );
+          }}
+        </FormItemRender>
+      </ProForm>
+    </div>
+  );
+};

--- a/tests/form/__snapshots__/demo.test.ts.snap
+++ b/tests/form/__snapshots__/demo.test.ts.snap
@@ -40360,6 +40360,452 @@ exports[`form demos > 📸 renders ./packages/form/src/components/StepsForm/demo
 </DocumentFragment>
 `;
 
+exports[`form demos > 📸 renders ./packages/form/src/demos/antd.modify.tsx correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="ant-app"
+  >
+    <div>
+      test
+    </div>
+    <form
+      class="ant-form ant-form-inline"
+      id="customized_form_controls"
+    >
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class=""
+              for="customized_form_controls_price"
+              title="Price"
+            >
+              Price
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <span>
+                  <input
+                    class="ant-input"
+                    style="width: 100px;"
+                    type="text"
+                    value="0"
+                  />
+                  <div
+                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow"
+                    style="width: 80px; margin: 0px 8px;"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="RMB"
+                      >
+                        RMB
+                      </span>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`form demos > 📸 renders ./packages/form/src/demos/antd.nest.tsx correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="ant-app"
+  >
+    <div>
+      test
+    </div>
+    <form
+      class="ant-form ant-form-inline"
+      id="customized_form_controls"
+    >
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class=""
+              for="customized_form_controls_price"
+              title="Price"
+            >
+              Price
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <div
+                  class="ant-space ant-space-horizontal ant-space-align-center"
+                >
+                  <div
+                    class="ant-space-item"
+                  >
+                    <input
+                      class="ant-input"
+                      id="customized_form_controls_price_number"
+                      style="width: 100px;"
+                      type="text"
+                      value="0"
+                    />
+                  </div>
+                  <div
+                    class="ant-space-item"
+                  >
+                    <div
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow"
+                      style="width: 80px; margin: 0px 8px;"
+                    >
+                      <div
+                        class="ant-select-selector"
+                      >
+                        <span
+                          class="ant-select-selection-search"
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-controls="customized_form_controls_price_currency_list"
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            aria-owns="customized_form_controls_price_currency_list"
+                            autocomplete="off"
+                            class="ant-select-selection-search-input"
+                            id="customized_form_controls_price_currency"
+                            readonly=""
+                            role="combobox"
+                            style="opacity: 0;"
+                            type="search"
+                            unselectable="on"
+                            value=""
+                          />
+                        </span>
+                        <span
+                          class="ant-select-selection-item"
+                          title="RMB"
+                        >
+                          RMB
+                        </span>
+                      </div>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-arrow"
+                        style="user-select: none;"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-select-suffix"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`form demos > 📸 renders ./packages/form/src/demos/antd.tsx correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="ant-app"
+  >
+    <div>
+      test
+    </div>
+    <form
+      class="ant-form ant-form-inline"
+      id="customized_form_controls"
+    >
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class=""
+              for="customized_form_controls_price"
+              title="Price"
+            >
+              Price
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <span>
+                  <input
+                    class="ant-input"
+                    style="width: 100px;"
+                    type="text"
+                    value="0"
+                  />
+                  <div
+                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow"
+                    style="width: 80px; margin: 0px 8px;"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-item"
+                        title="RMB"
+                      >
+                        RMB
+                      </span>
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`form demos > 📸 renders ./packages/form/src/demos/base.tsx correctly 1`] = `
 <DocumentFragment>
   <div
@@ -44934,6 +45380,661 @@ exports[`form demos > 📸 renders ./packages/form/src/demos/dependency.tsx corr
         </button>
       </div>
     </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`form demos > 📸 renders ./packages/form/src/demos/form-control-render.tsx correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="ant-app"
+  >
+    <div>
+      test
+    </div>
+    <form
+      class="ant-form ant-form-horizontal"
+    >
+      <div
+        class="ant-form-item ant-form-item-is-validating"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="text1"
+              title="文本框（没错误边框）"
+            >
+              文本框（没错误边框）
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <textarea
+                  aria-required="true"
+                  id="text1"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item ant-form-item-is-validating"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="text2"
+              title="文本框（添加自定义的错误边框）"
+            >
+              文本框（添加自定义的错误边框）
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <textarea
+                  id="text2"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item ant-form-item-is-validating"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="check"
+              title="复选框"
+            >
+              复选框
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <label
+                  class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
+                >
+                  <span
+                    class="ant-checkbox ant-wave-target"
+                  >
+                    <input
+                      aria-required="true"
+                      class="ant-checkbox-input"
+                      id="check"
+                      type="checkbox"
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    是否
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item ant-form-item-is-validating"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-label"
+          >
+            <label
+              class="ant-form-item-required"
+              for="check2"
+              title="复选框"
+            >
+              复选框
+            </label>
+          </div>
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <label
+                  class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
+                >
+                  <span
+                    class="ant-checkbox ant-wave-target"
+                  >
+                    <input
+                      aria-required="true"
+                      class="ant-checkbox-input"
+                      errors=""
+                      id="check2"
+                      status="validating"
+                      type="checkbox"
+                      warnings=""
+                    />
+                    <span
+                      class="ant-checkbox-inner"
+                    />
+                  </span>
+                  <span>
+                    是否
+                  </span>
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="ant-form-item"
+      >
+        <div
+          class="ant-row ant-form-item-row"
+        >
+          <div
+            class="ant-col ant-form-item-control"
+          >
+            <div
+              class="ant-form-item-control-input"
+            >
+              <div
+                class="ant-form-item-control-input-content"
+              >
+                <button
+                  class="ant-btn ant-btn-primary"
+                  type="submit"
+                >
+                  <span>
+                    Submit
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`form demos > 📸 renders ./packages/form/src/demos/form-item-render.tsx correctly 1`] = `
+<DocumentFragment>
+  <div
+    class="ant-app"
+  >
+    <div>
+      test
+    </div>
+    <div>
+      <form
+        autocomplete="off"
+        class="ant-form ant-form-vertical ant-pro-form"
+      >
+        <input
+          style="display: none;"
+          type="text"
+        />
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <span>
+                    单实例A
+                  </span>
+                  <input
+                    class="ant-input"
+                    placeholder="直接使用useControlModel"
+                    type="text"
+                    value=""
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <span>
+                    单实例B
+                  </span>
+                  <div
+                    class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow"
+                  >
+                    <div
+                      class="ant-select-selector"
+                    >
+                      <span
+                        class="ant-select-selection-search"
+                      >
+                        <input
+                          aria-autocomplete="list"
+                          aria-controls="rc_select_TEST_OR_SSR_list"
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="rc_select_TEST_OR_SSR_list"
+                          autocomplete="off"
+                          class="ant-select-selection-search-input"
+                          id="rc_select_TEST_OR_SSR"
+                          readonly=""
+                          role="combobox"
+                          style="opacity: 0;"
+                          type="search"
+                          unselectable="on"
+                          value=""
+                        />
+                      </span>
+                      <span
+                        class="ant-select-selection-placeholder"
+                      />
+                    </div>
+                    <span
+                      aria-hidden="true"
+                      class="ant-select-arrow"
+                      style="user-select: none;"
+                      unselectable="on"
+                    >
+                      <span
+                        aria-label="down"
+                        class="anticon anticon-down ant-select-suffix"
+                        role="img"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          data-icon="down"
+                          fill="currentColor"
+                          focusable="false"
+                          height="1em"
+                          viewBox="64 64 896 896"
+                          width="1em"
+                        >
+                          <path
+                            d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                          />
+                        </svg>
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-label"
+            >
+              <label
+                class=""
+                for="customInput"
+                title="多实例"
+              >
+                多实例
+              </label>
+            </div>
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div>
+                    <div>
+                      title: customInput-title
+                    </div>
+                    <label
+                      class="ant-checkbox-wrapper ant-checkbox-wrapper-in-form-item"
+                    >
+                      <span
+                        class="ant-checkbox ant-wave-target"
+                      >
+                        <input
+                          class="ant-checkbox-input"
+                          type="checkbox"
+                        />
+                        <span
+                          class="ant-checkbox-inner"
+                        />
+                      </span>
+                    </label>
+                    <div>
+                      description: customInput-desc
+                    </div>
+                    <input
+                      class="ant-input"
+                      placeholder="可以通过第二个参数达到使用多个实例的情况"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-label"
+            >
+              <label
+                class=""
+                for="FormControlFC"
+                title="使用FormControlFC类型定义"
+              >
+                使用FormControlFC类型定义
+              </label>
+            </div>
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div>
+                    <div>
+                      FormControlFC title
+                    </div>
+                    <input
+                      class="ant-input"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div
+                    id="inputA"
+                  >
+                    <h3>
+                      使用pickControlProps提取表单项属性
+                    </h3>
+                    <input
+                      class="ant-input"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div>
+                    <h3>
+                      使用pickControlPropsWithId提取表单项属性（包括id）
+                    </h3>
+                    <input
+                      class="ant-input"
+                      id="inputB"
+                      type="text"
+                      value=""
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div>
+                    <h3>
+                      自定义标题：
+                    </h3>
+                    <div
+                      class="ant-select ant-select-in-form-item ant-select-single ant-select-show-arrow"
+                    >
+                      <div
+                        class="ant-select-selector"
+                      >
+                        <span
+                          class="ant-select-selection-search"
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-controls="rc_select_TEST_OR_SSR_list"
+                            aria-expanded="false"
+                            aria-haspopup="listbox"
+                            aria-owns="rc_select_TEST_OR_SSR_list"
+                            autocomplete="off"
+                            class="ant-select-selection-search-input"
+                            id="rc_select_TEST_OR_SSR"
+                            readonly=""
+                            role="combobox"
+                            style="opacity: 0;"
+                            type="search"
+                            unselectable="on"
+                            value=""
+                          />
+                        </span>
+                        <span
+                          class="ant-select-selection-placeholder"
+                        />
+                      </div>
+                      <span
+                        aria-hidden="true"
+                        class="ant-select-arrow"
+                        style="user-select: none;"
+                        unselectable="on"
+                      >
+                        <span
+                          aria-label="down"
+                          class="anticon anticon-down ant-select-suffix"
+                          role="img"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="down"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M884 256h-75c-5.1 0-9.9 2.5-12.9 6.6L512 654.2 227.9 262.6c-3-4.1-7.8-6.6-12.9-6.6h-75c-6.5 0-10.3 7.4-6.5 12.7l352.6 486.1c12.8 17.6 39 17.6 51.7 0l352.6-486.1c3.9-5.3.1-12.7-6.4-12.7z"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="ant-form-item"
+        >
+          <div
+            class="ant-row ant-form-item-row"
+          >
+            <div
+              class="ant-col ant-form-item-label"
+            >
+              <label
+                class=""
+                for="selectB"
+                title="FormItemRender"
+              >
+                FormItemRender
+              </label>
+            </div>
+            <div
+              class="ant-col ant-form-item-control"
+            >
+              <div
+                class="ant-form-item-control-input"
+              >
+                <div
+                  class="ant-form-item-control-input-content"
+                >
+                  <div>
+                    <input
+                      class="ant-input"
+                      id="selectB"
+                      type="text"
+                      value="xxx"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          style="display: flex; gap: 8px; align-items: center;"
+        >
+          <button
+            class="ant-btn ant-btn-default"
+            type="button"
+          >
+            <span>
+              重 置
+            </span>
+          </button>
+          <button
+            class="ant-btn ant-btn-primary"
+            type="button"
+          >
+            <span>
+              提 交
+            </span>
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/tests/form/formitemrender.test.tsx
+++ b/tests/form/formitemrender.test.tsx
@@ -1,0 +1,131 @@
+import { pickControlProps, useControlModel } from '@ant-design/pro-form';
+import { cleanup, renderHook } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ProForm.FormItemRender target branch test', () => {
+  test('should return correct object when model is a single object', () => {
+    const onChange = vi.fn();
+    const value = 'test value';
+    const model = { valuePropName: 'value', trigger: 'onChange' };
+
+    const { result } = renderHook(() =>
+      useControlModel({ value, onChange }, model),
+    );
+
+    expect(result.current).toEqual({
+      value: value,
+      onChange: expect.any(Function),
+    });
+
+    // Trigger the onChange callback and verify if it's called with the correct value
+    result.current.onChange('new value');
+    expect(onChange).toHaveBeenCalledWith('new value');
+
+    result.current.onChange({ target: { value: 'new value' } });
+    expect(onChange).toHaveBeenCalledWith('new value');
+  });
+
+  test('should return correct object when model is an array', () => {
+    const onChange = vi.fn();
+    const value = { field1: 'value1', field2: 'value2' };
+    const model = [
+      'field1',
+      { name: 'field2', valuePropName: 'value', trigger: 'onChange' },
+    ];
+
+    const { result } = renderHook(
+      () => useControlModel({ value, onChange }, model as any) as any,
+    );
+
+    expect(result.current).toEqual({
+      field1: {
+        value: value.field1,
+        onChange: expect.any(Function),
+      },
+      field2: {
+        value: value.field2,
+        onChange: expect.any(Function),
+      },
+    });
+
+    // Trigger the onChange callback for field1 and verify if it's called with the correct value
+    result.current.field1.onChange('new value');
+    expect(onChange).toHaveBeenCalledWith({
+      field1: 'new value',
+      field2: 'value2',
+    });
+
+    result.current.field1.onChange({ target: { value: 'new value' } });
+    expect(onChange).toHaveBeenCalledWith({
+      field1: 'new value',
+      field2: 'value2',
+    });
+
+    // Trigger the onChange callback for field2 and verify if it's called with the correct value
+    result.current.field2.onChange('new value');
+    expect(onChange).toHaveBeenCalledWith({
+      field1: 'value1',
+      field2: 'new value',
+    });
+
+    result.current.field2.onChange({ target: { value: 'new value' } });
+    expect(onChange).toHaveBeenCalledWith({
+      field1: 'value1',
+      field2: 'new value',
+    });
+  });
+
+  // 测试用例1：验证函数是否正确提取了value和onChange属性
+  test('pickControlProps extracts value and onChange properties correctly', () => {
+    const props: any = {
+      value: 'initial value',
+      onChange: (newValue: string) => {
+        console.log('New value:', newValue);
+      },
+    };
+
+    const controlProps = pickControlProps(props);
+
+    expect(controlProps).toEqual({
+      value: 'initial value',
+      onChange: expect.any(Function),
+    });
+  });
+
+  // 测试用例2：验证onChange函数是否正确处理传入的值
+  test('onChange function extracts value correctly', () => {
+    const props: any = {
+      value: 'initial value',
+      onChange: (newValue: string) => {
+        expect(newValue).toBe('updated value');
+      },
+    };
+
+    const controlProps = pickControlProps(props);
+
+    controlProps.onChange('updated value');
+  });
+
+  // 测试用例3：验证onChange函数是否正确处理传入的事件对象
+  test('onChange function extracts value from event object correctly', () => {
+    const props: any = {
+      value: 'initial value',
+      onChange: (newValue: string) => {
+        expect(newValue).toBe('event value');
+      },
+    };
+
+    const controlProps = pickControlProps(props);
+
+    const event = {
+      target: {
+        value: 'event value',
+      },
+    };
+
+    controlProps.onChange(event);
+  });
+});


### PR DESCRIPTION
添加了一些可以更方便在业务中使用的组件，设计成render props的风格去劫持渲染函数的组件

- FormControlRender
- FormItemRender
- ProFormItemRender
- useControlModel

详细的使用也添加了演示例子