### PR TITLE
fix(table): Record Creator re-render when props change

### DIFF
--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -359,7 +359,7 @@ function EditableTable<
       )
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recordCreatorProps == false, maxLength, value?.length]);
+  }, [recordCreatorProps, maxLength, value?.length]);
 
   const buttonRenderProps = useMemo(() => {
     if (!creatorButtonDom) {


### PR DESCRIPTION
## what.
Revert previous change to `useMemo()` dependencies to allow re-rendering record creator button when button props have changed (not just toggled from false to object).

## why.
It has to be possible to re-render this button, in situations, when for example its state changed from "disabled" to "enabled".

## references.

Closes #7991