### PR TITLE
fix: 修复dateFormatter使用string类型提示错误

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -144,6 +144,7 @@ export type CommonFormProps<
    * @example  dateFormatter={(value)=>value.format("YYYY-MM-DD")}
    */
   dateFormatter?:
+    | (string & {})
     | 'string'
     | 'number'
     | ((value: dayjs.Dayjs, valueType: string) => string | number)

--- a/packages/table/src/typing.ts
+++ b/packages/table/src/typing.ts
@@ -375,6 +375,7 @@ export type ProTableProps<DataSource, U, ValueType = 'text'> = {
    * @name 如何格式化日期
    */
   dateFormatter?:
+    | (string & {})
     | 'string'
     | 'number'
     | ((value: dayjs.Dayjs, valueType: string) => string | number)

--- a/packages/utils/src/conversionMomentValue/index.ts
+++ b/packages/utils/src/conversionMomentValue/index.ts
@@ -8,6 +8,7 @@ import type { ProFieldValueType } from '../typing';
 dayjs.extend(quarterOfYear);
 
 type DateFormatter =
+  | (string & {})
   | 'number'
   | 'string'
   | ((value: dayjs.Dayjs, valueType: string) => string | number)
@@ -73,10 +74,7 @@ const isMoment = (value: any): boolean => !!value?._isAMomentObject;
  */
 export const convertMoment = (
   value: dayjs.Dayjs,
-  dateFormatter:
-    | string
-    | ((value: dayjs.Dayjs, valueType: string) => string | number)
-    | false,
+  dateFormatter: DateFormatter,
   valueType: string,
 ) => {
   if (!dateFormatter) {


### PR DESCRIPTION
<img width="1000" alt="image" src="https://github.com/ant-design/pro-components/assets/39440537/efc7a188-348b-431c-8f9a-4a64c2bf67e2">


Example
<img width="880" alt="image" src="https://github.com/ant-design/pro-components/assets/39440537/1fca851f-5c00-4ee4-9a71-9503bacadbab">



通过Example和测试发现`string`类型的参数生效, 但是类型声明需要调整一下