### PR TITLE
feat(table): column SettingTitle 内容太长时显示省略&弹出 tooltip

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@ant-design/icons';
 import { ProProvider, useIntl } from '@ant-design/pro-provider';
 import { runFunction, useRefFunction } from '@ant-design/pro-utils';
-import type { TableColumnType } from 'antd';
+import { type TableColumnType, Typography } from 'antd';
 import { Checkbox, ConfigProvider, Popover, Space, Tooltip, Tree } from 'antd';
 import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import type { DataNode } from 'antd/lib/tree';
@@ -160,6 +160,11 @@ const CheckboxList: React.FC<{
               : config.disable?.checkbox,
           isLeaf: parentConfig ? true : undefined,
         };
+        if (item.title) {
+          const titleJsx = <>{item.title}</>
+          item.title  = <Typography.Text style={{ width: 80 }} ellipsis={{ tooltip: titleJsx }}>{titleJsx}</Typography.Text>
+        }
+        
         if (children) {
           item.children = loopData(children, {
             ...config,

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -6,8 +6,16 @@ import {
 } from '@ant-design/icons';
 import { ProProvider, useIntl } from '@ant-design/pro-provider';
 import { runFunction, useRefFunction } from '@ant-design/pro-utils';
-import { type TableColumnType, Typography } from 'antd';
-import { Checkbox, ConfigProvider, Popover, Space, Tooltip, Tree } from 'antd';
+import {
+  Checkbox,
+  ConfigProvider,
+  Popover,
+  Space,
+  Tooltip,
+  Tree,
+  Typography,
+  type TableColumnType,
+} from 'antd';
 import type { CheckboxChangeEvent } from 'antd/lib/checkbox';
 import type { DataNode } from 'antd/lib/tree';
 import classNames from 'classnames';
@@ -160,7 +168,7 @@ const CheckboxList: React.FC<{
               : config.disable?.checkbox,
           isLeaf: parentConfig ? true : undefined,
         };
-        
+
         if (children) {
           item.children = loopData(children, {
             ...config,
@@ -261,8 +269,15 @@ const CheckboxList: React.FC<{
       titleRender={(_node) => {
         const node = { ..._node, children: undefined };
         if (!node.title) return null;
-        const normalizedTitle = runFunction(node.title, node)
-        const wrappedTitle = <Typography.Text style={{ width: 80 }} ellipsis={{ tooltip: normalizedTitle }}>{normalizedTitle}</Typography.Text>
+        const normalizedTitle = runFunction(node.title, node);
+        const wrappedTitle = (
+          <Typography.Text
+            style={{ width: 80 }}
+            ellipsis={{ tooltip: normalizedTitle }}
+          >
+            {normalizedTitle}
+          </Typography.Text>
+        );
 
         return (
           <CheckboxListItem

--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -160,10 +160,6 @@ const CheckboxList: React.FC<{
               : config.disable?.checkbox,
           isLeaf: parentConfig ? true : undefined,
         };
-        if (item.title) {
-          const titleJsx = <>{item.title}</>
-          item.title  = <Typography.Text style={{ width: 80 }} ellipsis={{ tooltip: titleJsx }}>{titleJsx}</Typography.Text>
-        }
         
         if (children) {
           item.children = loopData(children, {
@@ -265,12 +261,15 @@ const CheckboxList: React.FC<{
       titleRender={(_node) => {
         const node = { ..._node, children: undefined };
         if (!node.title) return null;
+        const normalizedTitle = runFunction(node.title, node)
+        const wrappedTitle = <Typography.Text style={{ width: 80 }} ellipsis={{ tooltip: normalizedTitle }}>{normalizedTitle}</Typography.Text>
+
         return (
           <CheckboxListItem
             className={className}
             {...node}
             showListItemOption={showListItemOption}
-            title={runFunction(node.title, node)}
+            title={wrappedTitle}
             columnKey={node.key as string}
           />
         );


### PR DESCRIPTION
### 效果演示

https://github.com/ant-design/pro-components/assets/63690944/29148fa9-f153-4957-863f-a0344d84c513

