### PR TITLE
fix: 修复ProFormSelect/LightSelect选中之后没有自动隐藏和fieldProps使用open属性不能效两个问题

### DIFF
--- a/packages/field/src/components/Select/LightSelect/index.tsx
+++ b/packages/field/src/components/Select/LightSelect/index.tsx
@@ -109,6 +109,15 @@ const LightSelect: React.ForwardRefRenderFunction<
     return values;
   }, [labelPropsName, options, valuePropsName, optionLabelProp]);
 
+  // 修复用户在使用ProFormSelect组件时，在fieldProps中使用open属性，不生效。
+  // ProComponents文档中写到“与select相同，且fieldProps同antd组件中的props”描述方案不相符
+  const mergeOpen = useMemo(() => {
+    if (Reflect.has(restProps, 'open')) {
+      return restProps?.open;
+    }
+    return open;
+  }, [open, restProps]);
+
   const filterValue = Array.isArray(value)
     ? value.map((v) => getValueOrLabel(valueMap, v))
     : getValueOrLabel(valueMap, value);
@@ -134,7 +143,15 @@ const LightSelect: React.ForwardRefRenderFunction<
         if (isLabelClick) {
           setOpen(!open);
         } else {
-          setOpen(true);
+          // 这里注释掉
+          /**
+           * 因为这里与代码
+           *  if (mode !== 'multiple') {
+           *   setOpen(false);
+           *  }
+           * 冲突了，导致这段代码不生效
+           */
+          // setOpen(true);
         }
       }}
     >
@@ -182,7 +199,7 @@ const LightSelect: React.ForwardRefRenderFunction<
             </div>
           );
         }}
-        open={open}
+        open={mergeOpen}
         onDropdownVisibleChange={(isOpen) => {
           if (!isOpen) {
             //  测试环境下直接跑

--- a/tests/field/field.test.tsx
+++ b/tests/field/field.test.tsx
@@ -1992,4 +1992,54 @@ describe('Field', () => {
       ).toEqual(1);
     });
   });
+
+  it(`🐴 light select open true`, async () => {
+    const html = render(
+      <Field
+        text="default"
+        valueType="select"
+        mode="edit"
+        light
+        open={true}
+        options={[
+          { label: '全部', value: 'all' },
+          { label: '未解决', value: 'open' },
+          { label: '已解决', value: 'closed' },
+          { label: '解决中', value: 'processing' },
+        ]}
+      />,
+    );
+    await waitForWaitTime(100);
+
+    await waitFor(() => {
+      expect(
+        html.baseElement.querySelectorAll('.ant-select-dropdown').length,
+      ).toEqual(1);
+    });
+  });
+
+  it(`🐴 light select open false`, async () => {
+    const html = render(
+      <Field
+        text="default"
+        valueType="select"
+        mode="edit"
+        light
+        open={false}
+        options={[
+          { label: '全部', value: 'all' },
+          { label: '未解决', value: 'open' },
+          { label: '已解决', value: 'closed' },
+          { label: '解决中', value: 'processing' },
+        ]}
+      />,
+    );
+    await waitForWaitTime(100);
+
+    await waitFor(() => {
+      expect(
+        html.baseElement.querySelectorAll('.ant-select-dropdown').length,
+      ).toEqual(0);
+    });
+  });
 });


### PR DESCRIPTION
此次PR修复了两个问题：
1、ProFormSelect选中某一项之后，下拉框没有自动消失。其实源码中有此逻辑，只不过没有生效，是因为下拉框选中自动消失的逻辑受到了其他代码的影响。我已经在此分支里加了相应的注释，并进行了修复。
2、在使用ProFormSelect组件时，在fieldProps中使用open属性，不生效。但是按照ProComponents官方文档的描述，fieldProps应该与antd中Select组件的props相同。导致源码逻辑与ProComponents官方文档的描述不一致。