### PR TITLE
fix(DragSortTable): demo 拖动排序后报错

### DIFF
--- a/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
+++ b/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
@@ -131,6 +131,7 @@ export default () => {
         headerTitle="拖拽排序(默认把手)"
         columns={columns}
         rowKey="key"
+        search={false}
         pagination={false}
         dataSource={dataSource1}
         dragSortKey="sort"

--- a/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
+++ b/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
@@ -90,17 +90,29 @@ export default () => {
   const actionRef = useRef<ActionType>();
   const [dataSource1, setDatasource1] = useState(data);
   const [dataSource2, setDatasource2] = useState(data);
-  const handleDragSortEnd1 = (newDataSource: any) => {
+  const handleDragSortEnd1 = (
+    beforeIndex: number,
+    afterIndex: number,
+    newDataSource: any,
+  ) => {
     console.log('排序后的数据', newDataSource);
     setDatasource1(newDataSource);
     message.success('修改列表排序成功');
   };
-  const handleDragSortEnd2 = (newDataSource: any) => {
+  const handleDragSortEnd2 = (
+    beforeIndex: number,
+    afterIndex: number,
+    newDataSource: any,
+  ) => {
     console.log('排序后的数据', newDataSource);
     setDatasource2(newDataSource);
     message.success('修改列表排序成功');
   };
-  const handleDragSortEnd3 = (newDataSource: any) => {
+  const handleDragSortEnd3 = (
+    beforeIndex: number,
+    afterIndex: number,
+    newDataSource: any,
+  ) => {
     console.log('排序后的数据', newDataSource);
     // 模拟将排序后数据发送到服务器的场景
     remoteData = newDataSource;

--- a/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
+++ b/packages/table/src/components/DragSortTable/demos/drag-sort-table.tsx
@@ -10,21 +10,18 @@ const data = [
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
-    index: 0,
   },
   {
     key: 'key2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
-    index: 1,
   },
   {
     key: 'key3',
     name: 'Joe Black',
     age: 32,
     address: 'Sidney No. 1 Lake Park',
-    index: 2,
   },
 ];
 const wait = async (delay = 1000) =>
@@ -142,7 +139,7 @@ export default () => {
       <DragSortTable
         headerTitle="拖拽排序(自定义把手)"
         columns={columns2}
-        rowKey="index"
+        rowKey="key"
         search={false}
         pagination={false}
         dataSource={dataSource2}
@@ -154,7 +151,7 @@ export default () => {
         actionRef={actionRef}
         headerTitle="使用 request 获取数据源"
         columns={columns2}
-        rowKey="index"
+        rowKey="key"
         search={false}
         pagination={false}
         request={request}

--- a/packages/table/src/components/DragSortTable/demos/drag.tsx
+++ b/packages/table/src/components/DragSortTable/demos/drag.tsx
@@ -64,6 +64,7 @@ export default () => {
       headerTitle="拖拽排序(默认把手)"
       columns={columns}
       rowKey="key"
+      search={false}
       pagination={false}
       dataSource={dataSource}
       dragSortKey="sort"

--- a/packages/table/src/components/DragSortTable/demos/drag.tsx
+++ b/packages/table/src/components/DragSortTable/demos/drag.tsx
@@ -31,21 +31,18 @@ const data = [
     name: 'John Brown',
     age: 32,
     address: 'New York No. 1 Lake Park',
-    index: 0,
   },
   {
     key: '2',
     name: 'Jim Green',
     age: 42,
     address: 'London No. 1 Lake Park',
-    index: 1,
   },
   {
     key: '3',
     name: 'Joe Black',
     age: 32,
     address: 'Sidney No. 1 Lake Park',
-    index: 2,
   },
 ];
 


### PR DESCRIPTION
1. demo 中 onDragSortEnd 方法 newDataSource 取值有误，导致拖动后会报错，官网可复现。
![image](https://github.com/ant-design/pro-components/assets/49969025/d7a36901-aada-4c67-98ba-a60a220efa0b)
3. demo 中的测试数据已经又 key 字段作为表格 rowKey 的传参，因此删除了多余的 index 字段。
4. demo 中的搜索表单没有效果，因此修改 search 进行隐藏。