### PR TITLE
feat: allow custom translations

### DIFF
--- a/packages/provider/src/index.tsx
+++ b/packages/provider/src/index.tsx
@@ -204,6 +204,7 @@ const ConfigProviderContainer: React.FC<{
   hashed?: boolean;
   dark?: boolean;
   prefixCls?: string;
+  intl?: IntlType
 }> = (props) => {
   const {
     children,
@@ -212,6 +213,7 @@ const ConfigProviderContainer: React.FC<{
     autoClearCache = false,
     token: propsToken,
     prefixCls,
+    intl,
   } = props;
   const { locale, getPrefixCls, ...restConfig } = useContext(
     AntdConfigProvider.ConfigContext,
@@ -246,8 +248,8 @@ const ConfigProviderContainer: React.FC<{
     const localeName = locale?.locale;
     const key = findIntlKeyByAntdLocaleKey(localeName);
     // antd 的 key 存在的时候以 antd 的为主
-    const intl =
-      localeName && proProvide.intl?.locale === 'default'
+    const resolvedIntl =
+      intl ?? localeName && proProvide.intl?.locale === 'default'
         ? intlMap[key! as 'zh-CN']
         : proProvide.intl || intlMap[key! as 'zh-CN'];
 
@@ -260,7 +262,7 @@ const ConfigProviderContainer: React.FC<{
         themeId: tokenContext.theme.id,
         layout: proLayoutTokenMerge,
       }),
-      intl: intl || zhCNIntl,
+      intl: resolvedIntl || zhCNIntl,
     };
   }, [
     locale?.locale,
@@ -271,6 +273,7 @@ const ConfigProviderContainer: React.FC<{
     proComponentsCls,
     antCls,
     proLayoutTokenMerge,
+    intl,
   ]);
 
   const finalToken = {
@@ -374,6 +377,7 @@ export const ProConfigProvider: React.FC<{
   dark?: boolean;
   hashed?: boolean;
   prefixCls?: string;
+  intl?: IntlType
 }> = (props) => {
   const { needDeps, dark, token } = props;
   const proProvide = useContext(ProConfigContext);

--- a/packages/provider/src/index.tsx
+++ b/packages/provider/src/index.tsx
@@ -204,7 +204,7 @@ const ConfigProviderContainer: React.FC<{
   hashed?: boolean;
   dark?: boolean;
   prefixCls?: string;
-  intl?: IntlType
+  intl?: IntlType;
 }> = (props) => {
   const {
     children,
@@ -249,9 +249,10 @@ const ConfigProviderContainer: React.FC<{
     const key = findIntlKeyByAntdLocaleKey(localeName);
     // antd 的 key 存在的时候以 antd 的为主
     const resolvedIntl =
-      intl ?? localeName && proProvide.intl?.locale === 'default'
+      intl ??
+      (localeName && proProvide.intl?.locale === 'default'
         ? intlMap[key! as 'zh-CN']
-        : proProvide.intl || intlMap[key! as 'zh-CN'];
+        : proProvide.intl || intlMap[key! as 'zh-CN']);
 
     return {
       ...proProvide,
@@ -377,7 +378,7 @@ export const ProConfigProvider: React.FC<{
   dark?: boolean;
   hashed?: boolean;
   prefixCls?: string;
-  intl?: IntlType
+  intl?: IntlType;
 }> = (props) => {
   const { needDeps, dark, token } = props;
   const proProvide = useContext(ProConfigContext);

--- a/tests/provider/index.test.tsx
+++ b/tests/provider/index.test.tsx
@@ -1,4 +1,4 @@
-import { ProConfigProvider, useStyle } from '@ant-design/pro-components';
+import { ProConfigProvider, ProForm, ProFormMoney, createIntl, useStyle } from '@ant-design/pro-components';
 import { cleanup, render } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
 
@@ -34,6 +34,30 @@ describe('ProConfigProvider', () => {
           <Demo />
         </ProConfigProvider>
       </ConfigProvider>,
+    );
+  });
+  
+  it('custom translations should be respected', () => {
+    const { container } = render(
+      <ConfigProvider
+      >
+        <ProConfigProvider intl={createIntl(
+          'en',
+          {
+            moneySymbol: '!?'
+          }
+        )}>
+          <ProForm
+          >
+            <ProFormMoney name="amount" initialValue={44.33} />
+          </ProForm>
+        </ProConfigProvider>
+      </ConfigProvider>,
+    );
+
+    expect(container.querySelectorAll('input#amount')[0]).toHaveAttribute(
+      'value',
+      '!? 44.33',
     );
   });
 });


### PR DESCRIPTION
This PR allows developers to pass an `intl` property (created via `createIntl`) to the ConfigProvider in order to define custom translations.