### PR TITLE
fix(QueryFilter): 修复 ProFormDependency 在 QueryFilter 中失效的问题

### DIFF
--- a/packages/form/src/layouts/QueryFilter/index.tsx
+++ b/packages/form/src/layouts/QueryFilter/index.tsx
@@ -200,21 +200,12 @@ export type BaseQueryFilterProps = Omit<
 const flatMapItems = (
   items: React.ReactNode[],
   ignoreRules?: boolean,
-  form?: FormInstance,
 ): React.ReactNode[] => {
   return items?.flatMap((item: any) => {
     if (item?.type.displayName === 'ProForm-Group' && !item.props?.title) {
       return item.props.children;
     }
-    if (item?.type.displayName === 'ProFormDependency' && !item.props?.title) {
-      const values = item.props.name.reduce((current: any, next: any) => {
-        return {
-          ...current,
-          [next]: form?.getFieldValue(next),
-        };
-      }, {});
-      return item.props.children(values);
-    }
+
     if (ignoreRules && React.isValidElement(item)) {
       return React.cloneElement(item, {
         ...(item.props as any),
@@ -290,7 +281,6 @@ const QueryFilterContent: React.FC<{
     showLength,
     searchGutter,
     showHiddenNum,
-    form,
   } = props;
 
   const submitter = useMemo(() => {
@@ -330,7 +320,7 @@ const QueryFilterContent: React.FC<{
   let currentSpan = 0;
 
   // 处理过，包含是否需要隐藏的 数组
-  const processedList = flatMapItems(items, props.ignoreRules, form).map(
+  const processedList = flatMapItems(items, props.ignoreRules).map(
     (
       item,
       index,


### PR DESCRIPTION
fix: https://github.com/ant-design/pro-components/issues/8067


这个 [pr](https://github.com/ant-design/pro-components/pull/7611) 中引入了这个 BUG，建议原 [issue](https://github.com/ant-design/pro-components/issues/6928) 自己实现 Table 的筛选区
