### PR TITLE
fix: 修复bootstrap.js创建文件bug

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -51,26 +51,25 @@ const { yParser } = require('@umijs/utils');
           access: 'public',
         },
       };
-      if (pkgJSONExists) {
-        const pkg = require(pkgJSONPath);
-        [
-          'dependencies',
-          'devDependencies',
-          'peerDependencies',
-          'bin',
-          'version',
-          'files',
-          'authors',
-          'types',
-          'sideEffects',
-          'main',
-          'module',
-          'description',
-        ].forEach((key) => {
-          if (pkg[key]) json[key] = pkg[key];
-        });
-      }
       writeFileSync(pkgJSONPath, `${JSON.stringify(json, null, 2)}\n`);
+    } else if (pkgJSONExists) {
+      const pkg = require(pkgJSONPath);
+      [
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'bin',
+        'version',
+        'files',
+        'authors',
+        'types',
+        'sideEffects',
+        'main',
+        'module',
+        'description',
+      ].forEach((key) => {
+        if (pkg[key]) json[key] = pkg[key];
+      });
     }
 
     const readmePath = join(


### PR DESCRIPTION
调整判断逻辑，原逻辑会导致packages目录下文件夹内有pacages.json没有README.md时，报错：`TypeError: Cannot read properties of undefined (reading 'description') `