### PR TITLE
 🐛 fix(proTable): 将Table columnsState storageValue覆盖defaultValue

### DIFF
--- a/packages/table/src/Store/Provide.tsx
+++ b/packages/table/src/Store/Provide.tsx
@@ -15,6 +15,7 @@ import type { ProTableProps } from '../index';
 import type { ActionType, ProColumns } from '../typing';
 import { genColumnKey } from '../utils';
 
+
 export type ColumnsState = {
   show?: boolean;
   fixed?: 'right' | 'left' | undefined;
@@ -88,12 +89,14 @@ function useContainer(props: UseContainerProps = {} as Record<string, any>) {
         /** 从持久化中读取数据 */
         const storage = window[persistenceType];
         try {
+         
           const storageValue = storage?.getItem(persistenceKey);
           if (storageValue) {
             if (props?.columnsState?.defaultValue) {
+              // 实际生产中，defaultValue往往作为系统方默认配置，则优先级不应高于用户配置的storageValue
               return merge(
-                JSON.parse(storageValue),
                 props?.columnsState?.defaultValue,
+                JSON.parse(storageValue),
               );
             }
             return JSON.parse(storageValue);
@@ -117,6 +120,7 @@ function useContainer(props: UseContainerProps = {} as Record<string, any>) {
 
   /**  配置或列更改时对columnsMap重新赋值 */
   useEffect(() => {
+
     const { persistenceType, persistenceKey } = props.columnsState || {};
 
     if (persistenceKey && persistenceType && typeof window !== 'undefined') {


### PR DESCRIPTION
   实际生产中，defaultValue往往作为系统方默认配置，则优先级不应高于用户配置的storageValue。
否则会出现在设置defaultValue后用户无论如何修改都无法获取自己配置的效果
[#8204](https://github.com/ant-design/pro-components/issues/8240)

原有代码  `  if (storageValue) {
            if (props?.columnsState?.defaultValue) {
              return merge(
                JSON.parse(storageValue),
                props?.columnsState?.defaultValue,
              );
            }
            return JSON.parse(storageValue);
          } `