### PR TITLE
perf：onFinish为同步函数时不用setLoading，避免开销浪费

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -81,7 +81,7 @@ export type CommonFormProps<
    *
    * @example onFinish={async (values) => { await save(values); return true }}
    */
-  onFinish?: (formData: T) => Promise<boolean | void>;
+  onFinish?: (formData: T) => Promise<boolean | void> | void;
   /**
    * @name 表单按钮的 loading 状态
    */
@@ -671,10 +671,13 @@ function BaseForm<T = Record<string, any>, U = Record<string, any>>(
     if (!propRest.onFinish) return;
     // 防止重复提交
     if (loading) return;
-    setLoading(true);
     try {
       const finalValues = formRef?.current?.getFieldsFormatValue?.();
-      await propRest.onFinish(finalValues);
+      const response = propRest.onFinish(finalValues);
+      if (response instanceof Promise) {
+        setLoading(true);
+      }
+      await response;
       if (syncToUrl) {
         // 把没有的值设置为未定义可以删掉 url 的参数
         const syncToUrlParams = Object.keys(

--- a/packages/form/src/components/form.md
+++ b/packages/form/src/components/form.md
@@ -12,7 +12,7 @@ ProForm 在原来的 Form 的基础上增加了一些语法糖和更多的布局
 
 - 如果想要设置默认值，请使用 `initialValues`，任何直接使用组件 `value` 和 `onChange` 的方式都有可能导致值绑定失效
 - 如果想要表单联动或者做一些依赖，可以使用 render props 模式，ProFormDependency 绝对是最好的选择
-- ProForm 的 onFinish 与 antd 的 Form 不同，是个 Promise，如果你正常返回会自动为你设置按钮的加载效果
+- ProForm 的 onFinish 与 antd 的 Form 不同，支持 Promise，如果你正常返回会自动为你设置按钮的加载效果
 - 如果想要监听某个值，建议使用 `onValuesChange`。保持单向的数据流无论对开发者还是维护者都大有裨益
 - ProForm 没有黑科技，只是 antd 的 Form 的封装，如果要使用自定义的组件可以用 Form.Item 包裹后使用，支持混用
 
@@ -242,7 +242,7 @@ ProForm 是对 antd Form 的再封装，如果你想要自定义表单元素，P
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| onFinish | 提交表单且数据验证成功后回调事件，同 antd 4 `Form` 组件 API | `(values)=>Promise<void>` | - |
+| onFinish | 提交表单且数据验证成功后回调事件，同 antd 4 `Form` 组件 API | `(values)=>Promise<void> ｜ void` | - |
 | onReset | 点击重置按钮的回调 | `(e)=>void` | - |
 | submitter | 提交按钮相关配置 | `boolean` \| `SubmitterProps` | `true` |
 | syncToUrl | 同步参数到 url 上，url 只支持 string，在使用之前最好读一下[url 中的参数类型](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) | `true` \| `(values,type)=>values` | - |


### PR DESCRIPTION
onFinish在部分场景或部分用户开发习惯中，是不需要写async函数的，所以不用默认去setLoading，省去2次组件刷新
