### PR TITLE
fix(form): textarea readonly mode cant use fieldProps.style

### DIFF
--- a/packages/field/src/components/TextArea/readonly.tsx
+++ b/packages/field/src/components/TextArea/readonly.tsx
@@ -15,7 +15,7 @@ import 'antd/lib/input/style';
  */
 const FieldTextAreaReadonly: ProFieldFC<{
   text: string;
-}> = ({ text }, ref) => {
+}> = ({ text, fieldProps }, ref) => {
   const { getPrefixCls } = useContext(ConfigProvider.ConfigContext);
   const readonlyClassName = getPrefixCls('pro-field-readonly');
   const compClassName = `${readonlyClassName}-textarea`;
@@ -24,7 +24,6 @@ const FieldTextAreaReadonly: ProFieldFC<{
     return {
       [`.${compClassName}`]: {
         display: 'inline-block',
-        // padding: '4px 11px',
         lineHeight: '1.5715',
         maxWidth: '100%',
         whiteSpace: 'pre-wrap',
@@ -36,7 +35,7 @@ const FieldTextAreaReadonly: ProFieldFC<{
     <span
       ref={ref}
       className={classNames(hashId, readonlyClassName, compClassName)}
-      style={{}}
+      {...fieldProps}
     >
       {text ?? '-'}
     </span>,


### PR DESCRIPTION
fix: textarea readonly mode cant use fieldProps.style
I add style `wordBreak: 'break-all'`, its not effective
```js
<ProFormTextArea
      name="name2"
      label="name"
      fieldProps={{
        style: {
         wordBreak: 'break-all',
       },
    }}
/>
```
![2024-04-21 000850](https://github.com/ant-design/pro-components/assets/167594187/000ec697-e06b-48d8-9d92-bfa3d152ff3d)
