### PR TITLE
fix(form): 修复openChange打开时不触发问题

### DIFF
--- a/packages/form/src/layouts/ModalForm/index.tsx
+++ b/packages/form/src/layouts/ModalForm/index.tsx
@@ -7,6 +7,7 @@ import { noteOnce } from 'rc-util/lib/warning';
 import React, {
   useCallback,
   useContext,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -129,14 +130,13 @@ function ModalForm<T = Record<string, any>, U = Record<string, any>>({
     [formRef.current],
   );
 
-  // useMergedState监听了open的变化
-  // useEffect(() => {
-  //   if (open && (propsOpen || propVisible)) {
-  //     onOpenChange?.(true);
-  //     onVisibleChange?.(true);
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [propVisible, propsOpen, open]);
+  useEffect(() => {
+    if (propsOpen || propVisible) {
+      onOpenChange?.(true);
+      onVisibleChange?.(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [propVisible, propsOpen]);
 
   const triggerDom = useMemo(() => {
     if (!trigger) {

--- a/tests/form/modalForm.test.tsx
+++ b/tests/form/modalForm.test.tsx
@@ -270,23 +270,22 @@ describe('ModalForm', () => {
     expect(fn).toBeCalledTimes(1); // 关闭只触发一次 onOpenChange
   });
 
-  // 如果默认就是 open 的 onOpenChange 预期应当不触发
-  // it('📦 modal open=true simulate onOpenChange', async () => {
-  //   const fn = vi.fn();
-  //   render(
-  //     <ModalForm
-  //       open
-  //       trigger={<Button id="new">新建</Button>}
-  //       onOpenChange={(visible) => fn(visible)}
-  //     >
-  //       <ProFormText name="name" />
-  //     </ModalForm>,
-  //   );
+  it('📦 modal open=true simulate onOpenChange', async () => {
+    const fn = vi.fn();
+    render(
+      <ModalForm
+        open
+        trigger={<Button id="new">新建</Button>}
+        onOpenChange={(visible) => fn(visible)}
+      >
+        <ProFormText name="name" />
+      </ModalForm>,
+    );
 
-  //   await waitFor(() => {
-  //     expect(fn).toBeCalledWith(true);
-  //   });
-  // });
+    await waitFor(() => {
+      expect(fn).toBeCalledWith(true);
+    });
+  });
 
   it('📦 reset button will simulate onOpenChange', async () => {
     const fn = vi.fn();

--- a/tests/form/modalForm.test.tsx
+++ b/tests/form/modalForm.test.tsx
@@ -267,7 +267,7 @@ describe('ModalForm', () => {
       await waitForWaitTime(100);
     });
     expect(fn).toBeCalledWith(false);
-    expect(fn).toBeCalledTimes(1); // 关闭只触发一次 onOpenChange
+    expect(fn).toBeCalledTimes(2); // 点击触发一次，关闭触发一次 onOpenChange
   });
 
   it('📦 modal open=true simulate onOpenChange', async () => {
@@ -385,7 +385,7 @@ describe('ModalForm', () => {
     await waitFor(async () => {
       await waitForWaitTime(100);
     });
-    expect(fn).toBeCalledTimes(0);
+    expect(fn).toBeCalledTimes(1); // 点击会触发一次onOpenChange
   });
 
   it('📦 ModalForm support submitter is false', async () => {


### PR DESCRIPTION
如果ModalForm的open状态由父级通过props控制，并且需要在打开时对form设定初值，就需要监听propOpen的状态，并在其为 true时执行一次onOpenChange。