### PR TITLE
DragSortTable layout flicker when using in explanable table

### DIFF
--- a/packages/table/src/components/DragSortTable/index.tsx
+++ b/packages/table/src/components/DragSortTable/index.tsx
@@ -87,25 +87,24 @@ function DragSortTable<
   };
 
   return wrapSSR(
-    <ProTable<T, U, ValueType>
-      {...(otherProps as ProTableProps<T, U, ValueType>)}
-      columns={otherProps.columns?.map((item): any => {
-        if (item.dataIndex == dragSortKey || item.key === dragSortKey) {
-          if (!item.render) {
-            item.render = () => null;
+    <DndContext>
+      <ProTable<T, U, ValueType>
+        {...(otherProps as ProTableProps<T, U, ValueType>)}
+        columns={otherProps.columns?.map((item): any => {
+          if (item.dataIndex == dragSortKey || item.key === dragSortKey) {
+            if (!item.render) {
+              item.render = () => null;
+            }
           }
-        }
-        return item;
-      })}
-      onLoad={wrapOnload}
-      rowKey={rowKey}
-      tableViewRender={(_, defaultDom) => {
-        return <DndContext>{defaultDom}</DndContext>;
-      }}
-      dataSource={dataSource}
-      components={components}
-      onDataSourceChange={onDataSourceChange}
-    />,
+          return item;
+        })}
+        onLoad={wrapOnload}
+        rowKey={rowKey}
+        dataSource={dataSource}
+        components={components}
+        onDataSourceChange={onDataSourceChange}
+      />
+    </DndContext>,
   );
 }
 


### PR DESCRIPTION
From this issue id #8232. I just move DndContext from tableViewRender to wrap ProTable component for avoid css ficking when some component in DragSortTable change state.

🐛 bug detail
when create or take any action to make DragSortTable component re-render it alway filking a bit