### PR TITLE
docs(proTable): 修复pro-table文档案例代码里Dropdown内元素key冲突问题

### DIFF
--- a/packages/table/src/demos/single.tsx
+++ b/packages/table/src/demos/single.tsx
@@ -223,11 +223,11 @@ export default () => {
               },
               {
                 label: '2nd item',
-                key: '1',
+                key: '2',
               },
               {
                 label: '3rd item',
-                key: '1',
+                key: '3',
               },
             ],
           }}

--- a/packages/table/src/demos/theme.tsx
+++ b/packages/table/src/demos/theme.tsx
@@ -214,11 +214,11 @@ export default () => {
                   },
                   {
                     label: '2nd item',
-                    key: '1',
+                    key: '2',
                   },
                   {
                     label: '3rd item',
-                    key: '1',
+                    key: '3',
                   },
                 ],
               }}


### PR DESCRIPTION
bug: pro-table案例代码dropdown子项key都一样导致鼠标悬浮dropdown时全部被选中
修改内容：将pro-table案例代码中的key从全部都是字符串1修改为1、2、3，与其他相关案例保持一致
<img width="1157" alt="image" src="https://github.com/ant-design/pro-components/assets/57085834/5805dfa8-13a5-47f5-a0ff-e9407c67b765">
