### PR TITLE
移除选中菜单hover字体变色的效果

### DIFF
--- a/packages/layout/src/components/SiderMenu/style/index.ts
+++ b/packages/layout/src/components/SiderMenu/style/index.ts
@@ -46,7 +46,7 @@ const genSiderMenuStyle: GenerateStyle<SiderMenuToken> = (token) => {
             fontSize: token.fontSizeSM,
             paddingBottom: 4,
           },
-          [`${token.antCls}-menu-item:hover`]: {
+          [`${token.antCls}-menu-item:not(${token.antCls}-menu-item-selected):hover`]: {
             color: token.layout?.sider?.colorTextMenuItemHover,
           },
         },


### PR DESCRIPTION
token.layout?.sider?.colorTextMenuItemHover
menuItem 的 hover 字体颜色，不应该包含已选中的菜单