### PR TITLE
Revert "DragSortTable layout flicker when using in explanable table"

### DIFF
--- a/packages/table/src/components/DragSortTable/index.tsx
+++ b/packages/table/src/components/DragSortTable/index.tsx
@@ -87,24 +87,25 @@ function DragSortTable<
   };
 
   return wrapSSR(
-    <DndContext>
-      <ProTable<T, U, ValueType>
-        {...(otherProps as ProTableProps<T, U, ValueType>)}
-        columns={otherProps.columns?.map((item): any => {
-          if (item.dataIndex == dragSortKey || item.key === dragSortKey) {
-            if (!item.render) {
-              item.render = () => null;
-            }
+    <ProTable<T, U, ValueType>
+      {...(otherProps as ProTableProps<T, U, ValueType>)}
+      columns={otherProps.columns?.map((item): any => {
+        if (item.dataIndex == dragSortKey || item.key === dragSortKey) {
+          if (!item.render) {
+            item.render = () => null;
           }
-          return item;
-        })}
-        onLoad={wrapOnload}
-        rowKey={rowKey}
-        dataSource={dataSource}
-        components={components}
-        onDataSourceChange={onDataSourceChange}
-      />
-    </DndContext>,
+        }
+        return item;
+      })}
+      onLoad={wrapOnload}
+      rowKey={rowKey}
+      tableViewRender={(_, defaultDom) => {
+        return <DndContext>{defaultDom}</DndContext>;
+      }}
+      dataSource={dataSource}
+      components={components}
+      onDataSourceChange={onDataSourceChange}
+    />,
   );
 }
 


### PR DESCRIPTION
Reverts ant-design/pro-components#8414