### PR TITLE
fix: 解决ProTable.editable.actionRender无法获取最新state快照的问题（第二种改法）

### DIFF
--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -772,6 +772,8 @@ const ProTable = <
     type,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     editableUtils.editableKeys && editableUtils.editableKeys.join(','),
+    // 如果传入了actionRender，则需要更新memo确保actionRender里能获取到最新的state快照
+    props.editable?.actionRender,
   ]);
 
   /** Table Column 变化的时候更新一下，这个参数将会用于渲染 */

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -772,8 +772,6 @@ const ProTable = <
     type,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     editableUtils.editableKeys && editableUtils.editableKeys.join(','),
-    // 如果传入了actionRender，则需要更新memo确保actionRender里能获取到最新的state快照
-    props.editable?.actionRender,
   ]);
 
   /** Table Column 变化的时候更新一下，这个参数将会用于渲染 */

--- a/packages/utils/src/useEditableArray/index.tsx
+++ b/packages/utils/src/useEditableArray/index.tsx
@@ -1027,6 +1027,13 @@ export function useEditableArray<RecordType>(
     },
   );
 
+  // 如果传入了自定义的actionRender，使用useRefFunction以确保内部的事件处理函数可以访问最新的state
+  const existCustomActionRender = props.actionRender && typeof props.actionRender === 'function'
+  const customActionRender = existCustomActionRender
+      ? props.actionRender
+      : () => {};
+  const customActionRenderRef = useRefFunction((customActionRender as ActionRenderFunction<RecordType>))
+
   const actionRender = (row: RecordType & { index: number }) => {
     const key = props.getRowKey(row, row.index);
     const config: ActionRenderConfig<any, NewLineConfig<any>> = {
@@ -1060,8 +1067,8 @@ export function useEditableArray<RecordType>(
     } else {
       saveRefsMap.current.set(recordKeyToString(key), renderResult.saveRef);
     }
-    if (props.actionRender)
-      return props.actionRender(row, config, {
+    if (existCustomActionRender)
+      return customActionRenderRef(row, config, {
         save: renderResult.save,
         delete: renderResult.delete,
         cancel: renderResult.cancel,


### PR DESCRIPTION
[#8547](https://github.com/ant-design/pro-components/pull/8547)的另外一种改法
