### PR TITLE
fix(provider): use built-in translation when translation in ProConfigContext is missing

### DIFF
--- a/packages/provider/src/intl.ts
+++ b/packages/provider/src/intl.ts
@@ -70,8 +70,14 @@ export const createIntl = (
   locale: string,
   localeMap: Record<string, any>,
 ): IntlType => ({
-  getMessage: (id: string, defaultMessage: string) =>
-    get(localeMap, id, defaultMessage) || defaultMessage,
+  getMessage: (id: string, defaultMessage: string) => {
+    const msg = get(localeMap, id, '');
+    if (msg) return msg;
+    const localKey = locale.replace('_', '-');
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const intl = intlMap[localKey! as 'zh-CN'];
+    return intl ? intl.getMessage(id, defaultMessage) : defaultMessage;
+  },
   locale,
 });
 


### PR DESCRIPTION
For example, if the user has not defined `editableTable.onlyAddOneLine` in the context:

```ts
// Intl passed to ProConfigProvider
export default {
  editableTable: {},
};
```

The translation will fall back to default message. However, `editableTable.onlyAddOneLine` is actually defined in the provider's default language set. This fix ensures that the translation is found in the default set.