### PR TITLE
fix(table): don't spread key to children

### DIFF
--- a/packages/table/src/components/ColumnSetting/index.tsx
+++ b/packages/table/src/components/ColumnSetting/index.tsx
@@ -282,7 +282,7 @@ const CheckboxList: React.FC<{
         return (
           <CheckboxListItem
             className={className}
-            {...node}
+            {...omit(node, ['key'])}
             showListItemOption={showListItemOption}
             title={wrappedTitle}
             columnKey={node.key as string}


### PR DESCRIPTION
fix: #8574 