### PR TITLE
fix: add unit to transition duration in procard

### DIFF
--- a/packages/card/src/components/Card/style.ts
+++ b/packages/card/src/components/Card/style.ts
@@ -28,7 +28,7 @@ const genProCardStyle: GenerateStyle<ProCardToken> = (token) => {
       paddingInline: 0,
       backgroundColor: token.colorBgContainer,
       borderRadius: token.borderRadius,
-      transition: 'all 0.3',
+      transition: 'all 0.3s',
       ...resetComponent?.(token),
 
       '&-box-shadow': {


### PR DESCRIPTION
<img width="328" alt="image" src="https://github.com/user-attachments/assets/f67e35f3-725a-4a79-869e-cc5c73ee243c">