### PR TITLE
docs(StepsForm): 修复文档案例(分步表单垂直模式)的布局错乱问题

### DIFF
--- a/packages/form/src/components/StepsForm/demos/steps-form-vertical.tsx
+++ b/packages/form/src/components/StepsForm/demos/steps-form-vertical.tsx
@@ -107,12 +107,12 @@ export default () => {
               label="记录保存时间"
               width="sm"
             />
-            <ProFormCheckbox.Group
+          </ProForm.Group>
+          <ProFormCheckbox.Group
               name="checkbox"
               label="迁移类型"
               options={['完整 LOB', '不同步 LOB', '受限制 LOB']}
-            />
-          </ProForm.Group>
+          />
         </StepsForm.StepForm>
         <StepsForm.StepForm<{
           checkbox: string;


### PR DESCRIPTION
bug：https://github.com/ant-design/pro-components/issues/8596
修改内容：修复文档案例(分步表单垂直模式)因ProFormCheckbox.Group嵌套层级不对导致的布局错乱的问题