### PR TITLE
fix(field): keyboard events of search input in LightSelect

### DIFF
--- a/packages/field/src/components/Select/LightSelect/index.tsx
+++ b/packages/field/src/components/Select/LightSelect/index.tsx
@@ -214,7 +214,13 @@ const LightSelect: React.ForwardRefRenderFunction<
                     }}
                     onKeyDown={(e) => {
                       // 避免按下删除键把选项也删除了
-                      e.stopPropagation();
+                      if (e.key === 'Backspace') {
+                        e.stopPropagation();
+                        return;
+                      }
+                      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                        e.preventDefault();
+                      }
                     }}
                     style={{ width: '100%' }}
                     prefix={<SearchOutlined />}


### PR DESCRIPTION
#### 现况
轻量筛选 通过搜索框筛选后只能再通过鼠标操作选择，操作稍显麻烦。
#### 修复后
搜索框输入后可直接通过方向键上下选择和回车选中。
#### 修复方式
恢复选择器输入框除退格键外的键盘事件。