### PR TITLE
fix(layout): downgrade path-to-regexp to version 8.0.0

### DIFF
--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -43,7 +43,7 @@
     "classnames": "^2.3.2",
     "lodash-es": "^4.17.21",
     "omit.js": "^2.0.2",
-    "path-to-regexp": "8.1.0",
+    "path-to-regexp": "8.0.0",
     "rc-resize-observer": "^1.1.0",
     "rc-util": "^5.0.6",
     "swr": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,8 +597,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       path-to-regexp:
-        specifier: 8.1.0
-        version: 8.1.0
+        specifier: 8.0.0
+        version: 8.0.0
       rc-resize-observer:
         specifier: ^1.1.0
         version: 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9900,6 +9900,10 @@ packages:
 
   path-to-regexp@1.7.0:
     resolution: {integrity: sha512-nifX1uj4S9IrK/w3Xe7kKvNEepXivANs9ng60Iq7PU/BlouV3yL/VUhFqTuTq33ykwUqoNcTeGo5vdOBP4jS/Q==}
+
+  path-to-regexp@8.0.0:
+    resolution: {integrity: sha512-GAWaqWlTjYK/7SVpIUA6CTxmcg65SP30sbjdCvyYReosRkk7Z/LyHWwkK3Vu0FcIi0FNTADUs4eh1AsU5s10cg==}
+    engines: {node: '>=16'}
 
   path-to-regexp@8.1.0:
     resolution: {integrity: sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==}
@@ -25714,6 +25718,8 @@ snapshots:
   path-to-regexp@1.7.0:
     dependencies:
       isarray: 0.0.1
+
+  path-to-regexp@8.0.0: {}
 
   path-to-regexp@8.1.0: {}
 


### PR DESCRIPTION
旧版本的webpack不支持新的写法

![image](https://github.com/user-attachments/assets/6dfa5772-ae2d-467e-bdd5-26613bfa49e7)
