### PR TITLE
feat: added exports to support ESM environments such as vitest

### DIFF
--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "lib",
     "es",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,6 +20,13 @@
   "unpkg": "dist/pro-components.min.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "lib",

--- a/packages/descriptions/package.json
+++ b/packages/descriptions/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "dist",

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -14,6 +14,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "dist",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "lib",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "dist",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -17,6 +17,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "dist",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "es",

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "lib",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "dist",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,6 +19,13 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "types": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "require": "./lib/index.js",
+      "types": "./es/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "es",


### PR DESCRIPTION
Added `exports` field so the components can be loaded with nodejs ESM resolver. This is needed when importing components in `vitest` for example.

Fixes https://github.com/ant-design/pro-components/issues/8627
