### PR TITLE
fix(layout): remove `autoClearCache` in ProLayout

### DIFF
--- a/packages/layout/src/ProLayout.tsx
+++ b/packages/layout/src/ProLayout.tsx
@@ -900,7 +900,6 @@ const ProLayout: React.FC<ProLayoutProps> = (props) => {
       }
     >
       <ProConfigProvider
-        autoClearCache
         {...darkProps}
         token={props.token}
         prefixCls={props.prefixCls}


### PR DESCRIPTION
情况

1. ProLayout 中只有获取菜单会用到 swr ，组件销毁时已有清理缓存

https://github.com/ant-design/pro-components/blob/a3d14c3464fb07f41c1e2be96ce3dd9e4a23d451/packages/layout/src/ProLayout.tsx#L494-L523

2.  设置了 `autoClearCache` 会把  SWR 全局缓存清掉，导致其他功能异常 #7670

https://github.com/ant-design/pro-components/blob/a3d14c3464fb07f41c1e2be96ce3dd9e4a23d451/packages/provider/src/index.tsx#L193-L210

因此这个属性可以直接去掉？