### PR TITLE
fix(FieldCheckbox):设置了fieldNames后控制器报错的问题 React does not recognize the…

### DIFF
--- a/packages/field/src/components/Checkbox/index.tsx
+++ b/packages/field/src/components/Checkbox/index.tsx
@@ -33,7 +33,6 @@ const FieldCheckbox: ProFieldFC<GroupProps> = (
   const layoutClassName = getPrefixCls('pro-field-checkbox');
   const status = Form.Item?.useStatus?.();
   const [loading, options, fetchData] = useFieldFetchData(rest);
-
   // css
   const { wrapSSR, hashId } = useStyle('Checkbox', (token) => {
     return {
@@ -115,10 +114,11 @@ const FieldCheckbox: ProFieldFC<GroupProps> = (
   }
 
   if (mode === 'edit') {
+    const {fieldNames,...restFieldProps} = rest.fieldProps || {};
     const dom = wrapSSR(
       //@ts-ignore
       <Checkbox.Group
-        {...rest.fieldProps}
+        {...restFieldProps}
         className={classNames(
           rest.fieldProps?.className,
           hashId,


### PR DESCRIPTION
FieldCheckbox中使用fieldNames 后报 React does not recognize the `fieldNames` prop on a DOM element.