### PR TITLE
feat(table ): EditableProTable支持自定义渲染新建按钮

### DIFF
--- a/packages/table/src/components/EditableTable/index.en-US.md
+++ b/packages/table/src/components/EditableTable/index.en-US.md
@@ -34,6 +34,7 @@ EditableProTable is essentially the same as ProTable, with a few presets added t
 | `value` | Same as dataSource, pass in an array of metadata for table rendering | `T[]` | `undefined` |
 | `onChange` | The dataSource is triggered when the table is modified, both deletion and modification. | `(value:T[])=>void` | `undefined` |
 | `recordCreatorProps` | Configuration related to creating a new row of data | [RecordCreatorProps](#recordcreator) & [ButtonProps](https://ant.design/components/button/#API) | - |
+| `renderCreatorButton` | Custom render new button | `(originNode: React.ReactNode) => originNode` | `undefined` |
 | `maxLength` | The maximum number of rows, the New button will disappear when the maximum number of rows is reached | number | - |
 | `editable` | Related configuration of editable table | [TableRowEditable](#editable-edit-line-configuration) | - |
 | `controlled` | Whether controlled, if controlled every edit modifies the dataSource | `boolean` | false |
@@ -135,6 +136,8 @@ recordCreatorProps = {
   newRecordType: 'dataSource',
   // If not specified, it will use the index as the row ID
   record: {},
+  // Set button text
+  creatorButtonText: 'New line ',
   // Button style settings, you can control whether the button is displayed
   // This can be used to implement features like maximum and minimum row limits
   style: {
@@ -142,25 +145,6 @@ recordCreatorProps = {
   },
   // Button properties, see https://ant.design/components/button/#API
   ...antButtonProps,
-};
-```
-
-```typescript
-recordCreatorProps = {
-  // Add at the top or at the end
-  position: 'bottom',
-  // the way to add a new line, default is cached, will disappear when cancelled
-  // if set to dataSource it will trigger onchange, it won't disappear if cancelled, only deleted
-  newRecordType: 'dataSource',
-  // If you don't write key, index will be used as row id
-  record: {},
-  // the style of the button, you can set whether the button is displayed or not
-  // so that you can do things like max row limit and min row limit
-  style: {
-    display: 'none',
-  },
-  // https://ant.design/components/button/#API
-  ... .antButtonProps,
 };
 ```
 

--- a/packages/table/src/components/EditableTable/index.md
+++ b/packages/table/src/components/EditableTable/index.md
@@ -48,6 +48,7 @@ atomId: EditableProTable
 | `value` | 同 dataSource，传入一个数组，是 table 渲染的元数据 | `T[]` | `undefined` |
 | `onChange` | dataSource 修改时触发，删除和修改都会触发，如果设置了 value，Table 会成为一个受控组件。 | `(value:T[])=>void` | `undefined` |
 | `recordCreatorProps` | 新建一行数据的相关配置 | [RecordCreatorProps](#recordcreator) & [ButtonProps](https://ant.design/components/button-cn/#API) | - |
+| `renderCreatorButton` | 自定义渲染新建按钮 | `(originNode: React.ReactNode) => originNode` | `undefined` |
 | `maxLength` | 最大的行数，到达最大行数新建按钮会自动消失 | number | - |
 | `editable` | 可编辑表格的相关配置 | [TableRowEditable](#editable-编辑行配置) | - |
 | `controlled` | 是否受控，如果受控每次编辑都会触发 onChange，并且会修改 dataSource | `boolean` | false |


### PR DESCRIPTION
需求场景：默认的新建按钮在禁用时可加入 Tooltip 提示信息；原本已有的 API 无法满足这一诉求。


```typescript
<EditableProTable>
  recordCreatorProps={{
    record: () => ({}),
    disabled: true,
  }}
  renderCreatorButton={(originNode) => {
    return <Tooltip title="禁用时提示文本">{originNode}</Tooltip>;
  }}
/>
```

效果图

![image](https://github.com/user-attachments/assets/75a84099-7af2-4380-84f8-e6646d216cfa)



