### PR TITLE
feat(table): EditableProTable支持自定义渲染新建按钮

### DIFF
--- a/packages/table/src/components/EditableTable/index.en-US.md
+++ b/packages/table/src/components/EditableTable/index.en-US.md
@@ -135,6 +135,10 @@ recordCreatorProps = {
   newRecordType: 'dataSource',
   // If not specified, it will use the index as the row ID
   record: {},
+  // Set button text
+  creatorButtonText: 'New line ',
+  // Custom render
+  render: (originNode) => originNode,
   // Button style settings, you can control whether the button is displayed
   // This can be used to implement features like maximum and minimum row limits
   style: {

--- a/packages/table/src/components/EditableTable/index.en-US.md
+++ b/packages/table/src/components/EditableTable/index.en-US.md
@@ -145,25 +145,6 @@ recordCreatorProps = {
 };
 ```
 
-```typescript
-recordCreatorProps = {
-  // Add at the top or at the end
-  position: 'bottom',
-  // the way to add a new line, default is cached, will disappear when cancelled
-  // if set to dataSource it will trigger onchange, it won't disappear if cancelled, only deleted
-  newRecordType: 'dataSource',
-  // If you don't write key, index will be used as row id
-  record: {},
-  // the style of the button, you can set whether the button is displayed or not
-  // so that you can do things like max row limit and min row limit
-  style: {
-    display: 'none',
-  },
-  // https://ant.design/components/button/#API
-  ... .antButtonProps,
-};
-```
-
 ### renderFormItem Custom Edit Component
 
 As much as we would like the default valueType to meet all our needs, the reality is often not as good as it could be. So we also provide `renderFormItem` to customize the edit input component.

--- a/packages/table/src/components/EditableTable/index.md
+++ b/packages/table/src/components/EditableTable/index.md
@@ -153,6 +153,8 @@ recordCreatorProps = {
   record: {},
   // 设置按钮文案
   creatorButtonText: '新增一行',
+  // 自定义渲染
+  render: (originNode) => originNode,
   // 按钮的样式设置，可以设置按钮是否显示
   // 这样可以做最大行限制和最小行限制之类的功能
   style: {

--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -68,7 +68,7 @@ export type EditableFormInstance<T = any> = ProFormInstance<T> & {
   setRowData?: (rowIndex: string | number, data: Partial<T>) => void;
 };
 
-export type RecordCreatorProps<DataSourceType> = {
+export interface RecordCreatorProps<DataSourceType> extends ButtonProps {
   record:
     | DataSourceType
     | ((index: number, dataSource: DataSourceType[]) => DataSourceType);
@@ -84,7 +84,11 @@ export type RecordCreatorProps<DataSourceType> = {
   parentKey?:
     | React.Key
     | ((index: number, dataSource: DataSourceType[]) => React.Key);
-};
+  /** 设置按钮文案 */
+  creatorButtonText?: React.ReactNode;
+  /** 自定义渲染 */
+  render?: (originNode: JSX.Element) => JSX.Element;
+}
 
 export type EditableProTableProps<
   T,
@@ -103,12 +107,7 @@ export type EditableProTableProps<
   editableFormRef?: React.Ref<EditableFormInstance<T> | undefined>;
 
   /** @name 新建按钮的设置 */
-  recordCreatorProps?:
-    | (RecordCreatorProps<T> &
-        ButtonProps & {
-          creatorButtonText?: React.ReactNode;
-        })
-    | false;
+  recordCreatorProps?: RecordCreatorProps<T> | false;
   /** 最大行数 */
   maxLength?: number;
   /** Table 的值发生改变，为了适应 Form 调整了顺序 */
@@ -325,6 +324,7 @@ function EditableTable<
     newRecordType,
     parentKey,
     style,
+    render,
     ...restButtonProps
   } = recordCreatorProps || {};
   const isTop = position === 'top';
@@ -333,6 +333,24 @@ function EditableTable<
     if (typeof maxLength === 'number' && maxLength <= value?.length) {
       return false;
     }
+
+    const innerCreatorButton = (
+      <Button
+        type="dashed"
+        style={{
+          display: 'block',
+          margin: '10px 0',
+          width: '100%',
+          ...style,
+        }}
+        icon={<PlusOutlined />}
+        {...restButtonProps}
+      >
+        {creatorButtonText ||
+          intl.getMessage('editableTable.action.add', '添加一行数据')}
+      </Button>
+    );
+
     return (
       recordCreatorProps !== false && (
         <RecordCreator
@@ -341,20 +359,7 @@ function EditableTable<
           parentKey={runFunction(parentKey, value?.length, value)}
           newRecordType={newRecordType}
         >
-          <Button
-            type="dashed"
-            style={{
-              display: 'block',
-              margin: '10px 0',
-              width: '100%',
-              ...style,
-            }}
-            icon={<PlusOutlined />}
-            {...restButtonProps}
-          >
-            {creatorButtonText ||
-              intl.getMessage('editableTable.action.add', '添加一行数据')}
-          </Button>
+          {render?.(innerCreatorButton) ?? innerCreatorButton}
         </RecordCreator>
       )
     );


### PR DESCRIPTION
## 背景：

[[需求] EditableProTable 可编辑表格新建按钮在禁用时候可以加入提示文本](https://github.com/ant-design/pro-components/issues/8813)

---

### 效果图：

![bd021de6185ecdd364ecb027076f135](https://github.com/user-attachments/assets/cc3b88cf-66d6-46c1-95a8-55f56f227d86)


