### PR TITLE
docs: PageHeader 超链接更新

### DIFF
--- a/packages/layout/src/components/PageContainer/index.en-US.md
+++ b/packages/layout/src/components/PageContainer/index.en-US.md
@@ -64,7 +64,7 @@ We have added a footer attribute to make it easier to do things like forms, so y
 
 ## PageContainer
 
-PageContainer wraps ant design's PageHeader component, adding tabList and content. It relies on Layout's route property to fill in the title and breadcrumb based on the current route. Of course you can pass in parameters to override the default values. PageContainer supports all of [Tabs](https://ant.design/components/tabs/) and [PageHeader](https://ant.design/components/page-header/)'s attributes of [Tabs]() and [PageHeader]().
+PageContainer wraps ant design's PageHeader component, adding tabList and content. It relies on Layout's route property to fill in the title and breadcrumb based on the current route. Of course you can pass in parameters to override the default values. PageContainer supports all of [Tabs](https://ant.design/components/tabs/) and [PageHeader](https://procomponents.ant.design/en-US/components/page-header)'s attributes of [Tabs]() and [PageHeader]().
 
 | Parameters | Description | Type | Default |
 | --- | --- | --- | --- |
@@ -74,7 +74,7 @@ PageContainer wraps ant design's PageHeader component, adding tabList and conten
 | tabActiveKey | The currently highlighted tab item | string | - |
 | onTabChange | Callback for switching panels | `(key) => void` | - |
 | tabBarExtraContent | Extra element on tab bar | `React.ReactNode` | - |
-| header | All properties of [PageHeader](https://ant.design/components/page-header/). | `PageHeaderProps` | - |
+| header | All properties of [PageHeader](https://procomponents.ant.design/en-US/components/page-header). | `PageHeaderProps` | - |
 | fixedHeader | Fix the content of the pageHeader to the top, better not to use it if the page content is small, it will have serious obscuration problems | `boolean` | - |
 | affixProps | The configuration of the fixed pins, exactly the same as antd | `AffixProps` | - |
 | footer | Hover over the bottom action bar, pass in an array that will automatically add spaces | `ReactNode[]` | - |

--- a/packages/layout/src/components/PageContainer/index.md
+++ b/packages/layout/src/components/PageContainer/index.md
@@ -66,7 +66,7 @@ PageContainer 封装了 antd 的 PageHeader 组件，增加了 tabList 和 conte
 
 ## PageContainer
 
-PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和 content。 根据当前的路由填入 title 和 breadcrumb。它依赖 Layout 的 route 属性。当然你可以传入参数来覆写默认值。 PageContainer 支持 [Tabs](https://ant.design/components/tabs-cn/) 和 [PageHeader](https://4x.ant.design/components/page-header-cn/) 的所有属性。
+PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和 content。 根据当前的路由填入 title 和 breadcrumb。它依赖 Layout 的 route 属性。当然你可以传入参数来覆写默认值。 PageContainer 支持 [Tabs](https://ant.design/components/tabs-cn/) 和 [PageHeader](https://procomponents.ant.design/components/page-header) 的所有属性。
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
@@ -76,7 +76,7 @@ PageContainer 封装了 ant design 的 PageHeader 组件，增加了 tabList 和
 | tabActiveKey | 当前高亮的 tab 项 | string | - |
 | onTabChange | 切换面板的回调 | `(key) => void` | - |
 | tabBarExtraContent | tab bar 上额外的元素 | `React.ReactNode` | - |
-| header | [PageHeader](https://ant.design/components/page-header-cn/) 的所有属性 | `PageHeaderProps` | - |
+| header | [PageHeader](https://procomponents.ant.design/components/page-header) 的所有属性 | `PageHeaderProps` | - |
 | ghost | 配置头部区域的背景颜色为透明 | boolean | false |
 | fixedHeader | 固定 pageHeader 的内容到顶部，如果页面内容较少，最好不要使用，会有严重的遮挡问题 | `boolean` | - |
 | affixProps | 固钉的配置，与 antd 完全相同 | `AffixProps` | - |


### PR DESCRIPTION
antd v5 移除 PageHeader 组件，移至 @ant-design/pro-components 中维护，修正相关 PageHeader 文档超链接。