### PR TITLE
fix:(editableTable)点击保存后valueType未读取到导致convertMoment的日期格式错误

### DIFF
--- a/packages/form/src/BaseForm/BaseForm.tsx
+++ b/packages/form/src/BaseForm/BaseForm.tsx
@@ -317,7 +317,13 @@ function BaseFormComponents<T = Record<string, any>, U = Record<string, any>>(
         if (!nameList) throw new Error('nameList is require');
         const value = getFormInstance()?.getFieldValue(nameList!);
         const obj = nameList ? set({}, nameList as string[], value) : value;
-        return get(transformKey(obj, omitNil, nameList), nameList as string[]);
+        //transformKey会将keys重新和nameList拼接，所以这里要将nameList的首个元素弹出
+        const newNameList = [...nameList];
+        newNameList.shift();
+        return get(
+          transformKey(obj, omitNil, newNameList),
+          nameList as string[],
+        );
       },
       /**
        * 获取被 ProForm 格式化后的单个数据, 包含他的 name


### PR DESCRIPTION
官网第一个demo保存就是有问题的，created_at格式变成了默认的 dateTime
https://github.com/ant-design/pro-components/issues/8875