### PR TITLE
perf: add pro-componets path

### DIFF
--- a/packages/form/tsconfig.json
+++ b/packages/form/tsconfig.json
@@ -16,7 +16,8 @@
     "paths": {
       "@ant-design/pro-field": ["../../packages/field/src/index.tsx"],
       "@ant-design/pro-provider": ["../../packages/provider/src/index.tsx"],
-      "@ant-design/pro-utils": ["../../packages/utils/src/index.tsx"]
+      "@ant-design/pro-utils": ["../../packages/utils/src/index.tsx"],
+      "@ant-design/pro-components": ["../../packages/components/src/index.tsx"]
     }
   },
   "include": ["./src"]


### PR DESCRIPTION
https://github.com/cycleccc/pro-components/blob/943212b57bbaeb67bc76bf2dfac46db53ba8630f/packages/form/src/components/SchemaForm/demos/schema.tsx#L5

类似于以上代码的导入语句因为没有配置对应的 tsconfig 路径导致不方便 查找源文件及对应的 ts type。
补齐似乎更好。