### PR TITLE
perf: replace substr with splice

### DIFF
--- a/packages/utils/src/components/FieldLabel/index.tsx
+++ b/packages/utils/src/components/FieldLabel/index.tsx
@@ -157,7 +157,7 @@ const FieldLabelFunction: React.ForwardRefRenderFunction<
           {prefix}
           <span style={{ paddingInlineStart: 4, display: 'flex' }}>
             {typeof str === 'string'
-              ? str?.toString()?.substr?.(0, valueMaxLength)
+              ? str?.toString()?.slice?.(0, valueMaxLength)
               : str}
           </span>
           {tail}


### PR DESCRIPTION
substr api 未来会已弃用，可以替换为 splice

> https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/substr
![image](https://github.com/user-attachments/assets/06a3e6c7-17e0-4056-ae5f-709547d9a337)
