### PR TITLE
fix: add emptyText fieldItem props

### DIFF
--- a/packages/form/src/components/Switch/index.tsx
+++ b/packages/form/src/components/Switch/index.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import type { ProFormFieldItemProps } from '../../typing';
 import ProField from '../Field';
 
-export type ProFormSwitchProps = ProFormFieldItemProps<
-  SwitchProps,
-  HTMLElement
+export type ProFormSwitchProps = Omit<
+  ProFormFieldItemProps<SwitchProps, HTMLElement>,
+  'emptyText'
 > & {
   checkedChildren?: SwitchProps['checkedChildren'];
   unCheckedChildren?: SwitchProps['unCheckedChildren'];

--- a/packages/form/src/typing.ts
+++ b/packages/form/src/typing.ts
@@ -129,6 +129,10 @@ export type ProFormFieldItemProps<T = Record<string, any>, K = any> = {
    */
   secondary?: boolean;
   /**
+   * @name 只读模式渲染文本,没有值的时候展示
+   */
+  emptyText?: React.ReactNode;
+  /**
    * @name 是否使用 swr 来缓存 缓存可能导致数据更新不及时，请谨慎使用，尤其是页面中多个组件 name 相同
    *
    * @default false


### PR DESCRIPTION
1.  添加 fieldItem 公共属性 emptyText
2.  针对 form switch 屏蔽 emptyText 属性（没找到 form option 组件 ）
相关issue：https://github.com/ant-design/pro-components/issues/8848