### PR TITLE
chore(TS): fix TS type error

### DIFF
--- a/packages/form/src/components/Select/index.tsx
+++ b/packages/form/src/components/Select/index.tsx
@@ -1,7 +1,6 @@
 import { runFunction } from '@ant-design/pro-utils';
 import type { SelectProps } from 'antd';
-import type { BaseOptionType } from 'antd/lib/cascader';
-import type { RefSelectProps } from 'antd/lib/select';
+import type { BaseOptionType, DefaultOptionType, RefSelectProps } from 'antd/lib/select';
 import React, { useContext } from 'react';
 import FieldContext from '../../FieldContext';
 import type {
@@ -12,7 +11,7 @@ import ProFormField from '../Field';
 
 export type ProFormSelectProps<
   ValueType = any,
-  OptionType extends BaseOptionType = any,
+  OptionType extends BaseOptionType | DefaultOptionType = DefaultOptionType,
 > = ProFormFieldItemProps<
   SelectProps<ValueType, OptionType> & {
     /**


### PR DESCRIPTION
不确定要不要提升 antd 依赖， 如果 antd 版本比较低的话， 可能 ts 类型会导出失败？

看了一下，至少 5.6.1 就有导出这几个类型的 see：https://github.com/ant-design/ant-design/blob/5.6.1/components/select/index.tsx#L29

fix #8901