### PR TITLE
fix(field): add preserveOriginalLabel prop to SearchSelect

### DIFF
--- a/packages/field/src/components/Select/SearchSelect/index.tsx
+++ b/packages/field/src/components/Select/SearchSelect/index.tsx
@@ -89,6 +89,13 @@ export interface SearchSelectProps<T = Record<string, any>>
 
   /** 默认搜索关键词 */
   defaultSearchValue?: string;
+
+  /**
+   * 在选择时保留选项的原始标签文本
+   * 当设置为 true 时，选中后回填的内容将使用选项的原始 label，而不是经过 optionItemRender 处理后的内容
+   * @default false
+   */
+  preserveOriginalLabel?: boolean;
 }
 
 const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
@@ -115,6 +122,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     showSearch,
     fieldNames,
     defaultSearchValue,
+    preserveOriginalLabel = false,
     ...restProps
   } = props;
 
@@ -163,6 +171,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
         return {
           ...dataItem,
           ...item,
+          label: preserveOriginalLabel ? dataItem.label : item.label,
         };
       });
     }
@@ -284,9 +293,23 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
           const dataItem = optionList && optionList['data-item'];
           // 如果value值为空则是清空时产生的回调,直接传值就可以了
           if (!value || !dataItem) {
-            onChange?.(value, optionList, ...rest);
+            const changedValue = value
+              ? {
+                  ...value,
+                  label: preserveOriginalLabel ? dataItem?.label : value.label,
+                }
+              : value;
+            onChange?.(changedValue, optionList, ...rest);
           } else {
-            onChange?.({ ...value, ...dataItem }, optionList, ...rest);
+            onChange?.(
+              {
+                ...value,
+                ...dataItem,
+                label: preserveOriginalLabel ? dataItem.label : value.label,
+              },
+              optionList,
+              ...rest,
+            );
           }
           return;
         }

--- a/packages/field/src/components/Select/index.tsx
+++ b/packages/field/src/components/Select/index.tsx
@@ -528,6 +528,7 @@ const FieldSelect: ProFieldFC<
             fetchData(keyWord);
           }}
           resetData={resetData}
+          preserveOriginalLabel
           optionItemRender={(item) => {
             if (typeof item.label === 'string' && keyWordsRef.current) {
               return (


### PR DESCRIPTION
- Add preserveOriginalLabel prop to control whether to use the original label when option is selected
- Fix the issue where highlighted search text appears in the input box when option is selected

BREAKING CHANGE: None

close #8918 


出现问题的原因：

在多选且开启 labelInValue 的情况，onChange 的时候会使用 getMergeValue 来合并最终数据

https://github.com/ant-design/pro-components/blob/21ce755745c1b5fa26415cd1dcc1a8ac8ed2c159/packages/field/src/components/Select/SearchSelect/index.tsx#L155

代码如下：
```typescript
// 多选模式开启 labelInValue 的时候生成最终变化的值的函数
const getMergeValue: SelectProps<any>['onChange'] = (value, option) => {
    if (Array.isArray(value) && Array.isArray(option) && value.length > 0) {
      // 多选情况且用户有选择
      return value.map((item, index) => {
        const optionItem = (option as DefaultOptionType[])?.[
          index
        ] as DefaultOptionType;
        const dataItem = optionItem?.['data-item'] || {};
        return {
          ...dataItem,
          ...item,
        };
      });
    }
    return [];
  };
  
  
  // 生成实际渲染的 options 的代码
  const genOptions = (
    mapOptions: RequestOptionsType[],
  ): DefaultOptionType[] => {
    return mapOptions.map((item, index) => {
      const {
        className: itemClassName,
        optionType,
        ...resetItem
      } = item as RequestOptionsType;

      const label = item[labelPropsName];
      const value = item[valuePropsName];
      const itemOptions = item[optionsPropsName] ?? [];

      if (optionType === 'optGroup' || item.options) {
        return {
          label: label,
          ...resetItem,
          data_title: label,
          title: label,
          key: value ?? `${label?.toString()}-${index}-${nanoid()}`, // 防止因key相同导致虚拟滚动出问题
          children: genOptions(itemOptions),
        } as DefaultOptionType;
      }

      return {
        title: label,
        ...resetItem,
        data_title: label,
        value: value ?? index,
        key: value ?? `${label?.toString()}-${index}-${nanoid()}`,
        'data-item': item,
        className: `${prefixCls}-option ${itemClassName || ''}`.trim(),
        label: optionItemRender?.(item as any) || label,
      } as DefaultOptionType;
    });
  };
  ```
  
  渲染的下拉列表里的 label 是经过optionItemRender 处理过的用关键词匹配加上高亮的 ReactNode (https://github.com/ant-design/pro-components/blob/21ce755745c1b5fa26415cd1dcc1a8ac8ed2c159/packages/field/src/components/Select/index.tsx#L531)，
  这里 item 里的 label 会把 dataItem 的 label 覆盖掉，就导致最终填充到输入框的内容也是带高亮样式的
  
  这个 PR 的解决方法：
  添加了一个属性 preserveOriginalLabel, 开启这个属性后，在开启 labelInValue 的时候，触发 onChange 的时候的 value 里就用原始的 options 里的 label，关闭后就用经过 optionItemRender 处理过的实际展示出来的 label
  