### PR TITLE
fix(table): resolve EditableProTable Form.Item shouldUpdate conflict

### DIFF
--- a/packages/table/src/components/EditableTable/index.tsx
+++ b/packages/table/src/components/EditableTable/index.tsx
@@ -529,8 +529,6 @@ function FieldEditableTable<
       style={{
         maxWidth: '100%',
       }}
-      {...props?.formItemProps}
-      name={props.name}
       shouldUpdate={(prev, next) => {
         const name = [props.name].flat(1) as string[];
         try {
@@ -541,6 +539,8 @@ function FieldEditableTable<
           return true;
         }
       }}
+      {...props?.formItemProps}
+      name={props.name}
     >
       <EditableTable<DataType, Params, ValueType>
         tableLayout="fixed"


### PR DESCRIPTION
# 描述

修复 EditableProTable 的 Form.Item 中 shouldUpdate 与 dependencies 的冲突问题。

目前，当使用带有 `name` 属性的 EditableProTable 时，如果我们想在 `formItemProps` 中使用 `dependencies`，会出现以下警告：

```tsx
warning(
  !(shouldUpdate && dependencies),
  'usage',
  "`shouldUpdate` and `dependencies` shouldn't be used together. See https://u.ant.design/form-deps.",
);
```

这是因为 EditableProTable 内置的 `shouldUpdate` 逻辑与 `dependencies` 产生了冲突。

## 解决方案

将默认的 `shouldUpdate` 移到 `{...props?.formItemProps}` 前面，这样用户的配置就可以覆盖默认值：

```diff
return (
  <Form.Item
    style={{
      maxWidth: '100%',
    }}
+   shouldUpdate={(prev, next) => {
+     const name = [props.name].flat(1) as string[];
+     try {
+       return JSON.stringify(get(prev, name)) !== JSON.stringify(get(next, name));
+     } catch (error) {
+       return true;
+     }
+   }}
    {...props?.formItemProps}
    name={props.name}
-   shouldUpdate={(prev, next) => {
-     const name = [props.name].flat(1) as string[];
-     try {
-       return JSON.stringify(get(prev, name)) !== JSON.stringify(get(next, name));
-     } catch (error) {
-       return true;
-     }
-   }}
  >
    {/* ... */}
  </Form.Item>
);
```

修改后可以：
1. 通过设置 `shouldUpdate={undefined}` 来正常使用 `dependencies={[name, 'other field']}`
2. 如果需要，可以覆盖默认的 `shouldUpdate` 行为，自行实现 update
3. 使用 `dependencies` 时不会再有警告

## 使用示例

```tsx
<EditableProTable
  name="table"
  formItemProps={{
    dependencies: ['table', 'other'],
    shouldUpdate: undefined,  // 避免警告
  }}
/>
```