### PR TITLE
chore(TS): fix TS compilation type errors

### DIFF
--- a/packages/layout/tsconfig.json
+++ b/packages/layout/tsconfig.json
@@ -13,6 +13,8 @@
     "declaration": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "resolvePackageJsonExports": false,
+    "resolvePackageJsonImports": false,
     "paths": {
       "@ant-design/pro-provider": ["../../packages/provider/src/index.tsx"],
       "@ant-design/pro-components": ["../../packages/components/src/index.tsx"],


### PR DESCRIPTION
# 问题
更新最新的pro-components后发现ProForm的index.d.ts文件有部分类型引入错误

<img width="774" alt="image" src="https://github.com/user-attachments/assets/3552be34-3755-4b8e-a780-79308df0840d" />

经过版本对比，typescript@v.5.7版本会把 "../.." 重写为 “src”

# 目前解决方案

添加了resolvePackageJsonExports和resolvePackageJsonImports选项避免typescript@v5.7把某些import路径编译为src路径下

