### PR TITLE
fix: updated translations in cs_CZ locale

### DIFF
--- a/packages/provider/src/locale/cs_CZ.tsx
+++ b/packages/provider/src/locale/cs_CZ.tsx
@@ -11,7 +11,7 @@ export default {
     },
   },
   tableForm: {
-    search: 'Dotaz',
+    search: 'Hledat',
     reset: 'Resetovat',
     submit: 'Odeslat',
     collapsed: 'Zvětšit',
@@ -21,7 +21,7 @@ export default {
   },
   alert: {
     clear: 'Vymazat',
-    selected: 'Vybraný',
+    selected: 'Vybráno',
     item: 'Položka',
   },
   pagination: {
@@ -37,12 +37,12 @@ export default {
     noPin: 'Odepnuto',
     leftFixedTitle: 'Fixováno nalevo',
     rightFixedTitle: 'Fixováno napravo',
-    noFixedTitle: 'Neopraveno',
+    noFixedTitle: 'Nefixováno',
     reset: 'Resetovat',
     columnDisplay: 'Zobrazení sloupců',
     columnSetting: 'Nastavení',
     fullScreen: 'Celá obrazovka',
-    exitFullScreen: 'Ukončete celou obrazovku',
+    exitFullScreen: 'Ukončit celou obrazovku',
     reload: 'Obnovit',
     density: 'Hustota',
     densityDefault: 'Výchozí',
@@ -64,11 +64,11 @@ export default {
       save: 'Uložit',
       cancel: 'Zrušit',
       delete: 'Vymazat',
-      add: 'přidat řádek dat',
+      add: 'Přidat řádek',
     },
   },
   switch: {
-    open: 'otevřít',
-    close: 'zavřít',
+    open: 'Otevřít',
+    close: 'Zavřít',
   },
 };


### PR DESCRIPTION
Several translation strings in the cs_CZ locale have been updated for clarity and consistency. Changes include modifying verb forms, capitalizing initial letters, and refining certain phrases to better match common usage.

issue #9047 