### PR TITLE
fix(QueryFilter): 修复使用QueryFilter时报findDOMNode is deprecated的问题。

### DIFF
--- a/packages/form/src/layouts/QueryFilter/index.tsx
+++ b/packages/form/src/layouts/QueryFilter/index.tsx
@@ -583,50 +583,52 @@ function QueryFilter<T = Record<string, any>>(props: QueryFilterProps<T>) {
         }
       }}
     >
-      <BaseForm
-        isKeyPressSubmit
-        preserve={preserve}
-        {...rest}
-        className={classNames(baseClassName, hashId, rest.className)}
-        onReset={onReset}
-        style={style}
-        layout={spanSize.layout}
-        fieldProps={{
-          style: {
-            width: '100%',
-          },
-        }}
-        formItemProps={formItemFixStyle}
-        groupProps={{
-          titleStyle: {
-            display: 'inline-block',
-            marginInlineEnd: 16,
-          },
-        }}
-        contentRender={(items, renderSubmitter, form) => (
-          <QueryFilterContent
-            spanSize={spanSize}
-            collapsed={controlCollapsed}
-            form={form}
-            submitterColSpanProps={submitterColSpanProps}
-            collapseRender={collapseRender}
-            defaultCollapsed={defaultCollapsed}
-            onCollapse={onCollapse}
-            optionRender={optionRender}
-            submitter={renderSubmitter}
-            items={items}
-            split={split}
-            baseClassName={baseClassName}
-            resetText={props.resetText}
-            searchText={props.searchText}
-            searchGutter={searchGutter}
-            preserve={preserve}
-            ignoreRules={ignoreRules}
-            showLength={showLength}
-            showHiddenNum={showHiddenNum}
-          />
-        )}
-      />
+      <div className={`${baseClassName}-container ${hashId}`}>
+        <BaseForm
+          isKeyPressSubmit
+          preserve={preserve}
+          {...rest}
+          className={classNames(baseClassName, hashId, rest.className)}
+          onReset={onReset}
+          style={style}
+          layout={spanSize.layout}
+          fieldProps={{
+            style: {
+              width: '100%',
+            },
+          }}
+          formItemProps={formItemFixStyle}
+          groupProps={{
+            titleStyle: {
+              display: 'inline-block',
+              marginInlineEnd: 16,
+            },
+          }}
+          contentRender={(items, renderSubmitter, form) => (
+            <QueryFilterContent
+              spanSize={spanSize}
+              collapsed={controlCollapsed}
+              form={form}
+              submitterColSpanProps={submitterColSpanProps}
+              collapseRender={collapseRender}
+              defaultCollapsed={defaultCollapsed}
+              onCollapse={onCollapse}
+              optionRender={optionRender}
+              submitter={renderSubmitter}
+              items={items}
+              split={split}
+              baseClassName={baseClassName}
+              resetText={props.resetText}
+              searchText={props.searchText}
+              searchGutter={searchGutter}
+              preserve={preserve}
+              ignoreRules={ignoreRules}
+              showLength={showLength}
+              showHiddenNum={showHiddenNum}
+            />
+          )}
+        />
+      </div>
     </RcResizeObserver>,
   );
 }


### PR DESCRIPTION
修复本地开发时，react版本为18.3.* 时，使用到QueryFilter会导致页面报错问题。
报错信息：
```
Warning: findDOMNode is deprecated and will be removed in the next major release. Instead, add a ref directly to the element you want to reference
```
<img width="1649" alt="image" src="https://github.com/user-attachments/assets/0330b197-ad25-4083-a40a-64f60ae75099" />
