### PR TITLE
chore(doc): 补充 EditableProTable 文档

### DIFF
--- a/packages/table/src/components/EditableTable/demos/basic.tsx
+++ b/packages/table/src/components/EditableTable/demos/basic.tsx
@@ -156,6 +156,7 @@ export default () => {
             ? {
                 position: position as 'top',
                 record: () => ({ id: (Math.random() * 1000000).toFixed(0) }),
+                newRecordType:"dataSource",
               }
             : false
         }


### PR DESCRIPTION
close: https://github.com/ant-design/pro-components/issues/9063

使文档第一个 demo 的 type:multiple 配置能够新增多行