### PR TITLE
fix:修复 EditableProTable 编辑状态取消导致数据被删除问题

### DIFF
--- a/packages/table/src/components/EditableTable/demos/basic.tsx
+++ b/packages/table/src/components/EditableTable/demos/basic.tsx
@@ -190,7 +190,20 @@ export default () => {
           success: true,
         })}
         value={dataSource}
-        onChange={setDataSource}
+        onChange={(value) => {
+          setDataSource((data) => {
+            const newMap = new Map(value.map((item) => [item.id, item]));
+            const merged = data.map((item) => {
+              return newMap.get(item.id) || item;
+            });
+            value.forEach((item) => {
+              if (!data.find((old) => old.id === item.id)) {
+                merged.push(item);
+              }
+            });
+            return merged;
+          });
+        }}
         editable={{
           type: 'multiple',
           editableKeys,


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [✅] 🐛 解决 bug

### 🔗 相关 Issue

修复 EditableProTable 中，取消编辑状态会错误触发 onChange 导致数据被清除的问题。

### 💡 需求背景和解决方案

点击“取消编辑”时，不应该触发 onChange 更新 dataSource，否则会造成数据丢失。

本 PR 使用基于 key 的数据合并策略，确保取消编辑不会触发误更新，同时保持 dataSource 顺序一致。

### 📝 更新日志

修复 EditableProTable 在 multiple 模式下，取消编辑状态会误触发 onChange 导致数据丢失的问题。
