### PR TITLE
fix(LightFilter):DatePicker resets to its initial state after data is cleared.

### DIFF
--- a/packages/field/src/components/RangePicker/index.tsx
+++ b/packages/field/src/components/RangePicker/index.tsx
@@ -89,8 +89,14 @@ const FieldRangePicker: ProFieldFC<
 
   if (mode === 'edit' || mode === 'update') {
     const dayValue = parseValueToDay(fieldProps.value) as dayjs.Dayjs[];
-    let dom;
+    let dom; 
+    const handleRangeChange = (value: any) => {
+      fieldProps?.onChange?.(value);
 
+      if (!value) {
+        setOpen(false);
+      }
+    };  
     if (light) {
       dom = (
         <FieldLabel
@@ -121,15 +127,16 @@ const FieldRangePicker: ProFieldFC<
                     intl.getMessage('tableForm.selectPlaceholder', '请选择'),
                   ]
                 }
-                onClear={() => {
-                  setOpen(false);
-                  fieldProps?.onClear?.();
-                }}
+                // onClear={() => {
+                //   setOpen(false);
+                //   fieldProps?.onClear?.();
+                // }}
                 value={dayValue}
                 onOpenChange={(isOpen) => {
                   if (dayValue) setOpen(isOpen);
                   fieldProps?.onOpenChange?.(isOpen);
                 }}
+                onChange={handleRangeChange}
               />
             ) : null
           }


### PR DESCRIPTION
### 🐛 Bug Fix
Fix issue [9105](https://github.com/ant-design/pro-components/issues/9105)

DatePicker 组件貌似没有提供 onClear 方法