### PR TITLE
fix :increase the parame of the actions function to maintain consistency.

### DIFF
--- a/packages/form/src/components/List/ListItem.tsx
+++ b/packages/form/src/components/List/ListItem.tsx
@@ -402,7 +402,7 @@ const ProFormListItem: React.FC<
                   .filter((item) => item !== undefined)
                   .flat(1),
               );
-              await action.add(row);
+              await action.add(row, count - 1);
               setLoadingCopy(false);
             }}
           />

--- a/packages/form/src/components/List/ListItem.tsx
+++ b/packages/form/src/components/List/ListItem.tsx
@@ -402,7 +402,7 @@ const ProFormListItem: React.FC<
                   .filter((item) => item !== undefined)
                   .flat(1),
               );
-              await action.add(row, count - 1);
+              await action.add(row, count);
               setLoadingCopy(false);
             }}
           />

--- a/tests/form/formList.test.tsx
+++ b/tests/form/formList.test.tsx
@@ -956,9 +956,9 @@ describe('ProForm List', () => {
             Icon: CloseOutlined,
           }}
           actionGuard={{
-            beforeAddRow: async (defaultValue, insertIndex) => {
+            beforeAddRow: async (defaultValue, insertIndex, count) => {
               return new Promise((resolve) => {
-                fnAdd(defaultValue?.name, insertIndex);
+                fnAdd(defaultValue?.name, insertIndex, count);
                 setTimeout(() => resolve(true), 1000);
               });
             },
@@ -994,7 +994,7 @@ describe('ProForm List', () => {
       (await html.findByText('添加一行数据')).parentElement?.click();
     });
 
-    expect(fnAdd).toHaveBeenLastCalledWith(undefined, 1);
+    expect(fnAdd).toHaveBeenLastCalledWith(undefined, 1, 1);
     expect(html.baseElement.querySelectorAll('input.ant-input').length).toBe(1);
     await waitForWaitTime(1200);
 
@@ -1007,7 +1007,7 @@ describe('ProForm List', () => {
         ?.click?.();
     });
 
-    expect(fnAdd).toHaveBeenLastCalledWith('1111', 2);
+    expect(fnAdd).toHaveBeenLastCalledWith('1111', 2, 2);
 
     await waitForWaitTime(1200);
 


### PR DESCRIPTION
increase the parame of the actions function to maintain consistency 
让onAfterAdd函数的入参保持一致性，既然复制一行总是会在最后一行添加，也把这个参数透出.

修复此issue的bug：[BUG] ProFormList的onAfterAdd回调函数参数异常 fix：#9102