### PR TITLE
feat(ProFiled): custom valuetypemap should not cull any props

### DIFF
--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -663,6 +663,7 @@ const ProFieldComponent: React.ForwardRefRenderFunction<
             ? undefined
             : (rest?.placeholder ?? fieldProps?.placeholder),
         }),
+        Object.keys(context.valueTypeMap || {})?.includes(valueType as string),
       ),
     }),
     context.valueTypeMap || {},

--- a/packages/utils/src/pickProProps/index.tsx
+++ b/packages/utils/src/pickProProps/index.tsx
@@ -2,12 +2,16 @@ const proFieldProps = `valueType request plain renderFormItem render text formIt
 
 const proFormProps = `fieldProps isDefaultDom groupProps contentRender submitterProps submitter`;
 
-export function pickProProps(props: Record<string, any>) {
+export function pickProProps(
+  props: Record<string, any>,
+  customValueType = false,
+) {
   const propList = `${proFieldProps} ${proFormProps}`.split(/[\s\n]+/);
 
   const attrs = {} as Record<string, any>;
   Object.keys(props || {}).forEach((key) => {
-    if (propList.includes(key)) {
+    //如果是自定义的 valueType，则不需要过滤掉，全部传给使用者
+    if (propList.includes(key) && !customValueType) {
       return;
     }
     attrs[key] = props[key];


### PR DESCRIPTION
https://github.com/ant-design/pro-components/issues/9148
自定义的valueTypeMap不应该走ProList的props剔除逻辑，应该全部放开给开发者


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 当使用自定义 valueType 时，属性过滤逻辑已优化，支持更多字段属性透传，增强了字段组件的灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->