### PR TITLE
fix(table):Dragging the table causes the page to scroll wirelessly.

### DIFF
--- a/packages/table/src/utils/useDragSort.tsx
+++ b/packages/table/src/utils/useDragSort.tsx
@@ -36,7 +36,6 @@ const SortableRow = (props: any) => {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    border:'1px solid red',
     ...props?.style,
   };
   const { DragHandle, dragSortKey, ...rest } = props;

--- a/packages/table/src/utils/useDragSort.tsx
+++ b/packages/table/src/utils/useDragSort.tsx
@@ -1,7 +1,7 @@
 import { useRefFunction } from '@ant-design/pro-utils';
 import type { DragEndEvent } from '@dnd-kit/core';
 import {
-  closestCenter,
+  rectIntersection,
   DndContext,
   MouseSensor,
   PointerSensor,
@@ -33,10 +33,10 @@ const SortableItemContextValue = createContext<{
 const SortableRow = (props: any) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id: props.id });
-
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    border:'1px solid red',
     ...props?.style,
   };
   const { DragHandle, dragSortKey, ...rest } = props;
@@ -193,7 +193,7 @@ export function useDragSort<T>(props: UseDragSortOptions<T>) {
         <DndContext
           modifiers={[restrictToVerticalAxis]}
           sensors={sensors}
-          collisionDetection={closestCenter}
+          collisionDetection={rectIntersection}
           onDragEnd={handleDragEnd}
         >
           {contextProps.children}


### PR DESCRIPTION
### 🐛 Bug Fix
fix issue https://github.com/ant-design/pro-components/issues/8583
使用默认的 rectIntersection 矩形交集不会触发该问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化**
  * 拖拽排序时，更新了碰撞检测策略，提升了拖拽体验。
* **样式**
  * 移除了多余的空行，代码更简洁。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->