### PR TITLE
fix(ProFormDependency): fix merge function bug

### DIFF
--- a/packages/form/src/components/Dependency/index.tsx
+++ b/packages/form/src/components/Dependency/index.tsx
@@ -1,9 +1,9 @@
-import { isDeepEqualReact, merge, ProFormContext } from '@ant-design/pro-utils';
+import { isDeepEqualReact, ProFormContext } from '@ant-design/pro-utils';
 import type { FormItemProps } from 'antd';
 import { Form } from 'antd';
 import type { NamePath } from 'antd/lib/form/interface';
 import get from 'rc-util/lib/utils/get';
-import set from 'rc-util/lib/utils/set';
+import set, { merge } from 'rc-util/lib/utils/set';
 import { useContext, useMemo } from 'react';
 import type { ProFormInstance } from '../../BaseForm';
 import { FormListContext } from '../List';


### PR DESCRIPTION
Fix accidental override of merge function，I don't think there should be overlay scenarios in form item merges.The local merge used by the project produces overwriting behavior. I observed that it was code that existed three years ago. I'm not sure if other places using this method are intentional. If not, I think the local method implementation should be removed and the rc-util method should be used
#9119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项**
  * 更新了依赖库的导入方式，不影响现有功能或用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->