### PR TITLE
fix(descriptions): add style

### DIFF
--- a/demos/descriptions/editable.tsx
+++ b/demos/descriptions/editable.tsx
@@ -22,6 +22,7 @@ export default () => {
             money: '1212100',
             state: 'all',
             state2: 'open',
+            textarea: '这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域',
           },
         });
       }}
@@ -49,6 +50,17 @@ export default () => {
             closed: {
               text: '已解决',
               status: 'Success',
+            },
+          },
+        },
+        {
+          title: '文本域',
+          key: 'textarea',
+          dataIndex: 'textarea',
+          valueType: 'textarea',
+          formItemProps: {
+            style: {
+             flex: 1,
             },
           },
         },

--- a/src/descriptions/index.tsx
+++ b/src/descriptions/index.tsx
@@ -305,6 +305,7 @@ export const FieldRender: React.FC<
         marginBottom: -5,
         marginLeft: 0,
         marginRight: 0,
+        width: '100%',
       }}
     >
       {renderDom()}

--- a/tests/descriptions/__snapshots__/editor.test.tsx.snap
+++ b/tests/descriptions/__snapshots__/editor.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Descriptions > 📝 columns support editable test 1`] = `
                   style="min-width: 0;"
                 >
                   <div
-                    style="margin: -5px 0px;"
+                    style="margin: -5px 0px; width: 100%;"
                   >
                     <div
                       style="display: flex; gap: 8px; align-items: baseline;"
@@ -191,7 +191,7 @@ exports[`Descriptions > 📝 formItemRender run defaultRender 1`] = `
                   style="min-width: 0;"
                 >
                   <div
-                    style="margin: -5px 0px;"
+                    style="margin: -5px 0px; width: 100%;"
                   >
                     <div
                       style="display: flex; gap: 8px; align-items: baseline;"

--- a/tests/descriptions/snapshot/snapshot-demos-descriptions-editable.html
+++ b/tests/descriptions/snapshot/snapshot-demos-descriptions-editable.html
@@ -190,6 +190,66 @@
                   <span
                     class="ant-descriptions-item-label"
                   >
+                    文本域
+                  </span>
+                  <span
+                    class="ant-descriptions-item-content"
+                    style="min-width: 0;"
+                  >
+                    <div
+                      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                    >
+                      <div
+                        class="ant-space-item"
+                      >
+                        <span
+                          class="ant-pro-field-readonly ant-pro-field-readonly-textarea"
+                        >
+                          这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域
+                        </span>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                      >
+                        <span
+                          aria-label="edit"
+                          class="anticon anticon-edit"
+                          role="img"
+                          tabindex="-1"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="edit"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="ant-descriptions-row"
+            >
+              <td
+                class="ant-descriptions-item"
+                colspan="1"
+              >
+                <div
+                  class="ant-descriptions-item-container"
+                >
+                  <span
+                    class="ant-descriptions-item-label"
+                  >
                     状态2
                   </span>
                   <span

--- a/tests/layout/__snapshots__/mobile.test.tsx.snap
+++ b/tests/layout/__snapshots__/mobile.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`mobile BasicLayout > 📱 layout=mix 1`] = `
         tabindex="-1"
       >
         <div
-          class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-start ant-drawer-mask-motion"
+          class="ant-drawer-mask ant-drawer-mask-motion-appear ant-drawer-mask-motion-appear-active ant-drawer-mask-motion"
         />
         <div
           aria-hidden="true"
@@ -416,7 +416,7 @@ exports[`mobile BasicLayout > 📱 layout=mix 1`] = `
           tabindex="0"
         />
         <div
-          class="ant-drawer-content-wrapper ant-drawer-panel-motion-left-appear ant-drawer-panel-motion-left-appear-start ant-drawer-panel-motion-left"
+          class="ant-drawer-content-wrapper ant-drawer-panel-motion-left-appear ant-drawer-panel-motion-left-appear-active ant-drawer-panel-motion-left"
           style="width: 215px;"
         >
           <div
@@ -447,13 +447,15 @@ exports[`mobile BasicLayout > 📱 layout=mix 1`] = `
                       tabindex="0"
                     >
                       <li
-                        class="ant-menu-submenu ant-menu-submenu-inline ant-pro-base-menu-inline-submenu ant-menu-submenu-open"
+                        class="ant-menu-submenu ant-menu-submenu-inline ant-pro-base-menu-inline-submenu ant-menu-submenu-open ant-menu-submenu-selected"
                         role="none"
                       >
                         <div
+                          aria-controls="rc-menu-uuid-84044-2-/564f79ec010d02670f2cd38274f84017d6ddf17759857629a1399aed6bb20925-popup"
                           aria-expanded="true"
                           aria-haspopup="true"
                           class="ant-menu-submenu-title"
+                          data-menu-id="rc-menu-uuid-84044-2-/564f79ec010d02670f2cd38274f84017d6ddf17759857629a1399aed6bb20925"
                           role="menuitem"
                           style="padding-left: 16px;"
                           tabindex="-1"
@@ -478,6 +480,7 @@ exports[`mobile BasicLayout > 📱 layout=mix 1`] = `
                         <ul
                           class="ant-menu ant-menu-sub ant-menu-inline"
                           data-menu-list="true"
+                          id="rc-menu-uuid-84044-2-/564f79ec010d02670f2cd38274f84017d6ddf17759857629a1399aed6bb20925-popup"
                           role="menu"
                         >
                           <li
@@ -485,9 +488,11 @@ exports[`mobile BasicLayout > 📱 layout=mix 1`] = `
                             role="none"
                           >
                             <div
+                              aria-controls="rc-menu-uuid-84044-2-/welcome-popup"
                               aria-expanded="false"
                               aria-haspopup="true"
                               class="ant-menu-submenu-title"
+                              data-menu-id="rc-menu-uuid-84044-2-/welcome"
                               role="menuitem"
                               style="padding-left: 32px;"
                               tabindex="-1"

--- a/tests/snapshot/snapshot-demos-descriptions-editable.html
+++ b/tests/snapshot/snapshot-demos-descriptions-editable.html
@@ -190,6 +190,66 @@
                   <span
                     class="ant-descriptions-item-label"
                   >
+                    文本域
+                  </span>
+                  <span
+                    class="ant-descriptions-item-content"
+                    style="min-width: 0;"
+                  >
+                    <div
+                      class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+                    >
+                      <div
+                        class="ant-space-item"
+                      >
+                        <span
+                          class="ant-pro-field-readonly ant-pro-field-readonly-textarea"
+                        >
+                          这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域-这是一个文本域
+                        </span>
+                      </div>
+                      <div
+                        class="ant-space-item"
+                      >
+                        <span
+                          aria-label="edit"
+                          class="anticon anticon-edit"
+                          role="img"
+                          tabindex="-1"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            data-icon="edit"
+                            fill="currentColor"
+                            focusable="false"
+                            height="1em"
+                            viewBox="64 64 896 896"
+                            width="1em"
+                          >
+                            <path
+                              d="M257.7 752c2 0 4-.2 6-.5L431.9 722c2-.4 3.9-1.3 5.3-2.8l423.9-423.9a9.96 9.96 0 000-14.1L694.9 114.9c-1.9-1.9-4.4-2.9-7.1-2.9s-5.2 1-7.1 2.9L256.8 538.8c-1.5 1.5-2.4 3.3-2.8 5.3l-29.5 168.2a33.5 33.5 0 009.4 29.8c6.6 6.4 14.9 9.9 23.8 9.9zm67.4-174.4L687.8 215l73.3 73.3-362.7 362.6-88.9 15.7 15.6-89zM880 836H144c-17.7 0-32 14.3-32 32v36c0 4.4 3.6 8 8 8h784c4.4 0 8-3.6 8-8v-36c0-17.7-14.3-32-32-32z"
+                            />
+                          </svg>
+                        </span>
+                      </div>
+                    </div>
+                  </span>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="ant-descriptions-row"
+            >
+              <td
+                class="ant-descriptions-item"
+                colspan="1"
+              >
+                <div
+                  class="ant-descriptions-item-container"
+                >
+                  <span
+                    class="ant-descriptions-item-label"
+                  >
                     状态2
                   </span>
                   <span


### PR DESCRIPTION
#9208 descriptions item把包裹容器宽度设置width:100%,解决textarea无法撑满span的问题,每个valuetype本地测试了下没发现异常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在描述视图中新增了“文本域”可编辑字段，支持长文本的显示与编辑。

* **样式**
  * 优化了可编辑字段容器的宽度，使其自适应占满可用空间。

* **测试**
  * 更新了快照测试，覆盖新增的“文本域”可编辑行，确保显示与交互一致。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->