### PR TITLE
解决 #9225 问题：取消嵌套列的全选后，选中子列，表格不渲染

### DIFF
--- a/demos/table/pollinga.tsx
+++ b/demos/table/pollinga.tsx
@@ -73,16 +73,22 @@ const columns: ProColumns<TableListItem>[] = [
     }),
   },
   {
-    title: '更新时间',
-    key: 'since2',
+    title: '时间',
+    key: 'since',
     dataIndex: 'createdAt',
     valueType: 'date',
-  },
-  {
-    title: '创建时间',
-    key: 'since3',
-    dataIndex: 'createdAt',
-    valueType: 'dateMonth',
+    children: [
+      {
+        title: '创建时间',
+        dataIndex: 'createdAt',
+        valueType: 'date',
+      },
+      {
+        title: '更新时间',
+        dataIndex: 'updatedAt',
+        valueType: 'date',
+      },
+    ],
   },
 ];
 

--- a/src/table/components/ColumnSetting/index.tsx
+++ b/src/table/components/ColumnSetting/index.tsx
@@ -139,7 +139,10 @@ const CheckboxList: React.FC<{
   const treeDataConfig = useMemo(() => {
     if (!show) return {};
     const checkedKeys: string[] = [];
-    const treeMap = new Map<string | number, DataNode>();
+    const treeMap = new Map<
+      string | number,
+      DataNode & { parentKey?: string }
+    >();
 
     const loopData = (
       data: any[],
@@ -183,7 +186,7 @@ const CheckboxList: React.FC<{
             checkedKeys.push(columnKey);
           }
         }
-        treeMap.set(key, item);
+        treeMap.set(key, { ...item, parentKey: parentConfig?.columnKey });
         return item;
       });
     return { list: loopData(list), keys: checkedKeys, map: treeMap };
@@ -235,6 +238,13 @@ const CheckboxList: React.FC<{
           .get(key)
           ?.children?.forEach((item) => loopSetShow(item.key as string));
       }
+
+      // 如果子节点选择，那父节点也应该选中
+      const parentKey = treeDataConfig.map?.get(key)?.parentKey;
+      if (parentKey) {
+        newColumnMap[parentKey] = { ...newColumnMap[parentKey], show: true };
+      }
+
       newColumnMap[key] = newSetting;
     };
     loopSetShow(e.node.key);


### PR DESCRIPTION
#9225
bug：修复如果取消列“时间”的选择状态后，点击子列后，表格不会渲染
<img width="849" height="390" alt="image" src="https://github.com/user-attachments/assets/9aac9674-0bb7-457e-a56f-1978c30b0fae" />

解决：
<img width="801" height="330" alt="image" src="https://github.com/user-attachments/assets/42b47b09-2649-4645-8a5d-50acb96a24a1" />
