### PR TITLE
fix: Cascading selectors require like selector behavior

### DIFF
--- a/src/field/ValueTypeToComponent.tsx
+++ b/src/field/ValueTypeToComponent.tsx
@@ -564,6 +564,7 @@ const ValueTypeToComponentMap: Record<string, ProRenderFieldPropsType> = {
         typeof props.placeholder === 'string' ? props.placeholder : undefined;
       return (
         <FieldCascader
+          {...props}
           mode={props.mode}
           text={text}
           placeholder={placeholder}
@@ -577,6 +578,7 @@ const ValueTypeToComponentMap: Record<string, ProRenderFieldPropsType> = {
         typeof props.placeholder === 'string' ? props.placeholder : undefined;
       return (
         <FieldCascader
+          {...props}
           mode={props.mode}
           text={text}
           placeholder={placeholder}


### PR DESCRIPTION
#9224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 修复级联选择器未完整接收传入属性的问题，现会转发全部外部属性，解决部分自定义配置不生效的情况，提升在表单与展示场景中的兼容性。
  - 仍保持显式配置（模式、文本、占位符、字段属性）优先生效，确保现有用法与行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->