### PR TITLE
fix(formItem):修复formItem中的help属性失效的问题

### DIFF
--- a/src/form/components/FormItem/index.tsx
+++ b/src/form/components/FormItem/index.tsx
@@ -197,35 +197,9 @@ const WarpFormItem: React.FC<
       return (
         <Form.Item
           {...props}
-          //help={typeof help !== 'function' ? help : undefined}
+          help={typeof help !== 'function' ? help : undefined}
           valuePropName={valuePropName}
           getValueProps={getValuePropsFunc}
-          // @ts-ignore
-          // _internalItemRender={{
-          //   mark: 'pro_table_render',
-          //   render: (
-          //     inputProps: FormItemProps & {
-          //       errors: React.ReactNode[];
-          //       warnings: React.ReactNode[];
-          //     },
-          //     doms: {
-          //       input: JSX.Element;
-          //       errorList: JSX.Element;
-          //       extra: JSX.Element;
-          //     },
-          //   ) => (
-          //     <>
-          //       {doms.input}
-          //       {typeof help === 'function'
-          //         ? help({
-          //             errors: inputProps.errors,
-          //             warnings: inputProps.warnings,
-          //           })
-          //         : doms.errorList}
-          //       {doms.extra}
-          //     </>
-          //   ),
-          // }}
         >
           {children}
         </Form.Item>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新增修复
  - 未使用前后缀的表单项中，help 文案现可正常显示，避免误触发函数式渲染导致的缺失或异常。

- 重构
  - 简化无前后缀场景的渲染逻辑，改用默认渲染；保留含前后缀场景的增强渲染与函数式 help 行为，提升一致性与可维护性。

- 杂务
  - 无公开 API 变更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->