### PR TITLE
fix: 移除  Statistic content value int 的字体大小样式。

### DIFF
--- a/src/card/components/Statistic/style.ts
+++ b/src/card/components/Statistic/style.ts
@@ -37,11 +37,6 @@ const genProStyle: GenerateStyle<ProListToken> = (token) => {
       },
       '&-content': {
         width: '100%',
-        [`${token.antCls}-statistic-content`]: {
-          '&-value-int': {
-            fontSize: token.fontSizeHeading3,
-          },
-        },
       },
       '&-description': {
         width: '100%',


### PR DESCRIPTION
因为这样设置了默认样式后，再通过 valueStyle 则无法进行修改。

<img width="1268" height="226" alt="image" src="https://github.com/user-attachments/assets/58cbecec-a81b-4a7d-b62c-857e7ce8fbd4" />
<img width="718" height="1014" alt="image" src="https://github.com/user-attachments/assets/c92a82fc-1e23-4765-971a-480ffab6c6c2" />
