### PR TITLE
fix(ProForm): stable defaultExtraUrlParams

### DIFF
--- a/src/form/BaseForm/BaseForm.tsx
+++ b/src/form/BaseForm/BaseForm.tsx
@@ -242,6 +242,8 @@ const covertFormName = (name?: NamePath) => {
   return [name];
 };
 
+const defaultExtraUrlParams = {} as Record<string, any>
+
 function BaseFormComponents<T = Record<string, any>, U = Record<string, any>>(
   props: BaseFormProps<T, U> & {
     loading: boolean;
@@ -262,7 +264,7 @@ function BaseFormComponents<T = Record<string, any>, U = Record<string, any>>(
     form,
     loading,
     formComponentType,
-    extraUrlParams = {} as Record<string, any>,
+    extraUrlParams = defaultExtraUrlParams,
     syncToUrl,
     onUrlSearchChange,
     onReset,


### PR DESCRIPTION
<img width="685" height="534" alt="image" src="https://github.com/user-attachments/assets/ce59ac8f-7970-4b74-93e8-1bb3f8fd5d79" />

这段代码会导致每次渲染时 extraUrlParams 都是新的引用导致 useEffect 等不必要的副作用，此 pr 修复该问题