### PR TITLE
fix(DrawerForm): issue#8858. prevent error when closing ModalForm/DrawerForm during request with destroyOnHidden

### DIFF
--- a/demos/form/ModalForm/drawer-form-request-destroy-debug.tsx
+++ b/demos/form/ModalForm/drawer-form-request-destroy-debug.tsx
@@ -1,0 +1,3 @@
+export { default } from './modal-form-request-destroy-debug';
+
+

--- a/demos/form/ModalForm/modal-form-request-destroy-debug.tsx
+++ b/demos/form/ModalForm/modal-form-request-destroy-debug.tsx
@@ -1,0 +1,47 @@
+import { ModalForm, DrawerForm, ProFormText } from '@ant-design/pro-components';
+import { Button, message } from 'antd';
+
+const wait = (time: number = 300) =>
+    new Promise((resolve) => setTimeout(resolve, time));
+
+export default () => {
+    return (
+        <>
+            <ModalForm
+                title="Debug: destroyOnHidden + request"
+                trigger={<Button type="primary">Open (Debug)</Button>}
+                modalProps={{ destroyOnHidden: true }}
+                // Simulate async data loading
+                request={async () => {
+                    await wait(3000);
+                    return { name: 'loaded' } as any;
+                }}
+                onFinish={async () => {
+                    message.success('Submission successful');
+                    return true;
+                }}
+            >
+                <ProFormText name="name" label="Name" placeholder="Close quickly while loading to test" />
+            </ModalForm>
+            <div style={{ height: 16 }} />
+            <DrawerForm
+                title="Debug: destroyOnHidden + request (Drawer)"
+                trigger={<Button type="primary">Open Drawer (Debug)</Button>}
+                drawerProps={{ destroyOnHidden: true }}
+                // Simulate async data loading
+                request={async () => {
+                    await wait(3000);
+                    return { name: 'loaded' } as any;
+                }}
+                onFinish={async () => {
+                    message.success('Submission successful');
+                    return true;
+                }}
+            >
+                <ProFormText name="name" label="Name" placeholder="Close quickly while loading to test" />
+            </DrawerForm>
+        </>
+    );
+};
+
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,10 +177,10 @@ importers:
         specifier: ^14.18.63
         version: 14.18.63
       '@types/react':
-        specifier: ^18.3.24
+        specifier: ^18.0.38
         version: 18.3.24
       '@types/react-dom':
-        specifier: ^18.3.7
+        specifier: ^18.0.11
         version: 18.3.7(@types/react@18.3.24)
       '@types/react-helmet':
         specifier: ^6.1.11

--- a/site/components/form/ModalForm/index.en-US.md
+++ b/site/components/form/ModalForm/index.en-US.md
@@ -24,6 +24,10 @@ ModalForm and DrawerForm both provide triggers to reduce state usage, if you nee
 
 <code src="../../../../demos/form/ModalForm/drawer-form-nested.tsx" debug  background="var(--main-bg-color)" oldtitle="Drawer Forms"></code>
 
+### Debug: Close while loading (Modal + Drawer)
+
+<code src="../../../../demos/form/ModalForm/modal-form-request-destroy-debug.tsx" debug  background="var(--main-bg-color)" oldtitle="Debug: destroyOnHidden + request (Modal & Drawer)"></code>
+
 ## Custom Modal Forms' Button
 
 <code src="../../../../demos/form/ModalForm/modal-form-submitter.tsx"  background="var(--main-bg-color)" oldtitle="Custom Modal Forms' Button"></code>

--- a/site/components/form/ModalForm/index.md
+++ b/site/components/form/ModalForm/index.md
@@ -25,6 +25,10 @@ ModalForm 和 DrawerForm 都提供了 trigger 来减少 state 的使用，如果
 
 <code src="../../../../demos/form/ModalForm/drawer-form-nested.tsx" debug  background="var(--main-bg-color)" title="Drawer Forms"></code>
 
+### Debug：请求加载中关闭（Modal + Drawer）
+
+<code src="../../../../demos/form/ModalForm/modal-form-request-destroy-debug.tsx" debug background="var(--main-bg-color)" title="Debug: destroyOnHidden + request (Modal & Drawer)"></code>
+
 ## 自定义 Modal 表单按钮
 
 <code src="../../../../demos/form/ModalForm/modal-form-submitter.tsx"  background="var(--main-bg-color)" title="自定义 Modal 表单按钮"></code>

--- a/site/components/modal-form/index.en-US.md
+++ b/site/components/modal-form/index.en-US.md
@@ -24,6 +24,11 @@ ModalForm and DrawerForm both provide triggers to reduce state usage, if you nee
 
 <code src="../../../demos/form/ModalForm/drawer-form-nested.tsx" debug  background="var(--main-bg-color)" oldtitle="Drawer Forms"></code>
 
+
+### Debug: Close while loading (Modal + Drawer)
+
+<code src="../../../demos/form/ModalForm/modal-form-request-destroy-debug.tsx" debug background="var(--main-bg-color)" title="Debug: destroyOnHidden + request (Modal & Drawer)"></code>
+
 ## Custom Modal Forms' Button
 
 <code src="../../../demos/form/ModalForm/modal-form-submitter.tsx"  background="var(--main-bg-color)" oldtitle="Custom Modal Forms' Button"></code>

--- a/site/components/modal-form/index.md
+++ b/site/components/modal-form/index.md
@@ -25,6 +25,10 @@ ModalForm 和 DrawerForm 都提供了 trigger 来减少 state 的使用，如果
 
 <code src="../../../demos/form/ModalForm/drawer-form-nested.tsx" debug  background="var(--main-bg-color)" title="Drawer Forms"></code>
 
+### Debug：请求加载中关闭（Modal + Drawer）
+
+<code src="../../../demos/form/ModalForm/modal-form-request-destroy-debug.tsx" debug background="var(--main-bg-color)" title="Debug: destroyOnHidden + request (Modal & Drawer)"></code>
+
 ## 自定义 Modal 表单按钮
 
 <code src="../../../demos/form/ModalForm/modal-form-submitter.tsx"  background="var(--main-bg-color)" title="自定义 Modal 表单按钮"></code>

--- a/src/form/layouts/DrawerForm/index.tsx
+++ b/src/form/layouts/DrawerForm/index.tsx
@@ -91,7 +91,7 @@ function DrawerForm<T = Record<string, any>, U = Record<string, any>>({
   );
   const resizeInfo: CustomizeResizeType = React.useMemo(() => {
     const defaultResize: CustomizeResizeType = {
-      onResize: () => {},
+      onResize: () => { },
       maxWidth: isBrowser() ? window.innerWidth * 0.8 : undefined,
       minWidth: 300,
     };
@@ -145,7 +145,9 @@ function DrawerForm<T = Record<string, any>, U = Record<string, any>>({
   const resetFields = useCallback(() => {
     const form = rest.formRef?.current ?? rest.form ?? formRef.current;
     // 重置表单
-    if (form && drawerProps?.destroyOnHidden) {
+    // issue: 8858 form.resetFields is not a function
+    if (form && drawerProps?.destroyOnHidden && typeof form.resetFields === 'function'
+    ) {
       form.resetFields();
     }
   }, [drawerProps?.destroyOnHidden, rest.form, rest.formRef]);

--- a/src/form/layouts/ModalForm/index.tsx
+++ b/src/form/layouts/ModalForm/index.tsx
@@ -102,7 +102,9 @@ function ModalForm<T = Record<string, any>, U = Record<string, any>>({
   const resetFields = useCallback(() => {
     const form = rest.form ?? rest.formRef?.current ?? formRef.current;
     // 重置表单
-    if (form && modalProps?.destroyOnHidden) {
+    // issue: 8858 form.resetFields is not a function
+    if (form && modalProps?.destroyOnHidden && typeof form.resetFields === 'function'
+    ) {
       form.resetFields();
     }
   }, [modalProps?.destroyOnHidden, rest.form, rest.formRef]);

--- a/tests/form/modalForm.test.tsx
+++ b/tests/form/modalForm.test.tsx
@@ -599,4 +599,36 @@ describe('ModalForm', () => {
       expect(formRef.current).toBeTruthy();
     });
   });
+
+  it('📦 ModalForm close during request loading with destroyOnHidden should not throw', async () => {
+    const wrapper = render(
+      <ModalForm
+        width={600}
+        modalProps={{ destroyOnHidden: true }}
+        request={async () => {
+          // Simulate slow request
+          return new Promise((resolve) => setTimeout(() => resolve({ name: 'demo' }), 200));
+        }}
+        trigger={<Button id="new">新建</Button>}
+      >
+        <ProFormText name="name" />
+      </ModalForm>,
+    );
+
+    await act(async () => {
+      const triggerButton = wrapper.getByText('新 建');
+      fireEvent.click(triggerButton);
+    });
+
+    // Close before request resolves (cancel button may not render while loading), click close icon
+    await act(async () => {
+      const closeButton = document.querySelector('button.ant-modal-close');
+      if (closeButton) {
+        fireEvent.click(closeButton);
+      }
+    });
+
+    // Wait a bit for async to flush
+    await waitForWaitTime(300);
+  });
 });


### PR DESCRIPTION
fix(DrawerForm): issue#8858. prevent error when closing ModalForm/DrawerForm during request with destroyOnHidden

- Guard resetFields call to ensure form instance and method exist
- Cover scenario with a new test: close ModalForm while request is loading
- Keep backward compatibility; no breaking changes

Closes #8858