### PR TITLE
fix(layout): prevent mobile menu drawer auto-collapsing on open

### DIFF
--- a/src/layout/components/SiderMenu/index.tsx
+++ b/src/layout/components/SiderMenu/index.tsx
@@ -51,8 +51,10 @@ const SiderMenuWrapper: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (
         placement={direction === 'rtl' ? 'right' : 'left'}
         className={classNames(`${prefixCls}-drawer-sider`, className)}
         open={!collapsed}
-        afterOpenChange={() => {
-          onCollapse?.(true);
+        afterOpenChange={(open) => {
+          if (!open) {
+            onCollapse?.(true);
+          }
         }}
         style={{
           padding: 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 修复了移动设备上侧边栏菜单抽屉的交互行为。打开抽屉时不再自动折叠菜单，仅在关闭抽屉时触发折叠操作，改善了用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->