### PR TITLE
fix: 文档首页,修复快速开始链接

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -74,7 +74,7 @@ export default defineConfig({
       description: '🏆 让中后台开发更简单',
       actions: {
         text: '🏮🏮 快速开始 →',
-        link: '/docs',
+        link: '/components',
       },
     },
 

--- a/site/index.md
+++ b/site/index.md
@@ -5,7 +5,7 @@ hero:
   description: 🏆 让中后台开发更简单
   actions:
     - text: 🚀 快速开始 →
-      link: /docs
+      link: /components
 footer: Open-source MIT Licensed | © 2017-present
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档更新**
  * 调整了首页英雄区“快速开始”按钮的目标链接，现改为指向组件页面（/components），以便更直接访问组件目录并提升导航体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->