### PR TITLE
FieldSelect unused api cleanup

### DIFF
--- a/src/field/components/Select/LightSelect/index.tsx
+++ b/src/field/components/Select/LightSelect/index.tsx
@@ -55,7 +55,6 @@ export const LightSelect: React.ForwardRefRenderFunction<
     onChange,
     value,
     mode,
-    children,
     defaultValue,
     size,
     showSearch,

--- a/src/field/components/Select/index.tsx
+++ b/src/field/components/Select/index.tsx
@@ -1,6 +1,5 @@
 import type { SelectProps } from 'antd';
 import { ConfigProvider, Spin } from 'antd';
-import type { ReactNode } from 'react';
 import React, {
   useContext,
   useEffect,
@@ -49,7 +48,6 @@ export type FieldSelectProps<FieldProps = any> = {
   variant?: 'outlined' | 'filled' | 'borderless';
   id?: string;
 
-  children?: ReactNode;
   /** 默认搜素条件 */
   defaultKeyWords?: string;
 } & ProFieldLightProps;
@@ -396,8 +394,6 @@ const FieldSelect: ProFieldFC<
     formItemRender,
     request,
     fieldProps,
-    plain,
-    children,
     light,
     proFieldKey,
     params,


### PR DESCRIPTION
Refactor `FieldSelect` component to remove unused props and imports.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c2dfa40-72da-4e76-943b-642b565b88ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c2dfa40-72da-4e76-943b-642b565b88ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

