### PR TITLE
EditableProTablet autofocus error

### DIFF
--- a/src/table/components/EditableTable/index.tsx
+++ b/src/table/components/EditableTable/index.tsx
@@ -1,4 +1,4 @@
-﻿import { PlusOutlined } from '@ant-design/icons';
+import { PlusOutlined } from '@ant-design/icons';
 import { get, set, useMergedState } from '@rc-component/util';
 import type { ButtonProps, FormItemProps, TablePaginationConfig } from 'antd';
 import { Button, Form } from 'antd';
@@ -458,6 +458,8 @@ function EditableTable<
     defaultValue,
     onChange,
     editableFormRef,
+    // @ts-ignore
+    autoFocus,
     ...rest
   } = props;
 


### PR DESCRIPTION
Remove `autoFocus` prop from `EditableTable` to fix `Invalid prop autoFocus supplied to React.Fragment` warning.

---
close https://github.com/ant-design/pro-components/issues/9316



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
* EditableTable 组件现已支持 autoFocus 属性，增强了表格编辑功能的可用性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->