### PR TITLE
fix(table): 修复 cardProps 的 bodyStyle 和 headStyle 被默认样式覆盖的问题

### DIFF
--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -705,13 +705,28 @@ function TableRender<T extends Record<string, any>, U, ValueType>(
   /** Table 区域的 dom，为了方便 render */
   const tableAreaDom =
     // cardProps 或者 有了name 就不需要这个padding了，不然会导致不好对齐
-    propsCardProps === false || notNeedCardDom === true || !!props.name ? (
+    propsCardProps === false || notNeedCardDom || !!props.name ? (
       tableContentDom
     ) : (
       <ProCard
         ghost={props.ghost}
         variant={isBordered('table', cardBordered) ? 'outlined' : 'borderless'}
-        styles={{ body: cardBodyStyle }}
+        styles={{
+          body: {
+            ...cardBodyStyle,
+            ...(propsCardProps && typeof propsCardProps === 'object'
+              ? propsCardProps.styles?.body || propsCardProps.bodyStyle
+              : {}),
+          },
+          ...(propsCardProps &&
+          typeof propsCardProps === 'object' &&
+          (propsCardProps.styles?.header || propsCardProps.headStyle)
+            ? {
+                header:
+                  propsCardProps.styles?.header || propsCardProps.headStyle,
+              }
+            : {}),
+        }}
         {...propsCardProps}
       >
         {tableContentDom}
@@ -1255,7 +1270,7 @@ const ProTable = <
       onSizeChange={counter.setTableSize}
       pagination={pagination}
       searchNode={searchNode}
-      rowSelection={propsRowSelection !== false ? rowSelection : undefined}
+      rowSelection={propsRowSelection ? rowSelection : undefined}
       className={className}
       tableColumn={tableColumn}
       isLightFilter={isLightFilter}

--- a/src/table/useFetchData.tsx
+++ b/src/table/useFetchData.tsx
@@ -288,9 +288,9 @@ const useFetchData = <DataSource extends RequestData<any>>(
 
       return msg;
     } catch (error) {
-    if (error === 'aborted') {
-      return [];
-    }
+      if (error === 'aborted') {
+        return [];
+      }
       throw error;
     }
   }, debounceTime || 30);

--- a/src/table/utils/genProColumnToColumn.tsx
+++ b/src/table/utils/genProColumnToColumn.tsx
@@ -35,14 +35,14 @@ type ColumnToColumnParams<T> = {
   editableUtils: UseEditableUtilType;
   proFilter: Record<string, FilterValue>;
   proSort: Record<string, SortOrder>;
-} & Pick<TableProps<T>, 'rowKey' | 'childrenColumnName'>;
+  childrenColumnName?: string;
+} & Pick<TableProps<T>, 'rowKey'>;
 
 /**
  * 转化 columns 到 pro 的格式 主要是 render 方法的自行实现
  *
- * @param columns
- * @param map
- * @param columnEmptyText
+ * @param params
+ * @param parents
  */
 export function genProColumnToColumn<T extends AnyObject>(
   params: ColumnToColumnParams<T> & { marginSM: number },


### PR DESCRIPTION
- 修复 Table 组件中 cardProps 的 bodyStyle 被内部计算的 cardBodyStyle 覆盖的问题
- 新增对 cardProps.headStyle 的支持
- 现在用户传入的样式会正确覆盖默认样式
- 同时支持旧的 bodyStyle/headStyle 和新的 styles.body/styles.header API
- 优先级：styles.body > bodyStyle, styles.header > headStyle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化表格区域包装逻辑，提高条件判断效率
  * 改进卡片样式合并机制，增强自定义样式支持
  * 简化表格行选择处理逻辑

* **其他**
  * 优化类型定义，更新相关文档注释
  * 代码格式调整

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->