### PR TITLE
Domestic mirror quick start

### DIFF
--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 export default defineConfig({
   title: 'ProComponents',
+  exportStatic: {},
   sitemap: { hostname: 'https://procomponents.ant.design' },
   alias: {
     '@ant-design/pro-components': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
Enable `exportStatic` in `.dumirc.ts` to fix 404 errors on static hosting mirror sites.

Static hosting environments for domestic mirrors do not support SPA route rewriting, causing 404 errors when accessing pages like `/components`. Enabling `exportStatic` ensures dumi generates static `index.html` files for each route, making them accessible on such servers.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a4d6429-e00e-4f01-9547-7a383d37d465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a4d6429-e00e-4f01-9547-7a383d37d465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新增功能

* 新增静态导出配置支持，增强文档生成和部署能力

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->