### PR TITLE
refactor(card, skeleton): replace deprecated useBreakpoint import with Grid destructuring

### DIFF
--- a/src/card/components/Card/index.tsx
+++ b/src/card/components/Card/index.tsx
@@ -1,7 +1,6 @@
 import { RightOutlined } from '@ant-design/icons';
 import { omit, useMergedState } from '@rc-component/util';
-import { ConfigProvider, Tabs } from 'antd';
-import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint';
+import { ConfigProvider, Grid, Tabs } from 'antd';
 import classNames from 'classnames';
 import React, { useContext } from 'react';
 import { LabelIconTip } from '../../../utils';
@@ -10,6 +9,7 @@ import Actions from '../Actions';
 import Loading from '../Loading';
 
 import useStyle from './style';
+const { useBreakpoint } = Grid;
 
 type ProCardChildType = React.ReactElement<CardProps, any>;
 

--- a/src/skeleton/components/Descriptions/index.tsx
+++ b/src/skeleton/components/Descriptions/index.tsx
@@ -1,7 +1,8 @@
-import { Card, Skeleton } from 'antd';
-import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint';
+import { Card, Grid, Skeleton } from 'antd';
 import React, { useMemo } from 'react';
 import { Line, PageHeaderSkeleton } from '../List';
+
+const { useBreakpoint } = Grid;
 
 export type DescriptionsPageSkeletonProps = {
   active?: boolean;

--- a/src/skeleton/components/List/index.tsx
+++ b/src/skeleton/components/List/index.tsx
@@ -1,6 +1,7 @@
-import { Card, Divider, Skeleton, Space } from 'antd';
-import useBreakpoint from 'antd/lib/grid/hooks/useBreakpoint';
+import { Card, Divider, Grid, Skeleton, Space } from 'antd';
 import React, { useMemo } from 'react';
+
+const { useBreakpoint } = Grid;
 
 /** 一条分割线 */
 export const Line = ({ padding }: { padding?: string | number }) => (


### PR DESCRIPTION
about #9345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 描述骨架屏组件现已支持 `list` 属性，可灵活配置列表/表格大小呈现。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->