### PR TITLE
chrome: Add browser targets for compatibility in .fatherrc.ts

### DIFF
--- a/.fatherrc.ts
+++ b/.fatherrc.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'father';
 
 const targets = {
-  edge: 100,
-  firefox: 100,
-  chrome: 100,
-  safari: 100,
-  opera: 100,
+  edge: 142,
+  firefox: 140,
+  chrome: 112,
+  safari: 18.5,
+  opera: 124,
   electron: 39,
 };
 


### PR DESCRIPTION
没有 [targets](https://github.com/umijs/father/blob/master/docs/config.md#targets) 时`father`会默认打包兼容到 `ie: 11`,多了很多不必要的兼容代码. 由于`father` 目前只支持对象配置, 想要设置的话必须将各个浏览器最低版本列举出来,现在提交的是根据当前 [browserslist](https://browsersl.ist/#q=last+2+versions%2C%0AFirefox+ESR%2C%0A%3E+1%25%2C%0Anot+dead) 查找到的版本号发现太新了, 应该讨论下最小环境版本.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **配置优化**
  * 更新构建配置以支持多个浏览器和平台的版本目标（包括 Edge、Firefox、Chrome、Safari、Opera 和 Electron）。
  * 优化 ESM、CJS 和 UMD 输出格式的兼容性配置。
  * 公共 API 接口保持不变。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->