### PR TITLE
fix(ProForm):设置variant参数时部分组件无效的bug

### DIFF
--- a/src/field/components/Cascader/index.tsx
+++ b/src/field/components/Cascader/index.tsx
@@ -111,7 +111,7 @@ const FieldCascader: ProFieldFC<GroupProps> = (
   if (mode === 'edit') {
     let dom = (
       <Cascader
-        variant={!light ? 'outlined' : 'borderless'}
+        variant={!light ? variant : 'borderless'}
         ref={cascaderRef}
         open={open}
         suffixIcon={loading ? <LoadingOutlined /> : undefined}

--- a/src/field/components/DatePicker/index.tsx
+++ b/src/field/components/DatePicker/index.tsx
@@ -29,7 +29,7 @@ const FieldDatePicker: ProFieldFC<
     text: string | number;
     format?: string;
     showTime?: boolean;
-    variant?: 'outlined' | 'borderless' | 'filled';
+    variant?: 'outlined' | 'borderless' | 'filled' | 'underlined';
     picker?: 'time' | 'date' | 'week' | 'month' | 'quarter' | 'year';
   } & ProFieldLightProps
 > = (
@@ -119,7 +119,7 @@ const FieldDatePicker: ProFieldFC<
           format={format}
           placeholder={placeholder}
           variant={
-            plain === undefined ? 'outlined' : plain ? 'borderless' : 'outlined'
+            plain === undefined ? variant : plain ? 'borderless' : 'outlined'
           }
           ref={ref}
           {...fieldProps}

--- a/src/field/components/RangePicker/index.tsx
+++ b/src/field/components/RangePicker/index.tsx
@@ -14,7 +14,7 @@ const FieldRangePicker: ProFieldFC<
   {
     text: string[];
     format?: string;
-    variant?: 'outlined' | 'borderless' | 'filled';
+    variant?: 'outlined' | 'borderless' | 'filled' | 'underlined';
     showTime?: boolean;
     picker?: 'time' | 'date' | 'week' | 'month' | 'quarter' | 'year';
   } & ProFieldLightProps
@@ -149,7 +149,7 @@ const FieldRangePicker: ProFieldFC<
             intl.getMessage('tableForm.selectPlaceholder', '请选择'),
           ]}
           variant={
-            plain === undefined ? 'outlined' : plain ? 'borderless' : 'outlined'
+            plain === undefined ? variant : plain ? 'borderless' : 'outlined'
           }
           {...fieldProps}
           value={dayValue}

--- a/src/field/components/TreeSelect/index.tsx
+++ b/src/field/components/TreeSelect/index.tsx
@@ -175,7 +175,7 @@ const FieldTreeSelect: ProFieldFC<GroupProps> = (
                 }
               : undefined
           }
-          variant={!light ? 'outlined' : 'borderless'}
+          variant={!light ? variant : 'borderless'}
           {...fieldProps}
           treeData={options as TreeSelectProps['treeData']}
           showSearch={showSearch}


### PR DESCRIPTION
ProForm设置variant参数后
在默认模式下（非light）Datepicker DateRangePicker Cascader TreeSelect 这四个组件variant无效，默认都是outlined

https://codesandbox.io/p/devbox/ji-ben-shi-yong-forked-xtnmjc?workspaceId=ws_KZ3MX3vYgUtZcydBrgtMuJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了级联选择器、日期选择器、日期范围选择器和树形选择器组件的变体样式处理逻辑，提供更灵活的自定义选项
  * 在日期选择器和日期范围选择器中新增"underlined"变体选项，扩展可用的界面样式

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->