### PR TITLE
refactor: Replace useMountMergeState with useMergedState 

### DIFF
--- a/src/card/components/CheckCard/Group.tsx
+++ b/src/card/components/CheckCard/Group.tsx
@@ -1,5 +1,5 @@
 import { RightOutlined } from '@ant-design/icons';
-import { omit } from '@rc-component/util';
+import { omit, useMergedState } from '@rc-component/util';
 import { ConfigProvider, Skeleton } from 'antd';
 import classNames from 'classnames';
 import React, {
@@ -11,7 +11,6 @@ import React, {
   useState,
 } from 'react';
 import { ProConfigProvider, proTheme } from '../../../provider';
-import { useMountMergeState } from '../../../utils';
 import CheckCard from './index';
 import { useStyle } from './style';
 
@@ -318,7 +317,7 @@ const CheckCardGroup: React.FC<CheckCardGroupProps> = (props) => {
     'size',
   ]);
 
-  const [stateValue, setStateValue] = useMountMergeState<
+  const [stateValue, setStateValue] = useMergedState<
     CheckCardValueType[] | CheckCardValueType | undefined
   >(props.defaultValue, {
     value: props.value,

--- a/src/card/components/CheckCard/index.tsx
+++ b/src/card/components/CheckCard/index.tsx
@@ -1,8 +1,8 @@
+import { useMergedState } from '@rc-component/util';
 import { Avatar, ConfigProvider } from 'antd';
 import classNames from 'classnames';
 import type { MouseEventHandler } from 'react';
 import React, { useContext, useEffect, useMemo } from 'react';
-import { useMountMergeState } from '../../../utils';
 import ProCardActions from '../Actions';
 import type { CheckCardGroupProps } from './Group';
 import CheckCardGroup, { CardLoading, CheckCardGroupConnext } from './Group';
@@ -169,7 +169,7 @@ export interface CheckCardState {
 const CheckCard: React.FC<CheckCardProps> & {
   Group: typeof CheckCardGroup;
 } = (props) => {
-  const [stateChecked, setStateChecked] = useMountMergeState<boolean>(
+  const [stateChecked, setStateChecked] = useMergedState<boolean>(
     props.defaultChecked || false,
     {
       value: props.checked,

--- a/src/field/components/Select/SearchSelect/index.tsx
+++ b/src/field/components/Select/SearchSelect/index.tsx
@@ -28,8 +28,10 @@ export type DataValueType<T> = KeyLabel & T;
 /** 可能单选，可能多选 */
 export type DataValuesType<T> = DataValueType<T> | DataValueType<T>[];
 
-export interface SearchSelectProps<T = Record<string, any>>
-  extends Omit<SelectProps<KeyLabel | KeyLabel[]>, 'options'> {
+export interface SearchSelectProps<T = Record<string, any>> extends Omit<
+  SelectProps<KeyLabel | KeyLabel[]>,
+  'options'
+> {
   /** 防抖动时间 默认10 单位ms */
   debounceTime?: number;
   /** 自定义搜索方法, 返回搜索结果的 Promise */

--- a/src/field/components/Select/index.tsx
+++ b/src/field/components/Select/index.tsx
@@ -1,3 +1,4 @@
+import { useControlledState } from '@rc-component/util';
 import type { SelectProps } from 'antd';
 import { ConfigProvider, Spin } from 'antd';
 import React, {
@@ -21,7 +22,6 @@ import {
   useDebounceValue,
   useDeepCompareEffect,
   useDeepCompareMemo,
-  useMountMergeState,
   useRefFunction,
   useStyle,
 } from '../../../utils';
@@ -268,16 +268,9 @@ export const useFieldFetchData = (
     return data;
   }, [fieldProps]);
 
-  const [options, setOptions] = useMountMergeState<SelectOptionType>(
-    () => {
-      if (props.valueEnum) {
-        return getOptionsFormValueEnum(props.valueEnum);
-      }
-      return [];
-    },
-    {
-      value: defaultOptions,
-    },
+  const [options, setOptions] = useControlledState<SelectOptionType>(
+    () => (props.valueEnum ? getOptionsFormValueEnum(props.valueEnum) : []),
+    defaultOptions,
   );
 
   useDeepCompareEffect(() => {

--- a/src/form/BaseForm/BaseForm.tsx
+++ b/src/form/BaseForm/BaseForm.tsx
@@ -3,6 +3,7 @@
   set as namePathSet,
   omit,
   set,
+  useMergedState,
   warning,
 } from '@rc-component/util';
 import { useUrlSearchParams } from '@umijs/use-params';
@@ -35,7 +36,6 @@ import {
   runFunction,
   transformKeySubmitValue,
   useFetchData,
-  useMountMergeState,
   usePrevious,
   useRefFunction,
   useStyle,
@@ -668,7 +668,7 @@ export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
     ...propRest
   } = props;
   const formRef = useRef<ProFormRef<any>>({} as any);
-  const [loading, setLoading] = useMountMergeState<boolean>(false, {
+  const [loading, setLoading] = useMergedState<boolean>(false, {
     onChange: onLoadingChange,
     value: propsLoading,
   });

--- a/src/form/BaseForm/LightWrapper/index.tsx
+++ b/src/form/BaseForm/LightWrapper/index.tsx
@@ -7,7 +7,6 @@ import {
   dateFormatterMap,
   FieldLabel,
   FilterDropdown,
-  useMountMergeState,
 } from '../../../utils';
 import type { LightFilterFooterRender } from '../../typing';
 import { useStyle } from './style';
@@ -72,7 +71,7 @@ const LightWrapper: React.ForwardRefRenderFunction<any, LightWrapperProps> = (
   const [tempValue, setTempValue] = useState<string | undefined | null>(
     (props as any)[valuePropName!],
   );
-  const [open, setOpen] = useMountMergeState<boolean>(false);
+  const [open, setOpen] = useState(false);
 
   const onChange = (...restParams: any[]) => {
     otherFieldProps?.onChange?.(...restParams);

--- a/src/form/components/FormItem/FormItemRender/index.tsx
+++ b/src/form/components/FormItem/FormItemRender/index.tsx
@@ -54,9 +54,8 @@ export function useControlModel<
   model?: T,
 ): { [P in GetArrayFieldType<T>]: ControlModelType };
 export function useControlModel<
-  T extends
-    | FormControlProps
-    | (string | FormControlMultiProps)[] = FormControlProps,
+  T extends FormControlProps | (string | FormControlMultiProps)[] =
+    FormControlProps,
 >({ value, onChange }: WithControlPropsType, model?: T): unknown {
   if (!Array.isArray(model)) {
     const p = getControlConfigProps(model);

--- a/src/form/components/FormItem/Group/index.tsx
+++ b/src/form/components/FormItem/Group/index.tsx
@@ -1,8 +1,9 @@
 import { RightOutlined } from '@ant-design/icons';
+import { useMergedState } from '@rc-component/util';
 import { ConfigProvider, Space } from 'antd';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useMemo } from 'react';
-import { LabelIconTip, useMountMergeState } from '../../../../utils';
+import { LabelIconTip } from '../../../../utils';
 import FieldContext from '../../../FieldContext';
 import { useGridHelpers } from '../../../helpers/grid';
 import { ProFormGroupProps } from '../../../typing';
@@ -32,7 +33,7 @@ const Group: React.FC<ProFormGroupProps> = React.forwardRef(
       ...props,
     };
 
-    const [collapsed, setCollapsed] = useMountMergeState(
+    const [collapsed, setCollapsed] = useMergedState(
       () => defaultCollapsed || false,
       {
         value: props.collapsed,

--- a/src/form/components/Text/index.tsx
+++ b/src/form/components/Text/index.tsx
@@ -1,10 +1,9 @@
-import { omit } from '@rc-component/util';
+import { omit, useMergedState } from '@rc-component/util';
 import { Form, Popover, PopoverProps, type InputProps } from 'antd';
 import type { InputRef, PasswordProps } from 'antd/lib/input';
 import React, { useState } from 'react';
 import { FieldPassword } from '../../../field';
 import { ProConfigProvider } from '../../../provider';
-import { useMountMergeState } from '../../../utils';
 import type { ProFormFieldItemProps } from '../../typing';
 import ProField from '../Field';
 
@@ -50,7 +49,7 @@ const PassWordStrength: React.FC<
     children: React.ReactNode;
   }
 > = (props) => {
-  const [open, setOpen] = useMountMergeState<boolean>(props.open || false, {
+  const [open, setOpen] = useMergedState<boolean>(props.open || false, {
     value: props.open,
     onChange: props.onOpenChange,
   });

--- a/src/form/layouts/QueryFilter/index.tsx
+++ b/src/form/layouts/QueryFilter/index.tsx
@@ -1,13 +1,13 @@
-/* eslint-disable no-param-reassign */ import { useMergedState } from '@rc-component/util';
+/* eslint-disable no-param-reassign */ import RcResizeObserver from '@rc-component/resize-observer';
+import { useMergedState } from '@rc-component/util';
 import type { ColProps, FormItemProps, RowProps } from 'antd';
 import { Col, ConfigProvider, Form, Row } from 'antd';
 import type { FormInstance, FormProps } from 'antd/lib/form/Form';
 import classNames from 'classnames';
-import RcResizeObserver from '@rc-component/resize-observer';
 import type { ReactElement } from 'react';
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { ProProvider, useIntl } from '../../../provider';
-import { isBrowser, useMountMergeState } from '../../../utils';
+import { isBrowser } from '../../../utils';
 import type { CommonFormProps } from '../../BaseForm';
 import { BaseForm } from '../../BaseForm';
 import type { ActionsProps } from './Actions';
@@ -529,11 +529,8 @@ function QueryFilter<T = Record<string, any>>(props: QueryFilterProps<T>) {
   const baseClassName = context.getPrefixCls('pro-query-filter');
   const { wrapSSR, hashId } = useStyle(baseClassName);
 
-  const [width, setWidth] = useMountMergeState(
-    () =>
-      (typeof style?.width === 'number'
-        ? style?.width
-        : defaultWidth) as number,
+  const [width, setWidth] = useState(() =>
+    typeof style?.width === 'number' ? style?.width : defaultWidth,
   );
 
   const spanSize = useMemo(

--- a/src/layout/ProLayout.tsx
+++ b/src/layout/ProLayout.tsx
@@ -16,12 +16,7 @@ import React, {
 import useSWR, { useSWRConfig } from 'swr';
 import type { GenerateStyle, ProTokenType } from '../provider';
 import { ProConfigProvider, ProProvider, isNeedOpenHash } from '../provider';
-import {
-  isBrowser,
-  useBreakpoint,
-  useDocumentTitle,
-  useMountMergeState,
-} from '../utils';
+import { isBrowser, useBreakpoint, useDocumentTitle } from '../utils';
 import { Logo } from './assert/Logo';
 import { DefaultFooter as Footer } from './components/Footer';
 import type { HeaderViewProps } from './components/Header';
@@ -449,7 +444,7 @@ const BaseProLayout: React.FC<ProLayoutProps> = (props) => {
 
   const prefixCls = props.prefixCls ?? context.getPrefixCls('pro');
 
-  const [menuLoading, setMenuLoading] = useMountMergeState(false, {
+  const [menuLoading, setMenuLoading] = useMergedState(false, {
     value: menu?.loading,
     onChange: menu?.onLoadingChange,
   });

--- a/src/layout/components/GlobalHeader/ActionsContent.tsx
+++ b/src/layout/components/GlobalHeader/ActionsContent.tsx
@@ -1,6 +1,6 @@
-﻿import { Avatar, ConfigProvider } from 'antd';
+﻿import ResizeObserver from '@rc-component/resize-observer';
+import { Avatar, ConfigProvider } from 'antd';
 import classNames from 'classnames';
-import ResizeObserver from '@rc-component/resize-observer';
 import React, { useContext, useMemo, useState } from 'react';
 import type { GlobalHeaderProps } from '.';
 import { useDebounceFn } from '../../../utils';

--- a/src/layout/components/PageHeader/index.tsx
+++ b/src/layout/components/PageHeader/index.tsx
@@ -1,9 +1,9 @@
 import { ArrowLeftOutlined, ArrowRightOutlined } from '@ant-design/icons';
+import ResizeObserver from '@rc-component/resize-observer';
 import type { AvatarProps, BreadcrumbProps, TagType } from 'antd';
 import { Avatar, Breadcrumb, ConfigProvider, Space } from 'antd';
 import type { DirectionType } from 'antd/lib/config-provider';
 import classNames from 'classnames';
-import ResizeObserver from '@rc-component/resize-observer';
 import React from 'react';
 import type { ContentWidth } from '../../defaultSettings';
 import useStyle from './style';

--- a/src/layout/components/SiderMenu/BaseMenu.tsx
+++ b/src/layout/components/SiderMenu/BaseMenu.tsx
@@ -1,4 +1,5 @@
 import { createFromIconfontCN } from '@ant-design/icons';
+import { useMergedState } from '@rc-component/util';
 import type { MenuProps } from 'antd';
 import { Menu, Skeleton, Tooltip } from 'antd';
 import { ItemType } from 'antd/lib/menu/interface';
@@ -6,7 +7,7 @@ import classNames from 'classnames';
 import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ProTokenType } from '../../../provider';
 import { ProProvider } from '../../../provider';
-import { isImg, isUrl, useMountMergeState } from '../../../utils';
+import { isImg, isUrl } from '../../../utils';
 import type { PureSettings } from '../../defaultSettings';
 import { defaultSettings } from '../../defaultSettings';
 import type {
@@ -571,13 +572,9 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
   // 用于减少 defaultOpenKeys 计算的组件
   const defaultOpenKeysRef = useRef<string[]>([]);
 
-  const [defaultOpenAll, setDefaultOpenAll] = useMountMergeState(
-    menu?.defaultOpenAll,
-  );
+  const [defaultOpenAll, setDefaultOpenAll] = useState(menu?.defaultOpenAll);
 
-  const [openKeys, setOpenKeys] = useMountMergeState<
-    (string | number)[] | false
-  >(
+  const [openKeys, setOpenKeys] = useMergedState<(string | number)[] | false>(
     () => {
       if (menu?.defaultOpenAll) {
         return getOpenKeysFromMenuData(menuData) || [];
@@ -593,18 +590,19 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
     },
   );
 
-  const [selectedKeys, setSelectedKeys] = useMountMergeState<
-    string[] | undefined
-  >([], {
-    value: propsSelectedKeys,
-    onChange: onSelect
-      ? (keys) => {
-          if (onSelect && keys) {
-            onSelect(keys as any);
+  const [selectedKeys, setSelectedKeys] = useMergedState<string[] | undefined>(
+    [],
+    {
+      value: propsSelectedKeys,
+      onChange: onSelect
+        ? (keys) => {
+            if (onSelect && keys) {
+              onSelect(keys as any);
+            }
           }
-        }
-      : undefined,
-  });
+        : undefined,
+    },
+  );
   useEffect(() => {
     if (menu?.defaultOpenAll || propsOpenKeys === false) {
       return;

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -1,4 +1,5 @@
 import { Summary } from '@rc-component/table';
+import { useControlledState } from '@rc-component/util';
 import type { TablePaginationConfig } from 'antd';
 import { ConfigProvider, Table } from 'antd';
 import type { GetRowKey, SortOrder } from 'antd/lib/table/interface';
@@ -13,6 +14,7 @@ import React, {
   useImperativeHandle,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import type { ActionType } from '.';
 import ValueTypeToComponent from '../field/ValueTypeToComponent';
@@ -28,7 +30,6 @@ import {
   useDeepCompareEffect,
   useDeepCompareEffectDebounce,
   useEditableArray,
-  useMountMergeState,
 } from '../utils';
 import Alert from './components/Alert';
 import { Container, TableContext } from './Store/Provide';
@@ -229,27 +230,25 @@ const ProTable = <
   useImperativeHandle(propsActionRef, () => actionRef.current);
 
   /** 单选多选的相关逻辑 */
-  const [selectedRowKeys, setSelectedRowKeys] = useMountMergeState<
+  const [selectedRowKeys, setSelectedRowKeys] = useControlledState<
     (string | number)[] | Key[] | undefined
   >(
     propsRowSelection
       ? propsRowSelection?.defaultSelectedRowKeys || []
       : undefined,
-    {
-      value: propsRowSelection ? propsRowSelection.selectedRowKeys : undefined,
-    },
+    propsRowSelection ? propsRowSelection.selectedRowKeys : undefined,
   );
 
-  const [formSearch, setFormSearch] = useMountMergeState<
-    Record<string, any> | undefined
-  >(() => {
-    // 如果手动模式，或者 search 不存在的时候设置为 undefined
-    // undefined 就不会触发首次加载
-    if (manualRequest || search !== false) {
-      return undefined;
-    }
-    return {};
-  });
+  const [formSearch, setFormSearch] = useState<Record<string, any> | undefined>(
+    () => {
+      // 如果手动模式，或者 search 不存在的时候设置为 undefined
+      // undefined 就不会触发首次加载
+      if (manualRequest || search !== false) {
+        return undefined;
+      }
+      return {};
+    },
+  );
 
   /**
    * `actionRef.current?.reset()` 会在同一事件循环里同步调用 `action.reload()`。
@@ -277,9 +276,9 @@ const ProTable = <
     };
   }, [propsColumns]);
   const [proFilter, setProFilter] =
-    useMountMergeState<Record<string, FilterValue>>(defaultProFilter);
+    useState<Record<string, FilterValue>>(defaultProFilter);
   const [proSort, setProSort] =
-    useMountMergeState<Record<string, SortOrder>>(defaultProSort);
+    useState<Record<string, SortOrder>>(defaultProSort);
 
   const intl = useIntl();
 

--- a/src/table/TableRender.tsx
+++ b/src/table/TableRender.tsx
@@ -10,16 +10,12 @@ import type {
   TableCurrentDataSource,
 } from 'antd/lib/table/interface';
 import classNames from 'classnames';
-import React, { Key, useContext, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import ProCard from '../card';
 import ProForm, { GridContext } from '../form';
 import { editableRowByKey, omitUndefined, recordKeyToString } from '../utils';
 import { TableContext } from './Store/Provide';
-import type {
-  FilterValue,
-  ProTableProps,
-  UseFetchDataAction,
-} from './typing';
+import type { FilterValue, ProTableProps, UseFetchDataAction } from './typing';
 import {
   flattenColumns,
   genColumnKey,
@@ -64,7 +60,9 @@ function getEditableDataSource<T>({
   if (newLineOptions?.parentKey) {
     const newRow = {
       ...defaultValue,
-      map_row_parentKey: recordKeyToString(newLineOptions.parentKey)?.toString(),
+      map_row_parentKey: recordKeyToString(
+        newLineOptions.parentKey,
+      )?.toString(),
     };
     const actionProps = {
       data: baseData,
@@ -259,7 +257,9 @@ export function TableRender<T extends Record<string, any>, U, ValueType>(
    * 是否需要 card 来包裹
    */
   const notNeedCardDom =
-    props.search === false && !props.headerTitle && props.toolBarRender === false;
+    props.search === false &&
+    !props.headerTitle &&
+    props.toolBarRender === false;
 
   /** 默认的 table dom，如果是编辑模式，外面还要包个 form */
   const baseTableDom = (
@@ -396,4 +396,3 @@ export function TableRender<T extends Record<string, any>, U, ValueType>(
     </ConfigProvider>
   );
 }
-

--- a/src/table/TableSearch.tsx
+++ b/src/table/TableSearch.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import type { ParamsType } from '../provider';
-import type { ActionType, ProTableProps } from './typing';
 import FormRender from './components/Form';
+import type { ActionType, ProTableProps } from './typing';
 
 export type TableSearchProps<T extends Record<string, any>, U, ValueType> = {
   search: ProTableProps<T, U, ValueType>['search'];
@@ -98,4 +98,3 @@ export function TableSearch<T extends Record<string, any>, U, ValueType>(
     type,
   ]);
 }
-

--- a/src/table/TableToolbar.tsx
+++ b/src/table/TableToolbar.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
 import type { Key } from 'react';
+import React, { useMemo } from 'react';
 import type { ActionType } from '.';
-import type { ProTableProps } from './typing';
 import Toolbar from './components/ToolBar';
+import type { ProTableProps } from './typing';
 
 export type TableToolbarProps<T extends Record<string, any>> = {
   toolBarRender: ProTableProps<T, any, any>['toolBarRender'];
@@ -87,4 +87,3 @@ export function TableToolbar<T extends Record<string, any>>(
     toolbar,
   ]);
 }
-

--- a/src/table/components/ListToolBar/index.tsx
+++ b/src/table/components/ListToolBar/index.tsx
@@ -1,8 +1,8 @@
+import ResizeObserver from '@rc-component/resize-observer';
 import { ConfigProvider, Input, TabPaneProps, Tabs, Tooltip } from 'antd';
 import type { LabelTooltipType } from 'antd/lib/form/FormItemLabel';
 import type { SearchProps } from 'antd/lib/input';
 import classNames from 'classnames';
-import ResizeObserver from '@rc-component/resize-observer';
 import React, { useContext, useMemo, useState } from 'react';
 import { proTheme, useIntl } from '../../../provider';
 import { LabelIconTip } from '../../../utils';

--- a/src/table/useFetchData.tsx
+++ b/src/table/useFetchData.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { useMergedState } from '@rc-component/util';
+import { useEffect, useRef, useState } from 'react';
 import {
   runFunction,
   useDebounceFn,
   useDeepCompareEffect,
-  useMountMergeState,
   usePrevious,
   useRefFunction,
 } from '../utils';
@@ -81,7 +81,7 @@ const useFetchData = <DataSource extends RequestData<any>>(
   /**
    * 用于存储最新的数据，这样可以在切换的时候保持数据的一致性
    */
-  const [tableDataList, setTableDataList] = useMountMergeState<
+  const [tableDataList, setTableDataList] = useMergedState<
     DataSource[] | undefined
   >(defaultData, {
     value: options?.dataSource,
@@ -91,7 +91,7 @@ const useFetchData = <DataSource extends RequestData<any>>(
   /**
    * 表格的加载状态
    */
-  const [tableLoading, setTableLoading] = useMountMergeState<boolean>(false, {
+  const [tableLoading, setTableLoading] = useMergedState<boolean>(false, {
     value:
       typeof options?.loading === 'object'
         ? options?.loading?.spinning
@@ -100,14 +100,14 @@ const useFetchData = <DataSource extends RequestData<any>>(
   });
 
   /**
-   * 表示页面信息的类型  useMountMergeState 钩子的初始值和参数
+   * 表示页面信息的类型  useMergedState 钩子的初始值和参数
    * @typedef {object} PageInfo
    * @property {number} current 当前页码
    * @property {number} pageSize 页面大小
    * @property {number} total 数据总量
    * @type {[PageInfo, React.Dispatch<React.SetStateAction<PageInfo>>]}
    */
-  const [pageInfo, setPageInfoState] = useMountMergeState<PageInfo>(
+  const [pageInfo, setPageInfoState] = useMergedState<PageInfo>(
     () => mergeOptionAndPageInfo(options),
     {
       onChange: options?.onPageInfoChange,
@@ -128,7 +128,7 @@ const useFetchData = <DataSource extends RequestData<any>>(
     }
   });
 
-  const [pollingLoading, setPollingLoading] = useMountMergeState(false);
+  const [pollingLoading, setPollingLoading] = useState(false);
 
   // Batching update  https://github.com/facebook/react/issues/14259
   const setDataAndLoading = (newData: DataSource[], dataTotal: number) => {

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -72,7 +72,6 @@ import type {
 } from './useEditableMap';
 import { useEditableMap } from './useEditableMap';
 import { useBreakpoint } from './useMediaQuery';
-import { useMountMergeState } from './useMountMergeState';
 
 export * from './typing';
 export {
@@ -128,7 +127,6 @@ export {
   useEditableMap,
   useFetchData,
   useLatest,
-  useMountMergeState,
   usePrevious,
   useReactiveRef,
   useRefCallback,

--- a/src/utils/useEditableArray/index.tsx
+++ b/src/utils/useEditableArray/index.tsx
@@ -27,7 +27,6 @@ import { ProFormContext } from '../components/ProFormContext';
 import { useDeepCompareEffectDebounce } from '../hooks/useDeepCompareEffect';
 import { usePrevious } from '../hooks/usePrevious';
 import { merge } from '../merge';
-import { useMountMergeState } from '../useMountMergeState';
 const { noteOnce } = rcWarning;
 
 /**
@@ -397,7 +396,7 @@ export function SaveEditableAction<T>(
 ) {
   const context = useContext(ProFormContext);
   const form = Form.useFormInstance();
-  const [loading, setLoading] = useMountMergeState<boolean>(false);
+  const [loading, setLoading] = useState(false);
   const save = useRefFunction(async () => {
     try {
       const isMapEditor = editorType === 'Map';
@@ -515,7 +514,7 @@ export const DeleteEditableAction: React.FC<
   children,
   deletePopconfirmMessage,
 }) => {
-  const [loading, setLoading] = useMountMergeState<boolean>(() => false);
+  const [loading, setLoading] = useState(false);
 
   const onConfirm = useRefFunction(async () => {
     try {
@@ -597,7 +596,9 @@ const CancelEditableAction: React.FC<ActionRenderConfig<any> & { row: any }> = (
 
         // 在清理编辑态前，先捕获“编辑前快照”（多行编辑时必须按 key 取值）
         const cachedPreEditRow =
-          recordKeyStr != null ? preEditRowRefs?.current?.get(recordKeyStr) : undefined;
+          recordKeyStr != null
+            ? preEditRowRefs?.current?.get(recordKeyStr)
+            : undefined;
 
         const isNewLineKeyMatch = (() => {
           const newLineKey = newLineConfig?.options?.recordKey;
@@ -611,8 +612,7 @@ const CancelEditableAction: React.FC<ActionRenderConfig<any> & { row: any }> = (
         const res = await onCancel?.(recordKey, record, row, newLineConfig);
         await cancelEditable(recordKey);
         /** 重置为默认值，不然编辑的行会丢掉 */
-        const restoreRow =
-          cachedPreEditRow ?? preEditRowRef?.current ?? row;
+        const restoreRow = cachedPreEditRow ?? preEditRowRef?.current ?? row;
         const shouldDeleteNewRow =
           cachedPreEditRow === null ||
           (cachedPreEditRow === undefined &&

--- a/src/utils/useMountMergeState/index.ts
+++ b/src/utils/useMountMergeState/index.ts
@@ -1,3 +1,0 @@
-import { useMergedState } from '@rc-component/util';
-
-export { useMergedState as useMountMergeState };

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -30,7 +30,6 @@ export default defineConfig({
         'src/**/typing.ts',
         'src/**/demos/**',
         'src/utils/isDeepEqualReact/*.{ts,tsx}',
-        'src/utils/useMountMergeState/*.{ts,tsx}',
       ],
     },
     testTimeout: 600_0000, // 60 seconds


### PR DESCRIPTION
[about](https://github.com/react-component/util/pull/673) 
同时删除了 项目里面的 `useMountMergeState` 改为统一从 `@rc-component/util` 导入

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 重构
* 优化了内部状态管理机制，提升代码可维护性和一致性
* 清理了模块导入和导出结构，删除不再使用的内部工具
* 调整代码格式，无功能性变化

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->