### PR TITLE
ValueType digitRange 日期显示

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,10 +165,10 @@ importers:
         specifier: ^14.18.63
         version: 14.18.63
       '@types/react':
-        specifier: ^18.3.27
+        specifier: ^18.0.38
         version: 18.3.27
       '@types/react-dom':
-        specifier: ^18.3.7
+        specifier: ^18.0.11
         version: 18.3.7(@types/react@18.3.27)
       '@types/react-helmet':
         specifier: ^6.1.11
@@ -13922,7 +13922,7 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-sequencer@26.6.3(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@14.18.63)(typescript@5.9.3))':
+  '@jest/test-sequencer@26.6.3':
     dependencies:
       '@jest/test-result': 26.6.2
       graceful-fs: 4.2.11
@@ -13930,11 +13930,7 @@ snapshots:
       jest-runner: 26.6.3(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@14.18.63)(typescript@5.9.3))
       jest-runtime: 26.6.3(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@14.18.63)(typescript@5.9.3))
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   '@jest/transform@26.6.2':
     dependencies:
@@ -20746,7 +20742,7 @@ snapshots:
   jest-config@26.6.3(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@14.18.63)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.28.5
-      '@jest/test-sequencer': 26.6.3(ts-node@10.9.2(@swc/core@1.9.2(@swc/helpers@0.5.15))(@types/node@14.18.63)(typescript@5.9.3))
+      '@jest/test-sequencer': 26.6.3
       '@jest/types': 26.6.2
       babel-jest: 26.6.3(@babel/core@7.28.5)
       chalk: 4.1.2

--- a/src/form/BaseForm/LightWrapper/index.tsx
+++ b/src/form/BaseForm/LightWrapper/index.tsx
@@ -84,9 +84,10 @@ const LightWrapper: React.ForwardRefRenderFunction<any, LightWrapperProps> = (
   /** DateRange的转化，dayjs 的 toString 有点不好用 */
   const labelValueText = useMemo(() => {
     if (!labelValue) return labelValue;
+    const lowerValueType = valueType?.toLowerCase?.();
     if (
-      valueType?.toLowerCase()?.endsWith('range') &&
-      valueType !== 'digitRange' &&
+      lowerValueType?.endsWith('range') &&
+      lowerValueType !== 'digitrange' &&
       !labelFormatter
     ) {
       return dateArrayFormatter(

--- a/tests/form/lightFilter.test.tsx
+++ b/tests/form/lightFilter.test.tsx
@@ -7,6 +7,7 @@ import {
   ProFormDateTimeRangePicker,
   ProFormDateWeekRangePicker,
   ProFormDateYearRangePicker,
+  ProFormDigitRange,
   ProFormSelect,
   ProFormSlider,
   ProFormText,
@@ -413,6 +414,39 @@ describe('LightFilter', () => {
     expect(weekLabel).toBe('2023-1st ~ 2023-2nd');
     expect(quarterLabel).toBe('2023-Q1 ~ 2023-Q1');
     expect(yearLabel).toBe('2022 ~ 2023');
+  });
+
+  it(' 🪕 should not format digitRange label as date range', async () => {
+    const { container } = render(
+      <LightFilter
+        initialValues={{
+          digitRange: [12, 34],
+        }}
+      >
+        <ProFormDigitRange
+          name="digitRange"
+          label="数字范围"
+          lightProps={{
+            // Simulate inconsistent casing from user config
+            valueType: 'DigitRange',
+          }}
+        />
+      </LightFilter>,
+    );
+
+    await waitFor(() => {
+      const fieldLabel = container.querySelector('.ant-pro-core-field-label');
+      expect(fieldLabel).toBeTruthy();
+      expect(fieldLabel?.textContent).toContain('数字范围');
+    });
+
+    const fieldLabelText =
+      container.querySelector('.ant-pro-core-field-label')?.textContent || '';
+
+    // If digitRange is mistakenly treated as dateRange, 12/34 would be formatted as timestamps (1970-...)
+    expect(fieldLabelText).not.toContain('1970-');
+    expect(fieldLabelText).toContain('12');
+    expect(fieldLabelText).toContain('34');
   });
 
   it(' 🪕 should support onFinish callback', async () => {


### PR DESCRIPTION
Fixes `digitRange` being incorrectly formatted as a date range in `LightFilter` due to a case-sensitivity mismatch in the `LightWrapper`'s exclusion logic.

The `LightWrapper` used `toLowerCase().endsWith('range')` to identify range types, but its subsequent exclusion for `digitRange` was case-sensitive (`valueType !== 'digitRange'`). This meant if `valueType` was `DigitRange`, it would pass the `endsWith('range')` check but fail the case-sensitive exclusion, leading to it being formatted as a date. The fix unifies the comparison to be case-insensitive for both checks.

---
close https://github.com/ant-design/pro-components/issues/7897


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes label formatting in light filter wrappers to correctly exclude numeric ranges from date-range formatting.
> 
> - Make `valueType` checks case-insensitive in `LightWrapper` using `lowerValueType` and exclude `digitrange` from date formatting
> - Add unit test in `tests/form/lightFilter.test.tsx` ensuring `ProFormDigitRange` labels are not formatted as dates and maintaining existing date range formatting behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f18479984ed848bb3c4c37c05276e7ceae3bd882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了数字范围类型的识别逻辑，现已支持不同大小写格式，提升了类型检测的健壮性。

* **Tests**
  * 新增测试用例验证数字范围类型在表单中的标签展示行为。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->