### PR TITLE
ProLayout menu click area

### DIFF
--- a/src/layout/components/SiderMenu/style/menu.ts
+++ b/src/layout/components/SiderMenu/style/menu.ts
@@ -1,4 +1,4 @@
-﻿import type { GenerateStyle, ProAliasToken } from '../../../../provider';
+import type { GenerateStyle, ProAliasToken } from '../../../../provider';
 import { useStyle as useAntdStyle } from '../../../../provider';
 import type { MenuMode } from '../BaseMenu';
 
@@ -31,8 +31,6 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
         width: '100%',
         height: '100%',
         display: 'inline-flex',
-      },
-      [`${token.antCls}-menu-title-content`]: {
         '&:first-child': {
           width: '100%',
         },
@@ -67,6 +65,7 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
         flexDirection: 'row',
         alignItems: 'center',
         gap: token.marginXS,
+        width: '100%',
         [`${token.componentCls}-item-text`]: {
           maxWidth: '100%',
           textOverflow: 'ellipsis',

--- a/tests/layout/__snapshots__/index.test.tsx.snap
+++ b/tests/layout/__snapshots__/index.test.tsx.snap
@@ -9,14 +9,14 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r63"
+      class="ant-layout ant-layout-has-sider css-var-r6d"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="width: 256px; overflow: hidden; max-width: 256px; min-width: 256px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 256px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r64"
+        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r6e"
         style="max-width: 256px; min-width: 256px; width: 256px; flex-grow: 0; flex-shrink: 0; flex-basis: 256px;"
       >
         <div
@@ -165,7 +165,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
               style="padding: 24px;"
             >
               <div
-                class="ant-skeleton ant-skeleton-active css-var-r64"
+                class="ant-skeleton ant-skeleton-active css-var-r6e"
               >
                 <div
                   class="ant-skeleton-section"
@@ -220,7 +220,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout css-var-r67"
+      class="ant-layout css-var-r6h"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
@@ -384,7 +384,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
                   style="margin-block-start: 16px;"
                 >
                   <div
-                    class="ant-skeleton ant-skeleton-active css-var-r6a"
+                    class="ant-skeleton ant-skeleton-active css-var-r6k"
                   >
                     <div
                       class="ant-skeleton-section"
@@ -416,14 +416,14 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r6d"
+      class="ant-layout ant-layout-has-sider css-var-r6n"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="width: 215px; overflow: hidden; max-width: 215px; min-width: 215px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 215px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-fixed-mix ant-pro-sider-layout-mix ant-pro-sider-light ant-pro-sider-mix css-var-r6e"
+        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-fixed-mix ant-pro-sider-layout-mix ant-pro-sider-light ant-pro-sider-mix css-var-r6o"
         style="max-width: 215px; min-width: 215px; width: 215px; flex-grow: 0; flex-shrink: 0; flex-basis: 215px;"
       >
         <div
@@ -436,7 +436,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
               style="padding: 24px;"
             >
               <div
-                class="ant-skeleton ant-skeleton-active css-var-r6e"
+                class="ant-skeleton ant-skeleton-active css-var-r6o"
               >
                 <div
                   class="ant-skeleton-section"
@@ -862,14 +862,14 @@ exports[`BasicLayout > 🥩 contentStyle should change dom 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r3h"
+      class="ant-layout ant-layout-has-sider css-var-r3r"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="width: 256px; overflow: hidden; max-width: 256px; min-width: 256px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 256px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r3i"
+        class="ant-layout-sider ant-layout-sider-dark ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r3s"
         style="max-width: 256px; min-width: 256px; width: 256px; flex-grow: 0; flex-shrink: 0; flex-basis: 256px;"
       >
         <div
@@ -1018,7 +1018,7 @@ exports[`BasicLayout > 🥩 contentStyle should change dom 1`] = `
               style="padding: 24px;"
             >
               <div
-                class="ant-skeleton ant-skeleton-active css-var-r3i"
+                class="ant-skeleton ant-skeleton-active css-var-r3s"
               >
                 <div
                   class="ant-skeleton-section"

--- a/tests/layout/index.test.tsx
+++ b/tests/layout/index.test.tsx
@@ -55,6 +55,33 @@ describe('BasicLayout', () => {
     html.unmount();
   });
 
+  it('🐞 menuItemRender clickable area should follow full title content', async () => {
+    const wrapper = render(
+      <ProLayout
+        menuDataRender={() => [
+          {
+            path: '/welcome',
+            name: '欢迎',
+          },
+        ]}
+        menuItemRender={(item, dom) => (
+          <div onClick={() => item.path}>{dom}</div>
+        )}
+      />,
+    );
+
+    await waitForWaitTime(100);
+
+    const titleContent = wrapper.baseElement.querySelector<HTMLElement>(
+      '.ant-pro-base-menu-inline .ant-menu-title-content',
+    );
+
+    expect(titleContent).toBeTruthy();
+    expect(getComputedStyle(titleContent!).width).toBe('100%');
+
+    wrapper.unmount();
+  });
+
   it('🥩 support loading', async () => {
     const wrapper = render(
       <ProLayout


### PR DESCRIPTION
Fixes ProLayout menu item's clickable area when `menuItemRender` is used by ensuring the default DOM spans the full width.

The `width/height: 100%` style for `.ant-menu-title-content` was being overridden due to duplicate CSS rules in `src/layout/components/SiderMenu/style/menu.ts`. This caused the default DOM passed to `menuItemRender` to only wrap the text/icon, leading to a smaller clickable area than visually expected. This PR merges the duplicate styles and explicitly sets `width: 100%` for the menu item title container.

---
<a href="https://cursor.com/background-agent?bcId=bc-1db9dc11-29c3-4bfa-bbcd-93b6f20c2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1db9dc11-29c3-4bfa-bbcd-93b6f20c2064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the menu item title content spans the full width so `menuItemRender` click targets match the visible area.
> 
> - Merge duplicate `.ant-menu-title-content` rules in `src/layout/components/SiderMenu/style/menu.ts`; enforce `width/height: 100%` and set `&-item-title` to `width: 100%`
> - Add test verifying the clickable area width with `menuItemRender`; update snapshots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 045157a68d27fce66715afc10d7b3680e9b095aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复菜单项标题宽度显示问题，确保点击区域正确覆盖整个标题内容。

* **Tests**
  * 添加新测试验证自定义菜单项渲染功能。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->