### PR TITLE
Editable onSave record value

### DIFF
--- a/tests/table/protable-editable-onsave-record.test.tsx
+++ b/tests/table/protable-editable-onsave-record.test.tsx
@@ -1,0 +1,131 @@
+import type { ProColumns } from '@ant-design/pro-components';
+import { ProForm, ProTable } from '@ant-design/pro-components';
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { waitForWaitTime } from '../util';
+
+type DataSourceType = {
+  id: number;
+  all_money: number | string;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+function createTable({
+  valueType,
+  onSave,
+}: {
+  valueType: 'digit' | 'text';
+  onSave: (key: any, record: any, origin: any) => Promise<void>;
+}) {
+  const columns: ProColumns<DataSourceType>[] = [
+    {
+      title: '奖励信息',
+      dataIndex: 'all_money',
+      valueType,
+      width: 200,
+      search: false,
+    },
+    {
+      title: '操作',
+      valueType: 'option',
+      render: () => null,
+    },
+  ];
+
+  return (
+    <ProForm
+      submitter={false}
+      initialValues={{
+        test: {
+          table: [{ id: 1, all_money: 10000 }],
+        },
+      }}
+    >
+      <ProTable<DataSourceType>
+        rowKey="id"
+        name={['test', 'table']}
+        columns={columns}
+        options={false}
+        search={false}
+        pagination={false}
+        dataSource={[
+          {
+            id: 1,
+            all_money: 10000,
+          },
+        ]}
+        editable={{
+          editableKeys: ['0'],
+          onSave,
+        }}
+      />
+    </ProForm>
+  );
+}
+
+describe('ProTable editable onSave record', () => {
+  it('should provide latest record for valueType=digit', async () => {
+    const onSave = vi.fn(async () => undefined);
+    const wrapper = render(createTable({ valueType: 'digit', onSave }));
+
+    await waitForWaitTime(200);
+
+    const input = wrapper.container.querySelector(
+      '.ant-table-tbody input',
+    ) as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+
+    act(() => {
+      fireEvent.change(input!, { target: { value: '22' } });
+      fireEvent.blur(input!);
+    });
+
+    await act(async () => {
+      wrapper.getByText('保存').click();
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    const record = onSave.mock.calls[0][1] as any;
+    expect(Number(record.all_money)).toBe(22);
+    expect(record).not.toHaveProperty('0');
+    expect(record).not.toHaveProperty('1');
+  });
+
+  it('should not merge primitive into record for valueType=text', async () => {
+    const onSave = vi.fn(async () => undefined);
+    const wrapper = render(createTable({ valueType: 'text', onSave }));
+
+    await waitForWaitTime(200);
+
+    const input = wrapper.container.querySelector(
+      '.ant-table-tbody input',
+    ) as HTMLInputElement | null;
+    expect(input).toBeTruthy();
+
+    act(() => {
+      fireEvent.change(input!, { target: { value: '22' } });
+      fireEvent.blur(input!);
+    });
+
+    await act(async () => {
+      wrapper.getByText('保存').click();
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    const record = onSave.mock.calls[0][1] as any;
+    expect(String(record.all_money)).toBe('22');
+    expect(record).not.toHaveProperty('0');
+    expect(record).not.toHaveProperty('1');
+  });
+});
+


### PR DESCRIPTION
Fixes `ProTable`/`EditableProTable` `editable.onSave` callback to provide the correct, updated `record` object.

Previously, the `record` parameter in `editable.onSave` would receive outdated values or incorrectly formatted objects (e.g., `{0:'2',1:'2'}` for `valueType='text'`). This was caused by `ProFormContext.getFieldFormatValue` incorrectly "unpacking" object results when `namePath` pointed to a row object, leading to `merge` operations failing or misinterpreting primitive values as arrays. The fix ensures `getFieldFormatValueObject` is used to retrieve the full row object, and `NamePath` segments are normalized for consistent behavior. New test cases have been added to cover `valueType='digit'` and `valueType='text'` scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1510f70-6d1e-496a-9372-4e9f38bbec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1510f70-6d1e-496a-9372-4e9f38bbec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves incorrect `record` passed to `editable.onSave` by stabilizing how row values are read from the form.
> 
> - Introduces `normalizeNamePath` to consistently build `NamePath` (`0` preserved, arrays flattened, numbers stringified)
> - Replaces `getFieldFormatValue` with `getFieldFormatValueObject` + `get(...)` to safely read full row objects for save/cancel flows
> - Applies normalized `namePath` in save/cancel and form reset logic; retains support for array `recordKey` paths
> - Adds tests `protable-editable-onsave-record.test.tsx` covering `valueType='digit'` and `valueType='text'` to verify latest record values and avoid primitive-array merges
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7c3943d97619a1b8c49515e8084a2fb6f3767ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **重构**
  * 优化可编辑表单字段的命名路径构造和值提取机制

* **测试**
  * 新增 ProTable 可编辑功能保存行为的测试用例
  * 验证数字和文本字段类型的值正确保存
  * 确保保存记录仅包含预期字段内容，无冗余数据

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->