### PR TITLE
fix: type error 

### DIFF
--- a/site/components/page-header/index.en-US.md
+++ b/site/components/page-header/index.en-US.md
@@ -16,19 +16,19 @@ PageHeader can be used to highlight the page topic, display important informatio
 
 ## PageHeader
 
-| Param            | Description                                                    | Type                                       | Default value   | Version |
-| ---------------- | -------------------------------------------------------------- | ------------------------------------------ | --------------- | ------- |
-| avatar           | Avatar next to the title bar                                   | [AvatarProps](/components/avatar/)         | -               |         |
-| backIcon         | Custom back icon, if false, the back icon will not be rendered | ReactNode \| boolean                       | \\<ArrowLeft /> |         |
-| breadcrumb       | Breadcrumb configuration                                       | [BreadcrumbProps](/components/breadcrumb/) | -               |         |
-| extra            | Operating area, at the end of the line of the title            | ReactNode                                  | -               |         |
-| ghost            | PageHeader type, will change background color                  | boolean                                    | true            |         |
-| subTitle         | Custom subtitle text                                           | ReactNode                                  | -               |         |
-| tags             | Tag list next to title                                         | [TagProps](/components/tag/)[]             | -               |         |
-| title            | Custom title text                                              | ReactNode                                  | -               |         |
-| onBack           | Back button click event                                        | () => void                                 | -               |         |
-| footer           | PageHeader footer, generally used to render TabBar             | ReactNode                                  | -               |         |
-| breadcrumbRender | Custom breadcrumb area content                                 | (props, originBreadcrumb) => ReactNode     | -               |         |
+| Param            | Description                                                    | Type                                       | Default value  | Version |
+| ---------------- | -------------------------------------------------------------- | ------------------------------------------ | -------------- | ------- |
+| avatar           | Avatar next to the title bar                                   | [AvatarProps](/components/avatar/)         | -              |         |
+| backIcon         | Custom back icon, if false, the back icon will not be rendered | ReactNode \| boolean                       | `<ArrowLeft/>` |         |
+| breadcrumb       | Breadcrumb configuration                                       | [BreadcrumbProps](/components/breadcrumb/) | -              |         |
+| extra            | Operating area, at the end of the line of the title            | ReactNode                                  | -              |         |
+| ghost            | PageHeader type, will change background color                  | boolean                                    | true           |         |
+| subTitle         | Custom subtitle text                                           | ReactNode                                  | -              |         |
+| tags             | Tag list next to title                                         | [TagProps](/components/tag/)[]             | -              |         |
+| title            | Custom title text                                              | ReactNode                                  | -              |         |
+| onBack           | Back button click event                                        | () => void                                 | -              |         |
+| footer           | PageHeader footer, generally used to render TabBar             | ReactNode                                  | -              |         |
+| breadcrumbRender | Custom breadcrumb area content                                 | (props, originBreadcrumb) => ReactNode     | -              |         |
 
 ## Code Examples
 

--- a/site/components/page-header/index.md
+++ b/site/components/page-header/index.md
@@ -16,19 +16,19 @@ cover: https://gw.alipayobjects.com/zos/alicdn/6bKE0Cq0R/PageHeader.svg
 
 ## PageHeader
 
-| 参数             | 说明                                             | 类型                                       | 默认值          | 版本 |
-| ---------------- | ------------------------------------------------ | ------------------------------------------ | --------------- | ---- |
-| avatar           | 标题栏旁的头像                                   | [AvatarProps](/components/avatar/)         | -               |      |
-| backIcon         | 自定义 back icon ，如果为 false 不渲染 back icon | ReactNode \| boolean                       | \\<ArrowLeft /> |      |
-| breadcrumb       | 面包屑的配置                                     | [BreadcrumbProps](/components/breadcrumb/) | -               |      |
-| extra            | 操作区，位于标题行的右侧                         | ReactNode                                  | -               |      |
-| ghost            | pageHeader 的类型，将会改变背景颜色              | boolean                                    | true            |      |
-| subTitle         | 自定义的二级标题文字                             | ReactNode                                  | -               |      |
-| tags             | title 旁的 tag 列表                              | [TagProps](/components/tag/)[]             | -               |      |
-| title            | 自定义标题文字                                   | ReactNode                                  | -               |      |
-| onBack           | 返回按钮的点击事件                               | () => void                                 | -               |      |
-| footer           | PageHeader 的页脚，一般用于渲染 TabBar           | ReactNode                                  | -               |      |
-| breadcrumbRender | 自定义面包屑区域的内容                           | (props, originBreadcrumb) => ReactNode     | -               |      |
+| 参数             | 说明                                             | 类型                                       | 默认值         | 版本 |
+| ---------------- | ------------------------------------------------ | ------------------------------------------ | -------------- | ---- |
+| avatar           | 标题栏旁的头像                                   | [AvatarProps](/components/avatar/)         | -              |      |
+| backIcon         | 自定义 back icon ，如果为 false 不渲染 back icon | ReactNode \| boolean                       | `<ArrowLeft/>` |      |
+| breadcrumb       | 面包屑的配置                                     | [BreadcrumbProps](/components/breadcrumb/) | -              |      |
+| extra            | 操作区，位于标题行的右侧                         | ReactNode                                  | -              |      |
+| ghost            | pageHeader 的类型，将会改变背景颜色              | boolean                                    | true           |      |
+| subTitle         | 自定义的二级标题文字                             | ReactNode                                  | -              |      |
+| tags             | title 旁的 tag 列表                              | [TagProps](/components/tag/)[]             | -              |      |
+| title            | 自定义标题文字                                   | ReactNode                                  | -              |      |
+| onBack           | 返回按钮的点击事件                               | () => void                                 | -              |      |
+| footer           | PageHeader 的页脚，一般用于渲染 TabBar           | ReactNode                                  | -              |      |
+| breadcrumbRender | 自定义面包屑区域的内容                           | (props, originBreadcrumb) => ReactNode     | -              |      |
 
 ## 代码演示
 

--- a/src/form/BaseForm/LightWrapper/index.tsx
+++ b/src/form/BaseForm/LightWrapper/index.tsx
@@ -91,7 +91,7 @@ const LightWrapper: React.ForwardRefRenderFunction<any, LightWrapperProps> = (
     ) {
       return dateArrayFormatter(
         labelValue,
-        (dateFormatterMap as any)[valueType] || 'YYYY-MM-DD',
+        (valueType && (dateFormatterMap as any)[valueType]) || 'YYYY-MM-DD',
       );
     }
     if (Array.isArray(labelValue))

--- a/src/table/components/Form/index.tsx
+++ b/src/table/components/Form/index.tsx
@@ -162,4 +162,4 @@ const isPropsEqual = <T, U>(
   });
 };
 
-export default memo(FormSearch, isPropsEqual);
+export default memo(FormSearch, isPropsEqual) as typeof FormSearch;

--- a/src/table/components/ToolBar/index.tsx
+++ b/src/table/components/ToolBar/index.tsx
@@ -412,4 +412,4 @@ const isPropsEqual = <T,>(
   );
 };
 
-export default memo(ToolbarRender, isPropsEqual);
+export default memo(ToolbarRender, isPropsEqual) as typeof ToolbarRender;


### PR DESCRIPTION
<img width="1642" height="174" alt="8687576f04e163be27a9a29d9e663dcc" src="https://github.com/user-attachments/assets/604f3fe8-1dc5-4273-b6c1-6421b3ee70b8" />
打包时会报这三个类型错误.

同时 当前的文档 https://pro-components.antdigital.dev/components/page-header 由于 ` \\<ArrowLeft />`这样的写法打不开

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了日期范围标签的格式化处理，增强了系统稳定性

* **文档**
  * 规范化了 PageHeader 组件文档格式和内容展示

* **代码质量改进**
  * 优化了组件类型定义，增强 TypeScript 类型推断准确性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->