### PR TITLE
ProTable search form reset

### DIFF
--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -637,7 +637,10 @@ const ProTable = <
       formRef?.current?.resetFields();
 
       // 同步更新请求参数，避免 resetFields 后请求仍使用旧的 formSearch
-      const resetValues = formRef?.current?.getFieldsValue?.(true) ?? {};
+      const resetValues =
+        formRef?.current?.getFieldsFormatValue?.(true) ??
+        formRef?.current?.getFieldsValue?.(true) ??
+        {};
       const nextSearch = beforeSearchSubmit
         ? beforeSearchSubmit(resetValues)
         : resetValues;


### PR DESCRIPTION
Update `ProTable`'s `resetAll` to use `getFieldsFormatValue` to ensure correct value types are preserved after form reset.

The previous implementation used `form.getFieldsValue(true)`, which returned raw form values (e.g., `Dayjs` objects for date fields). This could lead to inconsistencies when the `request` function expected formatted string values, causing issues with search form resets. Switching to `form.getFieldsFormatValue(true)` ensures that values are transformed according to `valueType` or `transform` configurations before being passed to `request`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3de2a7c9-70d1-4f41-a250-1659872ac20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3de2a7c9-70d1-4f41-a250-1659872ac20c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

