### PR TITLE
Cascader onOpenChange migration

### DIFF
--- a/src/field/components/Cascader/index.tsx
+++ b/src/field/components/Cascader/index.tsx
@@ -109,8 +109,7 @@ const FieldCascader: ProFieldFC<GroupProps> = (
   }
 
   if (mode === 'edit') {
-    const { onDropdownVisibleChange, ...fieldProps } = (rest.fieldProps ||
-      {}) as any;
+    const fieldProps = rest.fieldProps || {};
 
     let dom = (
       <Cascader


### PR DESCRIPTION
Remove deprecated `onDropdownVisibleChange` prop from `FieldCascader` to align with Ant Design's `Cascader` component API.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f83d10-2a5f-4ea0-b68a-499361378a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18f83d10-2a5f-4ea0-b68a-499361378a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 改进级联选择器组件的属性处理与事件响应机制，提升组件在各种使用场景下的稳定性和一致性，确保功能的正常运行

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->