### PR TITLE
Antd断点值配置

### DIFF
--- a/src/utils/useMediaQuery/index.ts
+++ b/src/utils/useMediaQuery/index.ts
@@ -1,34 +1,38 @@
-﻿import { useEffect, useState } from 'react';
+import { theme } from 'antd';
+import { useEffect, useState } from 'react';
 import useMediaQuery from './query';
+
+const { getDesignToken } = theme;
+const token = getDesignToken();
 
 export const MediaQueryEnum = {
   xs: {
-    maxWidth: 575,
-    matchMedia: '(max-width: 575px)',
+    maxWidth: token.screenXSMax,
+    matchMedia: `(max-width: ${token.screenXSMax}px)`,
   },
   sm: {
-    minWidth: 576,
-    maxWidth: 767,
-    matchMedia: '(min-width: 576px) and (max-width: 767px)',
+    minWidth: token.screenSMMin,
+    maxWidth: token.screenSMMax,
+    matchMedia: `(min-width: ${token.screenSMMin}px) and (max-width: ${token.screenSMMax}px)`,
   },
   md: {
-    minWidth: 768,
-    maxWidth: 991,
-    matchMedia: '(min-width: 768px) and (max-width: 991px)',
+    minWidth: token.screenMDMin,
+    maxWidth: token.screenMDMax,
+    matchMedia: `(min-width: ${token.screenMDMin}px) and (max-width: ${token.screenMDMax}px)`,
   },
   lg: {
-    minWidth: 992,
-    maxWidth: 1199,
-    matchMedia: '(min-width: 992px) and (max-width: 1199px)',
+    minWidth: token.screenLGMin,
+    maxWidth: token.screenLGMax,
+    matchMedia: `(min-width: ${token.screenLGMin}px) and (max-width: ${token.screenLGMax}px)`,
   },
   xl: {
-    minWidth: 1200,
-    maxWidth: 1599,
-    matchMedia: '(min-width: 1200px) and (max-width: 1599px)',
+    minWidth: token.screenXLMin,
+    maxWidth: token.screenXLMax,
+    matchMedia: `(min-width: ${token.screenXLMin}px) and (max-width: ${token.screenXLMax}px)`,
   },
   xxl: {
-    minWidth: 1600,
-    matchMedia: '(min-width: 1600px)',
+    minWidth: token.screenXXLMin,
+    matchMedia: `(min-width: ${token.screenXXLMin}px)`,
   },
 };
 


### PR DESCRIPTION
Refactor `MediaQueryEnum` to use Ant Design theme tokens for grid breakpoints to ensure consistency and eliminate hardcoded values.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1724e0f-8388-429c-9d7e-e75bfedd0f75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1724e0f-8388-429c-9d7e-e75bfedd0f75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 媒体查询断点值现已与设计系统令牌相关联，替代硬编码值。响应式布局断点现可动态同步设计令牌配置，确保应用视觉一致性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->