### PR TITLE
List renderItem card issue

### DIFF
--- a/src/list/ListView.tsx
+++ b/src/list/ListView.tsx
@@ -311,7 +311,17 @@ function ListView<RecordType extends AnyObject>(
         );
 
         if (renderItem) {
-          return renderItem(item, index, defaultDom);
+          const customDom = renderItem(item, index, defaultDom);
+          // When grid mode is enabled, wrap the renderItem result with card wrapper
+          // to ensure the Card appearance is preserved even when user doesn't use defaultDom
+          if (rest.grid) {
+            return (
+              <div className={clsx(hashId, `${prefixCls}-row-card`)}>
+                {customDom}
+              </div>
+            );
+          }
+          return customDom;
         }
         return defaultDom;
       }}

--- a/tests/list/__snapshots__/index.test.tsx.snap
+++ b/tests/list/__snapshots__/index.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`List > 🚏 ProList support rowClassName as a function 1`] = `
     class="ant-pro-table ant-pro-list ant-pro-list ant-pro-list-no-split"
   >
     <div
-      class="ant-list ant-list-split ant-pro-list-container css-var-r2f"
+      class="ant-list ant-list-split ant-pro-list-container css-var-r2n"
     >
       <div
-        class="ant-spin-nested-loading css-var-r2f"
+        class="ant-spin-nested-loading css-var-r2n"
       >
         <div
           class="ant-spin-container"
@@ -30,7 +30,7 @@ exports[`List > 🚏 ProList support rowClassName as a function 1`] = `
                     class="ant-pro-list-row-checkbox"
                   >
                     <label
-                      class="ant-checkbox-wrapper css-var-r2f ant-checkbox-css-var"
+                      class="ant-checkbox-wrapper css-var-r2n ant-checkbox-css-var"
                     >
                       <span
                         class="ant-checkbox ant-wave-target"
@@ -91,7 +91,7 @@ exports[`List > 🚏 ProList support rowClassName as a function 1`] = `
                     class="ant-pro-list-row-checkbox"
                   >
                     <label
-                      class="ant-checkbox-wrapper css-var-r2f ant-checkbox-css-var"
+                      class="ant-checkbox-wrapper css-var-r2n ant-checkbox-css-var"
                     >
                       <span
                         class="ant-checkbox ant-wave-target"
@@ -153,10 +153,10 @@ exports[`List > 🚏 ProList support rowClassName as a string 1`] = `
     class="ant-pro-table ant-pro-list ant-pro-list ant-pro-list-no-split"
   >
     <div
-      class="ant-list ant-list-split ant-pro-list-container css-var-r2b"
+      class="ant-list ant-list-split ant-pro-list-container css-var-r2j"
     >
       <div
-        class="ant-spin-nested-loading css-var-r2b"
+        class="ant-spin-nested-loading css-var-r2j"
       >
         <div
           class="ant-spin-container"
@@ -177,7 +177,7 @@ exports[`List > 🚏 ProList support rowClassName as a string 1`] = `
                     class="ant-pro-list-row-checkbox"
                   >
                     <label
-                      class="ant-checkbox-wrapper css-var-r2b ant-checkbox-css-var"
+                      class="ant-checkbox-wrapper css-var-r2j ant-checkbox-css-var"
                     >
                       <span
                         class="ant-checkbox ant-wave-target"

--- a/tests/list/index.test.tsx
+++ b/tests/list/index.test.tsx
@@ -418,6 +418,61 @@ describe('List', () => {
     expect(screen.getByTestId('test_index')).toHaveTextContent('0');
   });
 
+  it('🚏 ProList support renderItem with grid should keep Card wrapper', async () => {
+    const { container } = reactRender(
+      <ProList
+        dataSource={[
+          {
+            name: '我是名称',
+            content: <div>我是内容</div>,
+          },
+        ]}
+        grid={{ gutter: 16, column: 2 }}
+        renderItem={(item, index, defaultDom) => {
+          return <div data-testid="custom-item">{defaultDom}</div>;
+        }}
+        rowKey={(item) => {
+          return item.name;
+        }}
+        metas={{
+          title: {
+            dataIndex: 'name',
+          },
+        }}
+      />,
+    );
+
+    // Should have Card wrapper when using grid mode with renderItem
+    expect(container.querySelector('.ant-pro-checkcard')).toBeTruthy();
+  });
+
+  it('🚏 ProList support renderItem with grid without using defaultDom should keep Card wrapper', async () => {
+    const { container } = reactRender(
+      <ProList
+        dataSource={[
+          {
+            name: '我是名称',
+            content: <div>我是内容</div>,
+          },
+        ]}
+        grid={{ gutter: 16, column: 2 }}
+        renderItem={(item, index) => {
+          return <div data-testid="custom-content">自定义内容: {item.name}</div>;
+        }}
+        rowKey={(item) => {
+          return item.name;
+        }}
+      />,
+    );
+
+    // Should have Card wrapper container even when user doesn't use defaultDom
+    // The card wrapper has class `ant-pro-list-row-card`
+    expect(container.querySelector('.ant-pro-list-row-card')).toBeTruthy();
+    expect(screen.getByTestId('custom-content')).toHaveTextContent(
+      '自定义内容: 我是名称',
+    );
+  });
+
   it('🚏 rowSelection', async () => {
     const Wrapper = () => {
       return (


### PR DESCRIPTION
Ensures `ProList` items retain their Card wrapper when `renderItem` is customized in `grid` mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0de63bb-eced-4867-a6e0-da1e25c5ad45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0de63bb-eced-4867-a6e0-da1e25c5ad45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

