### PR TITLE
style:ProFormDigitRange将宽度调整为父元素宽度

### DIFF
--- a/src/field/components/DigitRange/index.tsx
+++ b/src/field/components/DigitRange/index.tsx
@@ -122,7 +122,7 @@ const FieldDigitRange: ProFieldFC<FieldDigitRangeProps> = (
         : placeholderValue;
 
     const dom = (
-      <Space.Compact onBlur={handleGroupBlur}>
+      <Space.Compact block onBlur={handleGroupBlur}>
         <InputNumber<number>
           {...fieldProps}
           placeholder={getInputNumberPlaceholder(0)}


### PR DESCRIPTION
优化ProFormDigitRange宽度默认占满
<img width="783" height="188" alt="ScreenShot_2026-01-30_175600_248" src="https://github.com/user-attachments/assets/dee47842-5003-4179-8307-6cce8a251e76" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **样式改进**
  * 数字范围字段编辑界面现在以全宽方式显示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->