### PR TITLE
列表头部对齐

### DIFF
--- a/src/table/components/ListToolBar/style.ts
+++ b/src/table/components/ListToolBar/style.ts
@@ -14,7 +14,7 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
         display: 'flex',
         justifyContent: 'space-between',
         paddingBlock: token.padding,
-        paddingInline: 0,
+        paddingInline: token.paddingXS,
         '&-mobile': { flexDirection: 'column' },
       },
       '&-title': {


### PR DESCRIPTION
Adjust `paddingInline` for `ListToolBar` container to align it with list items.

The `ListToolBar` container previously had no horizontal padding (`paddingInline: 0`), while list items had `padding: token.paddingXS`, causing misalignment between the header and list content. This change unifies the horizontal padding to `token.paddingXS`.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f2ac74cc-ea7d-4c15-960c-8031c487650b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2ac74cc-ea7d-4c15-960c-8031c487650b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CSS token change limited to the list toolbar container; low risk aside from minor layout shifts in consumers.
> 
> **Overview**
> Adjusts `ListToolBar` header layout by changing the container’s horizontal padding from `0` to `token.paddingXS`, aligning the toolbar content with the list item padding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c90d283cf1f525c83e6cec823702d11773f6570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式**
  * 优化列表工具栏的水平间距，使用设计规范的间距标准，提升界面视觉一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->