### PR TITLE
表单唯一名称

### DIFF
--- a/src/form/BaseForm/BaseForm.tsx
+++ b/src/form/BaseForm/BaseForm.tsx
@@ -187,7 +187,7 @@ export type CommonFormProps<
   /** 是否回车提交 */
   isKeyPressSubmit?: boolean;
 
-  /** 用于控制form 是否相同的key，高阶用法 */
+  /** 用于控制 form 是否相同的 key，高阶用法 */
   formKey?: string;
 
   /**
@@ -630,8 +630,11 @@ function BaseFormComponents<T = Record<string, any>, U = Record<string, any>>(
   );
 }
 
-/** 自动的formKey 防止重复 */
+/** 自动的 formKey 防止重复 */
 let requestFormCacheId = 0;
+
+/** 为表单生成唯一 name 的自增计数器，用于未显式指定 name 时 */
+let formNameCounter = 0;
 
 export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
   props: BaseFormProps<T, U>,
@@ -706,6 +709,10 @@ export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
     { disabled: !syncToUrl },
   );
   const curFormKey = useRef<string>(nanoid());
+  const formNameRef = useRef<string | null>(null);
+  if (formNameRef.current === null) {
+    formNameRef.current = `pro-form-${formNameCounter++}`;
+  }
 
   useEffect(() => {
     requestFormCacheId += 0;
@@ -961,6 +968,7 @@ export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
                 'labelWidth',
                 'autoFocusFirstInput',
               ] as any[])}
+              name={propRest.name ?? formNameRef.current!}
               ref={(instance) => {
                 if (!formRef.current) return;
                 formRef.current.nativeElement = instance?.nativeElement;

--- a/tests/form/__snapshots__/base.test.tsx.snap
+++ b/tests/form/__snapshots__/base.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`ProForm > 📦 submit props actionsRender is one 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r19 ant-form-css-var ant-pro-form"
+    id="pro-form-13"
   >
     <input
       style="display: none;"
@@ -22,6 +23,7 @@ exports[`ProForm > 📦 submit props actionsRender=()=>[] 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r1r ant-form-css-var ant-pro-form"
+    id="pro-form-19"
   >
     <input
       style="display: none;"
@@ -36,6 +38,7 @@ exports[`ProForm > 📦 submit props actionsRender=()=>false 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r16 ant-form-css-var ant-pro-form"
+    id="pro-form-12"
   >
     <input
       style="display: none;"
@@ -51,6 +54,7 @@ exports[`ProForm > 📦 submit props actionsRender=false 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r1 ant-form-css-var ant-pro-form"
+    id="pro-form-0"
   >
     <input
       style="display: none;"
@@ -65,6 +69,7 @@ exports[`ProForm > 📦 submit props actionsRender=false 2`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r1o ant-form-css-var ant-pro-form"
+    id="pro-form-18"
   >
     <input
       style="display: none;"
@@ -79,6 +84,7 @@ exports[`ProForm > 📦 submit props render=()=>[] 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r1u ant-form-css-var ant-pro-form"
+    id="pro-form-20"
   >
     <input
       style="display: none;"
@@ -101,6 +107,7 @@ exports[`ProForm > 📦 submitted value should be consistent with input when pre
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-rbd ant-form-css-var ant-pro-form"
+    id="pro-form-66"
   >
     <input
       style="display: none;"
@@ -117,7 +124,7 @@ exports[`ProForm > 📦 submitted value should be consistent with input when pre
         >
           <label
             class=""
-            for="count"
+            for="pro-form-66_count"
             title="人数"
           >
             人数
@@ -141,7 +148,7 @@ exports[`ProForm > 📦 submitted value should be consistent with input when pre
                   aria-valuenow="22"
                   autocomplete="off"
                   class="ant-input-number-input"
-                  id="count"
+                  id="pro-form-66_count"
                   placeholder="请输入"
                   role="spinbutton"
                   step="1"
@@ -240,6 +247,7 @@ exports[`ProForm > 📦 submitter props support resetButtonProps 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r24 ant-form-css-var ant-pro-form"
+    id="pro-form-22"
   >
     <input
       style="display: none;"
@@ -274,6 +282,7 @@ exports[`ProForm > 📦 submitter props support submitButtonProps 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-r21 ant-form-css-var ant-pro-form"
+    id="pro-form-21"
   >
     <input
       style="display: none;"
@@ -308,6 +317,7 @@ exports[`ProForm > 📦 validateFieldsReturnFormatValue 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-ra7 ant-form-css-var ant-pro-form"
+    id="pro-form-60"
   >
     <input
       style="display: none;"
@@ -337,7 +347,7 @@ exports[`ProForm > 📦 validateFieldsReturnFormatValue 1`] = `
                   <input
                     aria-invalid="false"
                     autocomplete="off"
-                    id="date"
+                    id="pro-form-60_date"
                     placeholder="请选择"
                     size="12"
                     value="2021-07-28"
@@ -426,6 +436,7 @@ exports[`ProForm > 📦 valueType digit with precision value 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-rb8 ant-form-css-var ant-pro-form"
+    id="pro-form-65"
   >
     <input
       style="display: none;"
@@ -442,7 +453,7 @@ exports[`ProForm > 📦 valueType digit with precision value 1`] = `
         >
           <label
             class=""
-            for="count"
+            for="pro-form-65_count"
             title="人数"
           >
             人数
@@ -466,7 +477,7 @@ exports[`ProForm > 📦 valueType digit with precision value 1`] = `
                   aria-valuenow="22"
                   autocomplete="off"
                   class="ant-input-number-input"
-                  id="count"
+                  id="pro-form-65_count"
                   placeholder="请输入"
                   role="spinbutton"
                   step="1"
@@ -565,6 +576,7 @@ exports[`ProForm > 📦 when dateFormatter is a Function 1`] = `
   <form
     autocomplete="off"
     class="ant-form ant-form-vertical css-var-raj ant-form-css-var ant-pro-form"
+    id="pro-form-62"
   >
     <input
       style="display: none;"
@@ -594,7 +606,7 @@ exports[`ProForm > 📦 when dateFormatter is a Function 1`] = `
                   <input
                     aria-invalid="false"
                     autocomplete="off"
-                    id="datetime"
+                    id="pro-form-62_datetime"
                     placeholder="请选择"
                     size="21"
                     value="2021-08-09 12:12:12"
@@ -665,7 +677,7 @@ exports[`ProForm > 📦 when dateFormatter is a Function 1`] = `
         >
           <label
             class=""
-            for="time2"
+            for="pro-form-62_time2"
             title="时间"
           >
             时间
@@ -689,7 +701,7 @@ exports[`ProForm > 📦 when dateFormatter is a Function 1`] = `
                   <input
                     aria-invalid="false"
                     autocomplete="off"
-                    id="time2"
+                    id="pro-form-62_time2"
                     placeholder="请选择时间"
                     size="10"
                     value=""

--- a/tests/form/base.test.tsx
+++ b/tests/form/base.test.tsx
@@ -718,7 +718,7 @@ describe('ProForm', () => {
 
     act(() => {
       fireEvent.change(
-        wrapper.baseElement.querySelectorAll<HTMLElement>('input#name')[0],
+        wrapper.baseElement.querySelector<HTMLElement>('input[id$="_name"]')!,
         {
           target: {
             value: 'test',
@@ -915,7 +915,7 @@ describe('ProForm', () => {
     await wrapper.findByText('提 交');
     act(() => {
       fireEvent.change(
-        wrapper.baseElement.querySelectorAll<HTMLElement>('input#name')[0],
+        wrapper.baseElement.querySelector<HTMLElement>('input[id$="_name"]')!,
         {
           target: {
             value: 'test',
@@ -926,9 +926,9 @@ describe('ProForm', () => {
 
     act(() => {
       fireEvent.change(
-        wrapper.baseElement.querySelectorAll<HTMLElement>(
-          'input#name2_text',
-        )[0],
+        wrapper.baseElement.querySelector<HTMLElement>(
+          'input[id$="_name2_text"]',
+        )!,
         {
           target: {
             value: 'test2',
@@ -3603,7 +3603,9 @@ describe('ProForm', () => {
     await waitForWaitTime(300);
     act(() => {
       const dom =
-        html.baseElement.querySelector<HTMLInputElement>('input#count')!;
+        html.baseElement.querySelector<HTMLInputElement>(
+          'input[id$="_count"]',
+        )!;
       fireEvent.change(dom, {
         target: {
           value: '22.22',
@@ -3614,7 +3616,9 @@ describe('ProForm', () => {
     });
     await waitForWaitTime(300);
     expect(
-      html.baseElement.querySelector<HTMLInputElement>('input#count')?.value,
+      html.baseElement.querySelector<HTMLInputElement>(
+        'input[id$="_count"]',
+      )?.value,
     ).toBe('22');
 
     await act(async () => {
@@ -3647,7 +3651,9 @@ describe('ProForm', () => {
     await waitForWaitTime(100);
 
     const dom =
-      html.baseElement.querySelector<HTMLInputElement>('input#count')!;
+      html.baseElement.querySelector<HTMLInputElement>(
+        'input[id$="_count"]',
+      )!;
 
     await act(async () => {
       fireEvent.change(dom, {


### PR DESCRIPTION
Automatically assign a unique `name` to forms when not provided to ensure unique form and input IDs and stabilize snapshot tests.

Initially, `nanoid` was used for unique IDs, but this caused instability in snapshot tests. The implementation was revised to use an auto-incrementing counter (`pro-form-0`, `pro-form-1`, etc.) to provide stable and predictable form IDs, which Ant Design's `Form` uses as its `id` and prefixes for child input IDs.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-43fc5764-8fd6-403f-bb0d-70fc8fba26e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-43fc5764-8fd6-403f-bb0d-70fc8fba26e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

