### PR TITLE
ProCard collapsible 图标失效

### DIFF
--- a/demos/card/collapsible.tsx
+++ b/demos/card/collapsible.tsx
@@ -112,6 +112,23 @@ export default () => {
           Content
         </ProCard>
         <ProCard
+          title="Collapsible - Custom Icon (Controlled)"
+          collapsibleIconRender={({
+            collapsed: buildInCollapsed,
+          }: {
+            collapsed: boolean;
+          }) =>
+            buildInCollapsed ? <span>Collapse - </span> : <span>Expand - </span>
+          }
+          style={{ marginBlockStart: 16 }}
+          headerBordered
+          collapsible
+          collapsed={collapsed}
+          onCollapse={setCollapsed}
+        >
+          Content
+        </ProCard>
+        <ProCard
           title="Collapsible - Custom Icon"
           collapsibleIconRender={({
             collapsed: buildInCollapsed,

--- a/src/card/components/Card/index.tsx
+++ b/src/card/components/Card/index.tsx
@@ -247,10 +247,8 @@ const Card = React.forwardRef((props: CardProps, ref: any) => {
     if (collapsible === 'icon') setCollapsed((prev) => !prev);
   }, [collapsible, setCollapsed]);
 
-  // 非受控情况下展示
   const collapsibleButton =
     collapsible &&
-    controlCollapsed === undefined &&
     (collapsibleIconRender ? (
       <span
         role="button"

--- a/tests/card/index.test.tsx
+++ b/tests/card/index.test.tsx
@@ -193,6 +193,44 @@ describe('Card', () => {
     });
   });
 
+  it('🥩 collapsible icon custom render with controlled collapsed', async () => {
+    const fn = vi.fn();
+    const wrapper = render(
+      <ProCard
+        title="可折叠-受控模式"
+        collapsibleIconRender={({ collapsed }: { collapsed: boolean }) =>
+          collapsed ? <span>更多</span> : <span>收起</span>
+        }
+        headerBordered
+        collapsible
+        collapsed
+        onCollapse={fn}
+      >
+        内容
+      </ProCard>,
+    );
+    await wrapper.findAllByText('可折叠-受控模式');
+
+    expect(
+      !!wrapper.baseElement.querySelector<HTMLDivElement>(
+        '.ant-pro-card-collapse',
+      ),
+    ).toBeTruthy();
+
+    const dom = await wrapper.findByText('更多');
+    expect(!!dom).toBe(true);
+
+    act(() => {
+      wrapper.baseElement
+        .querySelector<HTMLDivElement>('.ant-pro-card-collapsible-icon')
+        ?.click();
+    });
+
+    await waitFor(() => {
+      expect(fn).toHaveBeenCalledWith(false);
+    });
+  });
+
   it('🥩 tabs onChange', async () => {
     const fn = vi.fn();
     const wrapper = render(


### PR DESCRIPTION
Fix `collapsibleIconRender` not displaying when `ProCard` is in controlled `collapsed` mode.

The `collapsibleButton` rendering condition incorrectly checked for `controlCollapsed === undefined`, preventing the icon from showing when `collapsed` was explicitly controlled. This PR removes that condition, adds a test case for controlled `collapsibleIconRender`, and updates the demo.

---
close  https://github.com/ant-design/pro-components/issues/9428



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **新功能**
  * 可折叠卡片现在支持在受控模式下自定义图标渲染，用户可根据折叠状态动态显示不同的图标或文本

* **改进**
  * 优化了可折叠卡片的图标显示逻辑，使自定义图标功能在受控和非受控两种模式下均可使用

* **测试**
  * 添加新的测试用例，确保受控模式下的自定义图标渲染功能正常工作

<!-- end of auto-generated comment: release notes by coderabbit.ai -->