### PR TITLE
修复 ProList 分页器边距不生效的问题

### DIFF
--- a/src/list/style/index.ts
+++ b/src/list/style/index.ts
@@ -87,6 +87,11 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
       [`${token.proComponentsCls}-table-alert`]: {
         marginBlockEnd: token.margin,
       },
+      [`${token.proComponentsCls}-list-pagination`]: {
+        marginBlockStart: token.margin,
+        marginBlockEnd: 0,
+        marginInline: 0,
+      },
       [`${token.proComponentsCls}-list-item`]: {
         display: 'flex',
         flexDirection: 'row',
@@ -249,10 +254,6 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
           [`${token.proComponentsCls}-list-item-extra`]: {
             display: 'none',
           },
-        },
-        [`${token.proComponentsCls}-list-pagination`]: {
-          marginBlockStart: token.margin,
-          marginBlockEnd: token.margin,
         },
         [`${token.proComponentsCls}-list-list`]: {
           '&-item': {
@@ -569,11 +570,6 @@ const genProListStyle: GenerateStyle<ProListToken> = (token) => {
         '&-checkbox': {
           width: token.fontSizeLG,
           marginInlineEnd: token.marginSM,
-        },
-
-        [`${token.proComponentsCls}-list-pagination`]: {
-          marginBlockStart: token.margin,
-          marginBlockEnd: token.margin,
         },
         [`${token.proComponentsCls}-list-list`]: {
           '&-item': {


### PR DESCRIPTION
修复分页器边距不生效的问题，将 `ant-pro-list-pagination` 样式从 `&-row` 嵌套内提升至 componentCls 顶层（pagination 与 row 为兄弟节点，原选择器无法匹配）

分页器样式调整为 `marginBlockStart: token.margin`、`marginBlockEnd: 0`、`marginInline: 0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **样式改进**
  * 优化列表分页组件的间距设置
  * 调整列表项内容的垂直对齐方式
  * 消除样式冲突并确保列表样式在不同布局中的一致性应用

<!-- end of auto-generated comment: release notes by coderabbit.ai -->