### PR TITLE
fix(provider): avoid stale styles when toggling dark/light theme

### DIFF
--- a/src/provider/useStyle/index.ts
+++ b/src/provider/useStyle/index.ts
@@ -4,7 +4,7 @@ import { TinyColor } from '@ctrl/tinycolor';
 import { ConfigProvider as AntdConfigProvider, theme as antdTheme } from 'antd';
 import type { GlobalToken } from 'antd/lib/theme/interface';
 import type React from 'react';
-import { useContext } from 'react';
+import { useContext, useMemo, useRef } from 'react';
 import { ProProvider } from '../index';
 import type { ProTokenType } from '../typing/layoutToken';
 
@@ -90,6 +90,24 @@ export const operationUnit = (token: ProAliasToken): CSSObject => ({
   },
 });
 
+const hashString = (input: string): string => {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const getProTokenKey = (token: ProAliasToken): string => {
+  try {
+    // ProProvider exposes finalToken instead of useCacheToken token,
+    // so build a stable key from Pro token payload directly.
+    return hashString(JSON.stringify(token));
+  } catch {
+    return '';
+  }
+};
+
 /**
  * 封装了一下 antd 的 useStyle
  * @param componentName {string} 组件的名字
@@ -117,11 +135,38 @@ export function useStyle(
   token.antCls = `.${getPrefixCls()}`;
 
   // Register styles (side effect only in v2)
+  // Keep path sensitive to both antd theme and Pro token updates.
+  const proTokenKey = useMemo(() => {
+    return getProTokenKey(token as ProAliasToken);
+  }, [token]);
+
+  // Keep path monotonic across toggles to avoid style order issues
+  // when switching dark -> light (back to an old key).
+  const styleKey = [
+    hashId,
+    (theme as any).id,
+    token.themeId,
+    proTokenKey,
+  ]
+    .filter(Boolean)
+    .join('-');
+
+  const lastStyleKeyRef = useRef<string>('');
+  const styleVersionRef = useRef(0);
+  if (lastStyleKeyRef.current !== styleKey) {
+    styleVersionRef.current += 1;
+    lastStyleKeyRef.current = styleKey;
+  }
+
+  const stylePath = [componentName, styleKey, styleVersionRef.current].filter(
+    Boolean,
+  );
+
   useStyleRegister(
     {
       theme: theme as any,
       token,
-      path: [componentName],
+      path: stylePath,
       nonce: csp?.nonce,
       layer: {
         name: 'antd-pro',
@@ -130,7 +175,6 @@ export function useStyle(
     () => styleFn(token as ProAliasToken),
   );
 
-  // Return identity wrapper and hashId
   return {
     wrapSSR: (node: React.ReactElement) => node,
     hashId: hashed ? hashId : '',


### PR DESCRIPTION
## Summary
- avoid stale styles when toggling dark/light theme
- make style registration path theme-sensitive
- ensure each theme-key change gets a fresh style path version to prevent style order/cache conflicts
- keep current `wrapSSR` identity behavior unchanged

## Background
`useStyle` in provider registers styles via `useStyleRegister` with side effects. With a static path key, switching theme could reuse stale style cache/order and make styles not fully recover when toggling back.

## Fix
- derive a theme-aware `styleKey` from `hashId`, `theme.id`, `token._tokenKey`, and `token.themeId`
- track key changes and increment a local version so style path stays monotonic across toggles
- pass `[componentName, styleKey, version]` to `useStyleRegister`

## Repro
1. Open ProLayout demo with theme switcher
2. Toggle light -> dark -> light
3. Before: can get stale dark styles after toggling back
4. After: styles switch correctly in both directions

## Related
- Closes #9373


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化样式注册机制，增强主题切换过程中的稳定性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->