### PR TITLE
视图测试ID

### DIFF
--- a/src/layout/ProLayout.tsx
+++ b/src/layout/ProLayout.tsx
@@ -804,7 +804,7 @@ const BaseProLayout: React.FC<ProLayoutProps> = (props) => {
       {props.pure ? (
         <>{children}</>
       ) : (
-        <div className={className}>
+        <div className={className} data-testid="pro-layout">
           {bgImgStyleList || token.layout?.bgLayout ? (
             <div className={clsx(`${proLayoutClassName}-bg-list`, hashId)}>
               {bgImgStyleList}

--- a/src/layout/WrapContent.tsx
+++ b/src/layout/WrapContent.tsx
@@ -26,12 +26,20 @@ const WrapContent: React.FC<{
 
   const ErrorComponent = props.ErrorBoundary || ErrorBoundary;
   return props.ErrorBoundary === false ? (
-    <Layout.Content className={contentClassName} style={style}>
+    <Layout.Content
+      className={contentClassName}
+      style={style}
+      data-testid="pro-layout-content"
+    >
       {children}
     </Layout.Content>
   ) : (
     <ErrorComponent>
-      <Layout.Content className={contentClassName} style={style}>
+      <Layout.Content
+        className={contentClassName}
+        style={style}
+        data-testid="pro-layout-content"
+      >
         {children}
       </Layout.Content>
     </ErrorComponent>

--- a/src/layout/components/Footer.tsx
+++ b/src/layout/components/Footer.tsx
@@ -29,7 +29,11 @@ const DefaultFooter: React.FC<FooterProps> = ({
   className,
   prefixCls,
 }: FooterProps) => (
-  <Footer className={className} style={{ padding: 0, ...style }}>
+  <Footer
+    className={className}
+    style={{ padding: 0, ...style }}
+    data-testid="pro-layout-footer"
+  >
     <GlobalFooter
       links={links}
       prefixCls={prefixCls}

--- a/src/layout/components/GlobalFooter/index.tsx
+++ b/src/layout/components/GlobalFooter/index.tsx
@@ -41,7 +41,11 @@ const GlobalFooter = ({
   }
 
   return wrapSSR(
-    <div className={clsx(baseClassName, hashId, className)} style={style}>
+    <div
+      className={clsx(baseClassName, hashId, className)}
+      style={style}
+      data-testid="pro-global-footer"
+    >
       {links && (
         <div className={clsx(`${baseClassName}-list`, hashId)}>
           {links.map((link) => (

--- a/src/layout/components/GlobalHeader/index.tsx
+++ b/src/layout/components/GlobalHeader/index.tsx
@@ -145,7 +145,11 @@ const GlobalHeader: React.FC<GlobalHeaderProps & PrivateSiderMenuProps> = (
     </span>
   );
   return wrapSSR(
-    <div className={className} style={{ ...style }}>
+    <div
+      className={className}
+      style={{ ...style }}
+      data-testid="pro-layout-global-header"
+    >
       {isMobile && (
         <span
           className={clsx(`${baseClassName}-collapsed-button`, hashId)}

--- a/src/layout/components/GridContent/index.tsx
+++ b/src/layout/components/GridContent/index.tsx
@@ -42,6 +42,7 @@ const GridContent: React.FC<GridContentProps> = (props) => {
         [`${className}-wide`]: isWide,
       })}
       style={style}
+      data-testid="pro-grid-content"
     >
       <div className={clsx(`${prefixCls}-grid-content-children`, hashId)}>
         {children}

--- a/src/layout/components/Header/index.tsx
+++ b/src/layout/components/Header/index.tsx
@@ -157,7 +157,11 @@ const DefaultHeader: React.FC<HeaderViewProps & PrivateSiderMenuProps> = (
               }}
             />
           )}
-          <Header className={className} style={style}>
+          <Header
+            className={className}
+            style={style}
+            data-testid="pro-layout-header"
+          >
             {renderContent()}
           </Header>
         </ConfigProvider>

--- a/src/layout/components/PageContainer/index.tsx
+++ b/src/layout/components/PageContainer/index.tsx
@@ -420,7 +420,11 @@ const PageContainerBase: React.FC<PageContainerProps> = (props) => {
   return wrapSSR(
     stylish.wrapSSR(
       <>
-        <div style={style} className={containerClassName}>
+        <div
+          style={style}
+          className={containerClassName}
+          data-testid="pro-page-container"
+        >
           {fixedHeader && pageHeaderDom ? (
             // 在 hasHeader 且 fixedHeader 的情况下，才需要设置高度
             <Affix

--- a/src/layout/components/PageHeader/index.tsx
+++ b/src/layout/components/PageHeader/index.tsx
@@ -227,7 +227,12 @@ const PageHeader: React.FC<PageHeaderProps> = (props) => {
   return wrapSSR(
     <ResizeObserver onResize={onResize}>
       {(ref) => (
-        <div ref={ref} className={className} style={style}>
+        <div
+          ref={ref}
+          className={className}
+          style={style}
+          data-testid="pro-page-header"
+        >
           {breadcrumbDom}
           {title}
           {childDom}

--- a/src/layout/components/SiderMenu/SiderMenu.tsx
+++ b/src/layout/components/SiderMenu/SiderMenu.tsx
@@ -484,6 +484,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
           onCollapse?.(collapse);
         }}
         collapsedWidth={collapsedWidth}
+        data-testid="pro-layout-sider"
         style={style}
         theme={theme}
         width={siderWidth}

--- a/src/layout/components/SiderMenu/index.tsx
+++ b/src/layout/components/SiderMenu/index.tsx
@@ -52,6 +52,7 @@ const SiderMenuWrapper: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (
       <Drawer
         placement={direction === 'rtl' ? 'right' : 'left'}
         className={clsx(`${prefixCls}-drawer-sider`, className)}
+        data-testid="pro-layout-sider"
         open={!collapsed}
         afterOpenChange={(open) => {
           if (!open) {

--- a/src/layout/components/TopNavHeader/index.tsx
+++ b/src/layout/components/TopNavHeader/index.tsx
@@ -150,6 +150,7 @@ const TopNavHeader: React.FC<TopNavHeaderProps> = (
         [`${prefixCls}-light`]: true,
       })}
       style={style}
+      data-testid="pro-layout-top-nav-header"
     >
       <div
         ref={ref}

--- a/src/list/ProListBase.tsx
+++ b/src/list/ProListBase.tsx
@@ -506,7 +506,13 @@ const ProListContainerInner = React.forwardRef<HTMLDivElement, ListProps>(
     );
     return (
       <ProListContext.Provider value={contextValue}>
-        <div ref={ref} style={style} className={classString} {...rest}>
+        <div
+          ref={ref}
+          style={style}
+          className={classString}
+          data-testid="pro-list-view"
+          {...rest}
+        >
           <Spin spinning={isLoading}>
             {showPaginationTop && paginationNode}
             {header && <div className={`${prefixCls}-header`}>{header}</div>}

--- a/src/table/Table.tsx
+++ b/src/table/Table.tsx
@@ -1012,6 +1012,7 @@ const ProTable = <
       })}
       style={style}
       ref={counter.rootDomRef}
+      data-testid="pro-table"
     >
       {isLightFilter ? null : searchNode}
       {type !== 'form' && props.tableExtraRender && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
为主要视图组件添加 `data-testid` 属性，以方便自动化测试。

此PR为 `ProList`、`ProLayout` 及其子组件、`ProTable` 和 `PageContainer` 等核心视图组件增加了 `data-testid` 属性，便于在测试中通过 `screen.getByTestId` 等方法定位元素。

| 组件 | `data-testid` |
|---|---|
| `ProListContainer` / `ListView` | `pro-list-view` |
| `ProLayout` | `pro-layout` |
| `Header` | `pro-layout-header` |
| `SiderMenu` (侧边栏 / Drawer) | `pro-layout-sider` |
| `WrapContent` (主内容区) | `pro-layout-content` |
| `Footer` | `pro-layout-footer` |
| `GlobalHeader` | `pro-layout-global-header` |
| `TopNavHeader` | `pro-layout-top-nav-header` |
| `PageContainer` | `pro-page-container` |
| `PageHeader` | `pro-page-header` |
| `GridContent` | `pro-grid-content` |
| `GlobalFooter` | `pro-global-footer` |
| `ProTable` | `pro-table` |

<div><a href="https://cursor.com/agents/bc-1400d72e-741c-415b-b2bd-564c8d5d2855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1400d72e-741c-415b-b2bd-564c8d5d2855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **测试**
  * 为布局、页面、表格和列表组件添加了测试标识符，增强了自动化测试的可选择性和可维护性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->