### PR TITLE
refactor: remove ProDescriptionsItem and use columns only

### DIFF
--- a/demos/descriptions/_base.demo-test.tsx
+++ b/demos/descriptions/_base.demo-test.tsx
@@ -1,14 +1,9 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 import { Button } from 'antd';
 
 const Demo = () => {
   return (
     <>
-      <ProDescriptionsItem label="文本" valueType="option">
-        <Button key="primary" type="primary">
-          提交
-        </Button>
-      </ProDescriptionsItem>
       <ProDescriptions
         column={2}
         title="高级定义列表"
@@ -18,6 +13,15 @@ const Demo = () => {
           success: true,
         })}
         columns={[
+          {
+            label: '文本',
+            valueType: 'option',
+            render: () => [
+              <Button key="primary" type="primary">
+                提交
+              </Button>,
+            ],
+          },
           {
             title: () => '文本 2',
             key: 'text',

--- a/demos/descriptions/arrayDataIndex.tsx
+++ b/demos/descriptions/arrayDataIndex.tsx
@@ -1,5 +1,5 @@
 ﻿import type { ProDescriptionsActionType } from '@ant-design/pro-components';
-import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+import { ProDescriptions } from '@ant-design/pro-components';
 import { Button } from 'antd';
 import { useRef } from 'react';
 
@@ -22,46 +22,50 @@ const Demo = () => {
         });
       }}
       editable={{
-        onSave: async (keypath, newInfo, oriInfo) => {
-
+        onSave: async (_keypath, _newInfo, _oriInfo) => {
           return true;
         },
       }}
-    >
-      <ProDescriptionsItem
-        formItemProps={{
-          rules: [
-            {
-              required: true,
-              message: '此项为必填项',
-            },
+      columns={[
+        {
+          formItemProps: {
+            rules: [
+              {
+                required: true,
+                message: '此项为必填项',
+              },
+            ],
+          },
+          dataIndex: ['info', 'id'],
+        },
+        {
+          dataIndex: ['info', 'date'],
+          label: '日期',
+          valueType: 'date',
+        },
+        {
+          label: 'money',
+          dataIndex: ['info', 'money'],
+          valueType: 'money',
+        },
+        {
+          label: '文本',
+          valueType: 'option',
+          render: () => [
+            <Button
+              type="primary"
+              onClick={() => {
+                actionRef.current?.reload();
+              }}
+              key="reload"
+            >
+              刷新
+            </Button>,
+            <Button key="rest">重置</Button>,
           ],
-        }}
-        dataIndex={['info', 'id']}
-      />
-      <ProDescriptionsItem
-        dataIndex={['info', 'date']}
-        label="日期"
-        valueType="date"
-      />
-      <ProDescriptionsItem
-        label="money"
-        dataIndex={['info', 'money']}
-        valueType="money"
-      />
-      <ProDescriptionsItem label="文本" valueType="option">
-        <Button
-          type="primary"
-          onClick={() => {
-            actionRef.current?.reload();
-          }}
-          key="reload"
-        >
-          刷新
-        </Button>
-        <Button key="rest">重置</Button>
-      </ProDescriptionsItem>
-    </ProDescriptions>
+        },
+      ]}
+    />
   );
 };
 

--- a/demos/descriptions/base.tsx
+++ b/demos/descriptions/base.tsx
@@ -1,4 +1,4 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 import { Button } from 'antd';
 
 import { FIXED_BASE_DATE } from '../mockData';
@@ -9,92 +9,111 @@ const Demo = () => {
       column={2}
       title="订单详情"
       tooltip="展示订单的详细信息，包括金额、状态、日期等多种值类型"
-    >
-      <ProDescriptionsItem valueType="option">
-        <Button key="primary" type="primary">
-          提交审核
-        </Button>
-      </ProDescriptionsItem>
-      <ProDescriptionsItem
-        span={2}
-        valueType="text"
-        renderText={(_) => {
-          return _ + _;
-        }}
-        ellipsis
-        label="订单备注"
-      >
-        客户要求在一季度内完成全部部署上线工作，优先安排专属技术支持团队跟进对接，确保各环节顺利推进
-      </ProDescriptionsItem>
-      <ProDescriptionsItem
-        label="合同金额"
-        tooltip="仅供参考，以实际签约合同为准"
-        valueType="money"
-      >
-        128000
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="完成进度" valueType="percent">
-        75
-      </ProDescriptionsItem>
-      <ProDescriptionsItem
-        label="订单状态"
-        valueEnum={{
-          all: { text: '全部', status: 'Default' },
-          pending: {
-            text: '待审核',
-            status: 'Warning',
+      columns={[
+        {
+          valueType: 'option',
+          render: () => [
+            <Button key="primary" type="primary">
+              提交审核
+            </Button>,
+          ],
+        },
+        {
+          span: 2,
+          valueType: 'text',
+          renderText: (_) => {
+            return _ + _;
           },
-          processing: {
-            text: '处理中',
-            status: 'Processing',
+          ellipsis: true,
+          label: '订单备注',
+          children:
+            '客户要求在一季度内完成全部部署上线工作，优先安排专属技术支持团队跟进对接，确保各环节顺利推进',
+        },
+        {
+          label: '合同金额',
+          tooltip: '仅供参考，以实际签约合同为准',
+          valueType: 'money',
+          children: 128000,
+        },
+        {
+          label: '完成进度',
+          valueType: 'percent',
+          children: 75,
+        },
+        {
+          label: '订单状态',
+          valueEnum: {
+            all: { text: '全部', status: 'Default' },
+            pending: {
+              text: '待审核',
+              status: 'Warning',
+            },
+            processing: {
+              text: '处理中',
+              status: 'Processing',
+            },
+            completed: {
+              text: '已完成',
+              status: 'Success',
+            },
+            rejected: {
+              text: '已驳回',
+              status: 'Error',
+            },
           },
-          completed: {
-            text: '已完成',
-            status: 'Success',
-          },
-          rejected: {
-            text: '已驳回',
-            status: 'Error',
-          },
-        }}
-      >
-        processing
-      </ProDescriptionsItem>
-      <ProDescriptionsItem
-        label="付款方式"
-        request={async () => [
-          { label: '对公转账', value: 'bank' },
-          { label: '支付宝', value: 'alipay' },
-          { label: '微信支付', value: 'wechat' },
-          { label: '信用卡', value: 'credit' },
-        ]}
-      >
-        bank
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="交付进度" valueType="progress">
-        75
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="下单时间" valueType="dateTime">
-        {FIXED_BASE_DATE.valueOf()}
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="签约日期" valueType="date">
-        {FIXED_BASE_DATE.valueOf()}
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="服务周期" valueType="dateTimeRange">
-        {[FIXED_BASE_DATE.valueOf(), FIXED_BASE_DATE.add(365, 'd').valueOf()]}
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="创建时间" valueType="time">
-        {FIXED_BASE_DATE.valueOf()}
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="部署脚本" valueType="code">
-        {`
+          children: 'processing',
+        },
+        {
+          label: '付款方式',
+          request: async () => [
+            { label: '对公转账', value: 'bank' },
+            { label: '支付宝', value: 'alipay' },
+            { label: '微信支付', value: 'wechat' },
+            { label: '信用卡', value: 'credit' },
+          ],
+          children: 'bank',
+        },
+        {
+          label: '交付进度',
+          valueType: 'progress',
+          children: 75,
+        },
+        {
+          label: '下单时间',
+          valueType: 'dateTime',
+          children: FIXED_BASE_DATE.valueOf(),
+        },
+        {
+          label: '签约日期',
+          valueType: 'date',
+          children: FIXED_BASE_DATE.valueOf(),
+        },
+        {
+          label: '服务周期',
+          valueType: 'dateTimeRange',
+          children: [
+            FIXED_BASE_DATE.valueOf(),
+            FIXED_BASE_DATE.add(365, 'd').valueOf(),
+          ],
+        },
+        {
+          label: '创建时间',
+          valueType: 'time',
+          children: FIXED_BASE_DATE.valueOf(),
+        },
+        {
+          label: '部署脚本',
+          valueType: 'code',
+          children: `
 pnpm install
 pnpm run build
 pnpm run deploy --env production
-        `}
-      </ProDescriptionsItem>
-      <ProDescriptionsItem label="服务配置" valueType="jsonCode">
-        {`{
+        `,
+        },
+        {
+          label: '服务配置',
+          valueType: 'jsonCode',
+          children: `{
   "service": {
     "name": "user-auth-service",
     "port": 8080,
@@ -106,9 +125,10 @@ pnpm run deploy --env production
       "memory": "512Mi"
     }
   }
-}`}
-      </ProDescriptionsItem>
-    </ProDescriptions>
+}`,
+        },
+      ]}
+    />
   );
 };
 

--- a/demos/descriptions/columns.tsx
+++ b/demos/descriptions/columns.tsx
@@ -1,4 +1,4 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 
 const Demo = () => {
   return (
@@ -110,20 +110,22 @@ const Demo = () => {
               </a>,
             ],
           },
+          {
+            dataIndex: 'percent',
+            label: '百分比',
+            valueType: 'percent',
+            children: 100,
+          },
+          {
+            title: '多余节点',
+            render: () => <div>多余的dom</div>,
+          },
+          {
+            label: '超链接',
+            children: <a href="alipay.com">超链接</a>,
+          },
         ]}
-      >
-        <ProDescriptionsItem
-          dataIndex="percent"
-          label="百分比"
-          valueType="percent"
-        >
-          100
-        </ProDescriptionsItem>
-        <div>多余的dom</div>
-        <ProDescriptionsItem label="超链接">
-          <a href="alipay.com">超链接</a>
-        </ProDescriptionsItem>
-      </ProDescriptions>
+      />
 
       <div
         style={{
@@ -229,16 +231,10 @@ const Demo = () => {
             <strong>样式控制</strong>: 完全控制渲染内容的样式
           </li>
         </ul>
-        <h4>混合使用特点：</h4>
+        <h4>列配置方式：</h4>
         <ul>
           <li>
-            <strong>Columns 配置</strong>: 通过 columns 数组定义列
-          </li>
-          <li>
-            <strong>Item 组件</strong>: 同时支持 ProDescriptionsItem
-          </li>
-          <li>
-            <strong>优先级</strong>: Item 组件会覆盖 columns 中的配置
+            <strong>columns</strong>: 通过 columns 数组统一定义全部展示项
           </li>
         </ul>
         <h4>使用场景：</h4>

--- a/demos/descriptions/editable.tsx
+++ b/demos/descriptions/editable.tsx
@@ -1,4 +1,4 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 import { Input, Tooltip } from 'antd';
 import { useRef } from 'react';
 
@@ -139,16 +139,14 @@ const Demo = () => {
             </a>,
           ],
         },
+        {
+          dataIndex: 'percent',
+          label: '交付进度',
+          valueType: 'percent',
+          children: 75,
+        },
       ]}
-    >
-      <ProDescriptionsItem
-        dataIndex="percent"
-        label="交付进度"
-        valueType="percent"
-      >
-        75
-      </ProDescriptionsItem>
-    </ProDescriptions>
+    />
   );
 };
 

--- a/demos/descriptions/format.tsx
+++ b/demos/descriptions/format.tsx
@@ -1,4 +1,4 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 
 import { FIXED_BASE_DATE } from '../mockData';
 
@@ -9,55 +9,52 @@ const Demo = () => {
         column={2}
         title="高级定义列表"
         tooltip="包含了从服务器请求，columns等功能"
-      >
-        <ProDescriptionsItem
-          label="日期"
-          fieldProps={{
-            format: 'YYYY.MM.DD',
-          }}
-          valueType="date"
-        >
-          {FIXED_BASE_DATE.valueOf()}
-        </ProDescriptionsItem>
-        <ProDescriptionsItem
-          label="日期区间"
-          fieldProps={{
-            format: 'YYYY.MM.DD HH:mm:ss',
-          }}
-          valueType="dateTimeRange"
-        >
-          {[FIXED_BASE_DATE.add(-1, 'd').valueOf(), FIXED_BASE_DATE.valueOf()]}
-        </ProDescriptionsItem>
-        <ProDescriptionsItem
-          label="时间"
-          fieldProps={{
-            format: 'YYYY.MM.DD',
-          }}
-          valueType="time"
-        >
-          {FIXED_BASE_DATE.valueOf()}
-        </ProDescriptionsItem>
-
-        <ProDescriptionsItem
-          label="时间日期"
-          fieldProps={{
-            format: 'YYYY.MM.DD HH:mm:ss',
-          }}
-          valueType="dateTime"
-        >
-          {FIXED_BASE_DATE.valueOf()}
-        </ProDescriptionsItem>
-
-        <ProDescriptionsItem
-          label="更新时间"
-          fieldProps={{
-            format: 'YYYY.MM.DD',
-          }}
-          valueType="fromNow"
-        >
-          {FIXED_BASE_DATE.add(-1, 'month').valueOf()}
-        </ProDescriptionsItem>
-      </ProDescriptions>
+        columns={[
+          {
+            label: '日期',
+            fieldProps: {
+              format: 'YYYY.MM.DD',
+            },
+            valueType: 'date',
+            children: FIXED_BASE_DATE.valueOf(),
+          },
+          {
+            label: '日期区间',
+            fieldProps: {
+              format: 'YYYY.MM.DD HH:mm:ss',
+            },
+            valueType: 'dateTimeRange',
+            children: [
+              FIXED_BASE_DATE.add(-1, 'd').valueOf(),
+              FIXED_BASE_DATE.valueOf(),
+            ],
+          },
+          {
+            label: '时间',
+            fieldProps: {
+              format: 'YYYY.MM.DD',
+            },
+            valueType: 'time',
+            children: FIXED_BASE_DATE.valueOf(),
+          },
+          {
+            label: '时间日期',
+            fieldProps: {
+              format: 'YYYY.MM.DD HH:mm:ss',
+            },
+            valueType: 'dateTime',
+            children: FIXED_BASE_DATE.valueOf(),
+          },
+          {
+            label: '更新时间',
+            fieldProps: {
+              format: 'YYYY.MM.DD',
+            },
+            valueType: 'fromNow',
+            children: FIXED_BASE_DATE.add(-1, 'month').valueOf(),
+          },
+        ]}
+      />
 
       <div
         style={{
@@ -79,7 +76,7 @@ const Demo = () => {
             <strong>tooltip</strong>: 标题提示信息
           </li>
         </ul>
-        <h4>ProDescriptionsItem 配置：</h4>
+        <h4>列配置（columns）常用项：</h4>
         <ul>
           <li>
             <strong>label</strong>: 标签文本
@@ -91,7 +88,7 @@ const Demo = () => {
             <strong>fieldProps</strong>: 字段属性配置
           </li>
           <li>
-            <strong>children</strong>: 数据内容
+            <strong>children</strong>: 数据内容（无 dataIndex 时作为展示值）
           </li>
         </ul>
         <h4>FieldProps 格式化配置：</h4>
@@ -175,7 +172,7 @@ const Demo = () => {
             <strong>时间区间</strong>: 展示时间范围
           </li>
           <li>
-            <strong>相对时间</strong>: 展示相对时间，如"一个月前"
+            <strong>相对时间</strong>: 展示相对时间，如&quot;一个月前&quot;
           </li>
           <li>
             <strong>格式化定制</strong>: 根据需求定制显示格式

--- a/demos/descriptions/request.tsx
+++ b/demos/descriptions/request.tsx
@@ -1,5 +1,5 @@
 ﻿import type { ProDescriptionsActionType } from '@ant-design/pro-components';
-import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+import { ProDescriptions } from '@ant-design/pro-components';
 import { Button } from 'antd';
 import { useRef } from 'react';
 
@@ -17,27 +17,28 @@ const Demo = () => {
           });
         }}
         extra={<Button type="link">修改</Button>}
-      >
-        <ProDescriptionsItem dataIndex="id" />
-        <ProDescriptionsItem dataIndex="date" label="日期" valueType="date" />
-        <ProDescriptionsItem
-          label="money"
-          dataIndex="money"
-          valueType="money"
-        />
-        <ProDescriptionsItem label="文本" valueType="option">
-          <Button
-            type="primary"
-            onClick={() => {
-              actionRef.current?.reload();
-            }}
-            key="reload"
-          >
-            刷新
-          </Button>
-          <Button key="rest">重置</Button>
-        </ProDescriptionsItem>
-      </ProDescriptions>
+        columns={[
+          { dataIndex: 'id' },
+          { dataIndex: 'date', label: '日期', valueType: 'date' },
+          { label: 'money', dataIndex: 'money', valueType: 'money' },
+          {
+            label: '文本',
+            valueType: 'option',
+            render: () => [
+              <Button
+                type="primary"
+                onClick={() => {
+                  actionRef.current?.reload();
+                }}
+                key="reload"
+              >
+                刷新
+              </Button>,
+              <Button key="rest">重置</Button>,
+            ],
+          },
+        ]}
+      />
 
       <div
         style={{
@@ -78,7 +79,7 @@ const Demo = () => {
             <strong>错误处理</strong>: 自动处理请求错误
           </li>
         </ul>
-        <h4>ProDescriptionsItem 配置：</h4>
+        <h4>columns 与 request 配合：</h4>
         <ul>
           <li>
             <strong>dataIndex</strong>: 数据字段名，自动绑定到 request
@@ -91,7 +92,8 @@ const Demo = () => {
             <strong>valueType</strong>: 值类型，决定如何渲染数据
           </li>
           <li>
-            <strong>children</strong>: 自定义内容，如操作按钮
+            <strong>render</strong>: 自定义内容，如操作按钮（valueType 为
+            option 时放入 extra 区域）
           </li>
         </ul>
         <h4>ActionRef 操作方法：</h4>

--- a/demos/descriptions/use-data-source.tsx
+++ b/demos/descriptions/use-data-source.tsx
@@ -1,4 +1,4 @@
-﻿import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+﻿import { ProDescriptions } from '@ant-design/pro-components';
 
 const Demo = () => {
   return (
@@ -69,12 +69,13 @@ const Demo = () => {
               </a>,
             ],
           },
+          {
+            label: '百分比',
+            valueType: 'percent',
+            children: 100,
+          },
         ]}
-      >
-        <ProDescriptionsItem label="百分比" valueType="percent">
-          100
-        </ProDescriptionsItem>
-      </ProDescriptions>
+      />
 
       <div
         style={{
@@ -180,16 +181,10 @@ const Demo = () => {
             <strong>样式控制</strong>: 完全控制渲染内容的样式
           </li>
         </ul>
-        <h4>混合使用特点：</h4>
+        <h4>列配置方式：</h4>
         <ul>
           <li>
-            <strong>Columns 配置</strong>: 通过 columns 数组定义列
-          </li>
-          <li>
-            <strong>Item 组件</strong>: 同时支持 ProDescriptionsItem
-          </li>
-          <li>
-            <strong>优先级</strong>: Item 组件会覆盖 columns 中的配置
+            <strong>columns</strong>: 通过 columns 数组定义全部列
           </li>
         </ul>
         <h4>与 Request 的区别：</h4>

--- a/site/changelog.en-US.md
+++ b/site/changelog.en-US.md
@@ -2,6 +2,11 @@
 
 ## [3.1.3-0] - 2026-04-06
 
+### 🗑 Breaking Changes
+
+- ProDescriptions
+  - 🗑 Remove `ProDescriptionsItem` export; use `columns` instead (types remain `ProDescriptionsItemProps`)
+
 ### 🛠 Refactor / Documentation
 
 - ProForm

--- a/site/changelog.en-US.md
+++ b/site/changelog.en-US.md
@@ -5,7 +5,10 @@
 ### 🗑 Breaking Changes
 
 - ProDescriptions
-  - 🗑 Remove `ProDescriptionsItem` export; use `columns` instead (types remain `ProDescriptionsItemProps`)
+  - 🗑 Remove `ProDescriptionsItem` export; use `columns` instead
+  - 🛠 Rename column type to `ProDescriptionsColumn` (`ProDescriptionsItemProps` remains an alias)
+  - 🛠 Tighten `request` return type to `ProDescriptionsRequestResult<T>`; `params` is `Record<string, unknown>`; `onDataSourceChange` may receive `undefined`
+  - 🛠 `ProDescriptionsProps` no longer accepts `items` (generated internally)
 
 ### 🛠 Refactor / Documentation
 

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -2,6 +2,11 @@
 
 ## [3.1.3-0] - 2026-04-06
 
+### 🗑 破坏性变更
+
+- ProDescriptions
+  - 🗑 移除 `ProDescriptionsItem` 导出；请使用 `columns` 配置列（类型仍为 `ProDescriptionsItemProps`）
+
 ### 🛠 重构 / 文档
 
 - ProForm

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -5,7 +5,10 @@
 ### 🗑 破坏性变更
 
 - ProDescriptions
-  - 🗑 移除 `ProDescriptionsItem` 导出；请使用 `columns` 配置列（类型仍为 `ProDescriptionsItemProps`）
+  - 🗑 移除 `ProDescriptionsItem` 导出；请使用 `columns` 配置列
+  - 🛠 列类型更名为 `ProDescriptionsColumn`（`ProDescriptionsItemProps` 保留为别名）
+  - 🛠 `request` 返回类型收紧为 `ProDescriptionsRequestResult<T>`；`params` 为 `Record<string, unknown>`；`onDataSourceChange` 可收到 `undefined`
+  - 🛠 `ProDescriptionsProps` 不再接受 `items`（由组件内部生成）
 
 ### 🛠 重构 / 文档
 

--- a/site/components/descriptions.en-US.md
+++ b/site/components/descriptions.en-US.md
@@ -132,7 +132,7 @@ API is the same as ProTable
 
 ### columns
 
-Each item is `ProDescriptionsItemProps` (same schema family as ProTable `columns`). Common fields:
+Each item is `ProDescriptionsColumn` (same schema family as ProTable `columns`; `ProDescriptionsItemProps` is an alias). Common fields:
 
 | Parameters | Description                                                                                                                    | Type                                                         | Default Value |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------- |

--- a/site/components/descriptions.en-US.md
+++ b/site/components/descriptions.en-US.md
@@ -100,11 +100,11 @@ API is the same as ProTable
 | loading        | Display a loaded skeleton screen, the skeleton screen and dom will not correspond one-to-one                                               | `boolean`                                      | -             |
 | extra          | Describe the operation area of ​​the list, displayed on the upper right                                                                    | `string` \| `ReactNode`                        | -             |
 | bordered       | Whether to display the border                                                                                                              | boolean                                        | false         |
-| column         | The number of `ProDescriptionsItems` in a row, can be written as pixel value or support responsive object writing `{ xs: 1, sm: 2, md: 3}` | number                                         | 3             |
+| column         | The number of description cells per row, can be written as pixel value or support responsive object writing `{ xs: 1, sm: 2, md: 3}` | number                                         | 3             |
 | size           | Set the size of the list. Can be set to `middle`, `small`, or left blank (only setting `bordered={true}` takes effect)                     | `default` \| `middle` \| `small`               | -             |
 | layout         | Description layout                                                                                                                         | `horizontal` \| `vertical`                     | `horizontal`  |
-| colon          | Configure the default value of `colon` for `Descriptions.Item` (use `ProDescriptionsItem` for typed props)                                 | boolean                                        | true          |
-| request        | Request data; when columns are not set, set `dataIndex` per item (use `ProDescriptionsItem` for children)                                  | `(params: U) => Promise<RequestData<T>>`       | -             |
+| colon          | Configure the default `colon` for antd `Descriptions` cells                                 | boolean                                        | true          |
+| request        | Request data; use with `dataIndex` in `columns`                                  | `(params: U) => Promise<RequestData<T>>`       | -             |
 | onRequestError | Handling request errors, by default an error will be thrown directly                                                                       | `(error: Error) => void`                       | -             |
 | columns        | Column definition, used with request [columns](/components/table#columns)                                                                  | `ProColumns<T>[]`                              | -             |
 | editable       | Editable related configuration                                                                                                             | [EditableConfig](#editable-edit-configuration) | -             |
@@ -130,7 +130,9 @@ API is the same as ProTable
 | onlyOneLineEditorAlertMessage | Only one line can be edited                                                                                                                                                               | `ReactNode`                                                             | `Only one line can be edited at the same time` |
 | onlyAddOneLineAlertMessage    | Only one line can be added at the same time                                                                                                                                               | `ReactNode`                                                             | `Only add one line`                            |
 
-### ProDescriptionsItem
+### columns
+
+Each item is `ProDescriptionsItemProps` (same schema family as ProTable `columns`). Common fields:
 
 | Parameters | Description                                                                                                                    | Type                                                         | Default Value |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | ------------- |
@@ -138,14 +140,14 @@ API is the same as ProTable
 | tooltip    | Supplementary description of the content, displayed after hover                                                                | string                                                       | -             |
 | ellipsis   | Whether to abbreviate automatically                                                                                            | `boolean`                                                    | -             |
 | copyable   | Whether to support copying                                                                                                     | `boolean`                                                    | -             |
-| span       | number of columns included                                                                                                     | number                                                       | 1             |
+| span       | Column span (antd Descriptions cell span)                                                                                                     | number                                                       | 1             |
 | valueType  | Formatted type                                                                                                                 | `ValueType`                                                  | -             |
 | valueEnum  | Enumeration of current column values ​​[valueEnum](/components/table#valueenum)                                                | `Record`                                                     | -             |
 | request    | Request enumerated data from the network                                                                                       | `()=>Promise<{[key:string`\|`number]:any}>`                  | -             |
 | dataIndex  | The key of the returned data is used in conjunction with the request of ProDescriptions for the definition list of the profile | `React.Text` \| `React.Text[]`                               | -             |
 | editable   | Whether it is editable in the edit table, the parameters of the function are the same as the render of the table               | `false` \| `(text: any, record: T,index: number) => boolean` | true          |
 
-> span is the number of Description.Item. span={2} will occupy the width of two DescriptionItem.
+> `span={2}` spans two description cells.
 
 ### ActionRef
 

--- a/site/components/descriptions.md
+++ b/site/components/descriptions.md
@@ -100,11 +100,11 @@ API 与 ProTable 相同
 | loading        | 展示一个加载的骨架屏，骨架屏和 dom 不会一一对应                                                   | `boolean`                                | -            |
 | extra          | 描述列表的操作区域，显示在右上方                                                                  | `string` \| `ReactNode`                  | -            |
 | bordered       | 是否展示边框                                                                                      | boolean                                  | false        |
-| column         | 一行的 `ProDescriptionsItems` 数量，可以写成像素值或支持响应式的对象写法 `{ xs: 1, sm: 2, md: 3}` | number                                   | 3            |
+| column         | 一行的描述项数量，可以写成像素值或支持响应式的对象写法 `{ xs: 1, sm: 2, md: 3}` | number                                   | 3            |
 | size           | 设置列表的大小。可以设置为 `middle` 、`small`，或不填（只有设置 `bordered={true}` 生效）          | `default` \| `middle` \| `small`         | -            |
 | layout         | 描述布局                                                                                          | `horizontal` \| `vertical`               | `horizontal` |
-| colon          | 配置 `Descriptions.Item`（推荐使用 `ProDescriptionsItem`）的 `colon` 的默认值                     | boolean                                  | true         |
-| request        | 请求数据，不设置 columns 时需为每项设置对应的 dataIndex（子项使用 `ProDescriptionsItem`）         | `(params: U) => Promise<RequestData<T>>` | -            |
+| colon          | 配置 antd `Descriptions` 单元格 `colon` 的默认值                     | boolean                                  | true         |
+| request        | 请求数据，与 `columns` 中的 `dataIndex` 配合使用         | `(params: U) => Promise<RequestData<T>>` | -            |
 | onRequestError | 处理 request 的错误，默认会直接抛出错误                                                           | `(error: Error) => void`                 | -            |
 | columns        | 列定义，与 request 配合使用 [columns](/components/table#columns)                                  | `ProColumns<T>[]`                        | -            |
 | editable       | 编辑的相关配置                                                                                    | [EditableConfig](#editable-编辑配置)     | -            |
@@ -130,7 +130,9 @@ API 与 ProTable 相同
 | onlyOneLineEditorAlertMessage | 只能编辑一行的的提示                                                                                    | `ReactNode`                                                             | `只能同时编辑一行` |
 | onlyAddOneLineAlertMessage    | 只能同时新增一行的提示                                                                                  | `ReactNode`                                                             | `只能新增一行`     |
 
-### ProDescriptionsItem
+### columns 列配置
+
+每一项为 `ProDescriptionsItemProps`（与 ProTable 的 `columns` 同源 schema），常用字段如下：
 
 | 参数      | 说明                                                                        | 类型                                                         | 默认值 |
 | --------- | --------------------------------------------------------------------------- | ------------------------------------------------------------ | ------ |
@@ -138,14 +140,14 @@ API 与 ProTable 相同
 | tooltip   | 内容的补充描述，hover 后显示                                                | string                                                       | -      |
 | ellipsis  | 是否自动缩略                                                                | `boolean`                                                    | -      |
 | copyable  | 是否支持复制                                                                | `boolean`                                                    | -      |
-| span      | 包含列的数量                                                                | number                                                       | 1      |
+| span      | 包含列的数量（对应 antd Descriptions 列跨度）                                | number                                                       | 1      |
 | valueType | 格式化的类型                                                                | `ValueType`                                                  | -      |
 | valueEnum | 当前列值的枚举 [valueEnum](/components/table#valueenum)                     | `Record`                                                     | -      |
 | request   | 从网络请求枚举数据                                                          | `()=>Promise<{[key:string`\|`number]:any}>`                  | -      |
 | dataIndex | 返回数据的 key 与 ProDescriptions 的 request 配合使用，用于配置式的定义列表 | `React.Text` \| `React.Text[]`                               | -      |
 | editable  | 在编辑表格中是否可编辑的，函数的参数和 table 的 render 一样                 | `false` \| `(text: any, record: T,index: number) => boolean` | true   |
 
-> span 是 Description.Item 的数量。 span={2} 会占用两个 DescriptionItem 的宽度。
+> `span={2}` 会占用两个描述单元格的宽度。
 
 ### ActionRef
 

--- a/site/components/descriptions.md
+++ b/site/components/descriptions.md
@@ -132,7 +132,7 @@ API 与 ProTable 相同
 
 ### columns 列配置
 
-每一项为 `ProDescriptionsItemProps`（与 ProTable 的 `columns` 同源 schema），常用字段如下：
+每一项为 `ProDescriptionsColumn`（与 ProTable 的 `columns` 同源 schema；`ProDescriptionsItemProps` 为别名），常用字段如下：
 
 | 参数      | 说明                                                                        | 类型                                                         | 默认值 |
 | --------- | --------------------------------------------------------------------------- | ------------------------------------------------------------ | ------ |

--- a/src/descriptions/FieldRender.tsx
+++ b/src/descriptions/FieldRender.tsx
@@ -9,13 +9,13 @@ import {
   InlineErrorFormItem,
   getFieldPropsOrFormItemProps,
 } from '../utils';
-import type { ProDescriptionsItemProps } from './typing';
+import type { ProDescriptionsColumn } from './typing';
 
 /**
  * Descriptions 单列：只读 / 可编辑下的 ProFormField 渲染
  */
 export const FieldRender: React.FC<
-  Omit<ProDescriptionsItemProps<any>, 'valueType'> & {
+  Omit<ProDescriptionsColumn<any>, 'valueType'> & {
     text: any;
     valueType: ProFieldValueTypeInput;
     entity: any;

--- a/src/descriptions/ProDescriptions.tsx
+++ b/src/descriptions/ProDescriptions.tsx
@@ -1,5 +1,4 @@
-﻿import { toArray } from '@rc-component/util';
-import type { DescriptionsItemType } from 'antd/es/descriptions';
+﻿import type { DescriptionsItemType } from 'antd/es/descriptions';
 import { ConfigProvider, Descriptions, Space } from 'antd';
 import React, { useContext, useEffect } from 'react';
 import ValueTypeToComponent from '../field/ValueTypeToComponent';
@@ -41,6 +40,9 @@ const ProDescriptions = <
     ...rest
   } = props;
 
+  const { children: _ignoredChildren, ...descriptionsProps } = rest as typeof rest &
+    { children?: React.ReactNode };
+
   const proContext = useContext(ProConfigContext);
   const context = useContext(ConfigProvider.ConfigContext);
 
@@ -81,38 +83,7 @@ const ProDescriptions = <
   }
 
   const getColumns = (): ProDescriptionsItemProps<RecordType, ValueType>[] => {
-    const childrenColumns = toArray(props.children)
-      .filter(Boolean)
-      .map((item) => {
-        if (!React.isValidElement(item)) {
-          return item;
-        }
-        const {
-          valueEnum,
-          valueType,
-          dataIndex,
-          ellipsis,
-          copyable,
-          request: itemRequest,
-        } = item?.props as ProDescriptionsItemProps;
-
-        if (
-          !valueType &&
-          !valueEnum &&
-          !dataIndex &&
-          !itemRequest &&
-          !ellipsis &&
-          !copyable
-        ) {
-          return item;
-        }
-
-        return {
-          ...(item?.props as ProDescriptionsItemProps),
-          entity: dataSource,
-        };
-      }) as ProDescriptionsItemProps<RecordType, ValueType>[];
-    return [...(columns || []), ...childrenColumns]
+    return (columns || [])
       .filter((item) => {
         if (!item) return false;
         if (
@@ -142,8 +113,13 @@ const ProDescriptions = <
   const FormComponent = editable ? ProForm : DefaultProDescriptionsDom;
 
   let title = null;
-  if (rest.title || rest.tooltip) {
-    title = <LabelIconTip label={rest.title} tooltip={rest.tooltip} />;
+  if (descriptionsProps.title || descriptionsProps.tooltip) {
+    title = (
+      <LabelIconTip
+        label={descriptionsProps.title}
+        tooltip={descriptionsProps.tooltip}
+      />
+    );
   }
 
   const className = context.getPrefixCls('pro-descriptions');
@@ -162,17 +138,17 @@ const ProDescriptions = <
         >
           <Descriptions
             className={className}
-            {...rest}
+            {...descriptionsProps}
             styles={{
               content: {
                 minWidth: 0,
               },
             }}
             extra={
-              rest.extra ? (
+              descriptionsProps.extra ? (
                 <Space>
                   {options}
-                  {rest.extra}
+                  {descriptionsProps.extra}
                 </Space>
               ) : (
                 options
@@ -186,9 +162,6 @@ const ProDescriptions = <
     </ErrorBoundary>
   );
 };
-
-/** antd `Descriptions.Item`，并扩展 `ProDescriptionsItemProps`（`valueType`、`dataIndex` 等） */
-export const ProDescriptionsItem = Descriptions.Item as React.FC<ProDescriptionsItemProps>;
 
 export { ProDescriptions };
 export default ProDescriptions;

--- a/src/descriptions/ProDescriptions.tsx
+++ b/src/descriptions/ProDescriptions.tsx
@@ -12,8 +12,8 @@ import {
   useEditableMap,
 } from '../utils';
 import { schemaToDescriptionsItem } from './schemaToDescriptionsItem';
-import type { ProDescriptionsItemProps, ProDescriptionsProps } from './typing';
-import type { RequestData } from './useFetchData';
+import type { ProDescriptionsColumn, ProDescriptionsProps } from './typing';
+import type { ProDescriptionsRequestResult } from './useFetchData';
 import useFetchData from './useFetchData';
 
 const DefaultProDescriptionsDom = (dom: { children: any }) => dom.children;
@@ -40,15 +40,14 @@ const ProDescriptions = <
     ...rest
   } = props;
 
-  const { children: _ignoredChildren, ...descriptionsProps } = rest as typeof rest &
-    { children?: React.ReactNode };
-
   const proContext = useContext(ProConfigContext);
   const context = useContext(ConfigProvider.ConfigContext);
 
-  const action = useFetchData<RequestData>(
+  const action = useFetchData<RecordType, ProDescriptionsRequestResult<RecordType>>(
     async () => {
-      const data = request ? await request(params || {}) : { data: {} };
+      const data = request
+        ? await request(params)
+        : { data: {} as RecordType };
       return data;
     },
     {
@@ -82,7 +81,7 @@ const ProDescriptions = <
     return <ProSkeleton type="descriptions" list={false} pageHeader={false} />;
   }
 
-  const getColumns = (): ProDescriptionsItemProps<RecordType, ValueType>[] => {
+  const getColumns = (): ProDescriptionsColumn<RecordType, ValueType>[] => {
     return (columns || [])
       .filter((item) => {
         if (!item) return false;
@@ -104,7 +103,7 @@ const ProDescriptions = <
 
   const { options, children } = schemaToDescriptionsItem(
     getColumns(),
-    action.dataSource || {},
+    action.dataSource,
     actionRef?.current || action,
     editable ? editableUtils : undefined,
     props.emptyText,
@@ -113,12 +112,9 @@ const ProDescriptions = <
   const FormComponent = editable ? ProForm : DefaultProDescriptionsDom;
 
   let title = null;
-  if (descriptionsProps.title || descriptionsProps.tooltip) {
+  if (rest.title || rest.tooltip) {
     title = (
-      <LabelIconTip
-        label={descriptionsProps.title}
-        tooltip={descriptionsProps.tooltip}
-      />
+      <LabelIconTip label={rest.title} tooltip={rest.tooltip} />
     );
   }
 
@@ -138,17 +134,17 @@ const ProDescriptions = <
         >
           <Descriptions
             className={className}
-            {...descriptionsProps}
+            {...rest}
             styles={{
               content: {
                 minWidth: 0,
               },
             }}
             extra={
-              descriptionsProps.extra ? (
+              rest.extra ? (
                 <Space>
                   {options}
-                  {descriptionsProps.extra}
+                  {rest.extra}
                 </Space>
               ) : (
                 options

--- a/src/descriptions/getDataFromConfig.ts
+++ b/src/descriptions/getDataFromConfig.ts
@@ -1,22 +1,22 @@
 ﻿import { get } from '@rc-component/util';
-import type { ProDescriptionsItemProps } from './typing';
+import type { ProDescriptionsColumn } from './typing';
 
 /**
- * 根据 dataIndex 获取值，支持 dataIndex 为数组（与重构前逻辑一致）
+ * 根据 dataIndex 从 entity 取值；无 dataIndex 或值为 undefined/null 时用列上的 children
  */
 export function getDataFromConfig(
-  item: ProDescriptionsItemProps,
-  entity: any,
+  item: ProDescriptionsColumn,
+  entity: Record<string, unknown> | undefined,
 ) {
   const { dataIndex } = item;
-  if (dataIndex) {
+  if (dataIndex != null && entity != null) {
     const data = Array.isArray(dataIndex)
       ? get(entity, dataIndex as string[])
-      : entity[dataIndex as string];
+      : (entity as Record<string, unknown>)[dataIndex as string];
 
-    if (data !== undefined || data !== null) {
+    if (data !== undefined && data !== null) {
       return data;
     }
   }
-  return item.children as string;
+  return item.children;
 }

--- a/src/descriptions/index.tsx
+++ b/src/descriptions/index.tsx
@@ -5,6 +5,7 @@ export { default } from './ProDescriptions';
 export type {
   DescriptionsItemProps,
   ProDescriptionsActionType,
+  ProDescriptionsColumn,
   ProDescriptionsItemProps,
   ProDescriptionsProps,
   ProFieldBuiltinValueType,
@@ -13,4 +14,5 @@ export type {
   ProFieldValueType,
   ProFieldValueTypeInput,
 } from './typing';
+export type { ProDescriptionsRequestResult } from './useFetchData';
 export { PRO_FIELD_SCHEMA_LAYOUT_VALUE_TYPES } from './typing';

--- a/src/descriptions/index.tsx
+++ b/src/descriptions/index.tsx
@@ -1,5 +1,5 @@
 ﻿export { FieldRender } from './FieldRender';
-export { ProDescriptions, ProDescriptionsItem } from './ProDescriptions';
+export { ProDescriptions } from './ProDescriptions';
 export { default } from './ProDescriptions';
 
 export type {

--- a/src/descriptions/resolveValueType.ts
+++ b/src/descriptions/resolveValueType.ts
@@ -1,12 +1,12 @@
 ﻿import type { ProFieldValueTypeInput } from '../utils/typing';
-import type { ProDescriptionsItemProps } from './typing';
+import type { ProDescriptionsColumn } from './typing';
 
 /**
  * 解析列上 `valueType`（支持函数形式），供 Descriptions 渲染路径使用
  */
 export function resolveDescriptionsValueType(
-  item: ProDescriptionsItemProps,
-  entity: Record<string, any>,
+  item: ProDescriptionsColumn,
+  entity: Record<string, unknown>,
 ): ProFieldValueTypeInput {
   const { valueType } = item;
   return (

--- a/src/descriptions/schemaToDescriptionsItem.tsx
+++ b/src/descriptions/schemaToDescriptionsItem.tsx
@@ -7,11 +7,11 @@ import { LabelIconTip, genCopyable } from '../utils';
 import { FieldRender } from './FieldRender';
 import { getDataFromConfig } from './getDataFromConfig';
 import { resolveDescriptionsValueType } from './resolveValueType';
-import type { ProDescriptionsItemProps } from './typing';
+import type { ProDescriptionsColumn } from './typing';
 
 export function schemaToDescriptionsItem(
-  items: ProDescriptionsItemProps<any, any>[],
-  entity: any,
+  items: ProDescriptionsColumn<any, any>[],
+  entity: Record<string, unknown> | undefined,
   action: ProCoreActionType<any>,
   editableUtils?: UseEditableMapUtilType,
   emptyText?: React.ReactNode,
@@ -19,6 +19,7 @@ export function schemaToDescriptionsItem(
   const options: React.JSX.Element[] = [];
   const children = items
     ?.map?.((item, index) => {
+      const row = entity ?? {};
       const {
         valueEnum: _valueEnum,
         render: _render,
@@ -30,12 +31,12 @@ export function schemaToDescriptionsItem(
         params: _params,
         editable,
         ...restItem
-      } = item as ProDescriptionsItemProps;
+      } = item as ProDescriptionsColumn;
 
       const defaultData = getDataFromConfig(item, entity) ?? restItem.children;
 
       const text = renderText
-        ? renderText(defaultData, entity, index, action)
+        ? renderText(defaultData, row, index, action)
         : defaultData;
 
       const title =
@@ -43,7 +44,7 @@ export function schemaToDescriptionsItem(
           ? restItem.title(item, 'descriptions', null)
           : restItem.title;
 
-      const valueType = resolveDescriptionsValueType(item, entity || {});
+      const valueType = resolveDescriptionsValueType(item, row);
 
       const isEditable = editableUtils?.isEditable(
         (dataIndex as React.Key) || index,
@@ -55,7 +56,7 @@ export function schemaToDescriptionsItem(
         editableUtils &&
         fieldMode === 'read' &&
         editable !== false &&
-        editable?.(text, entity, index) !== false;
+        editable?.(text, row, index) !== false;
 
       const Component = showEditIcon ? Space : React.Fragment;
 
@@ -87,7 +88,7 @@ export function schemaToDescriptionsItem(
                     mode={fieldMode}
                     text={contentDom}
                     valueType={valueType}
-                    entity={entity}
+                    entity={row}
                     index={index}
                     emptyText={emptyText}
                     action={action}
@@ -114,7 +115,7 @@ export function schemaToDescriptionsItem(
                     mode={fieldMode}
                     text={contentDom}
                     valueType={valueType}
-                    entity={entity}
+                    entity={row}
                     index={index}
                     action={action}
                     editableUtils={editableUtils}

--- a/src/descriptions/schemaToDescriptionsItem.tsx
+++ b/src/descriptions/schemaToDescriptionsItem.tsx
@@ -1,5 +1,5 @@
 ﻿import { EditOutlined } from '@ant-design/icons';
-import { Descriptions, Space } from 'antd';
+import { Space } from 'antd';
 import type { DescriptionsItemType } from 'antd/es/descriptions';
 import React from 'react';
 import type { ProCoreActionType, UseEditableMapUtilType } from '../utils';
@@ -19,11 +19,6 @@ export function schemaToDescriptionsItem(
   const options: React.JSX.Element[] = [];
   const children = items
     ?.map?.((item, index) => {
-      if (React.isValidElement(item)) {
-        return {
-          children: item,
-        };
-      }
       const {
         valueEnum: _valueEnum,
         render: _render,
@@ -111,7 +106,7 @@ export function schemaToDescriptionsItem(
               ),
             } as DescriptionsItemType)
           : ((
-              <Descriptions.Item {...restItem} key={key} label={label}>
+              <React.Fragment key={key}>
                 <Component>
                   <FieldRender
                     {...item}
@@ -134,7 +129,7 @@ export function schemaToDescriptionsItem(
                     />
                   )}
                 </Component>
-              </Descriptions.Item>
+              </React.Fragment>
             ) as React.JSX.Element);
       if (valueType === 'option') {
         options.push(field as React.JSX.Element);

--- a/src/descriptions/typing.ts
+++ b/src/descriptions/typing.ts
@@ -1,9 +1,5 @@
 ﻿import type { DescriptionsProps, FormProps } from 'antd';
-import type { Breakpoint } from 'antd/es/_util/responsiveObserver';
-import type {
-  CellSemanticClassNames,
-  CellSemanticStyles,
-} from 'antd/es/descriptions/DescriptionsContext';
+import type { DescriptionsItemProps as AntdDescriptionsCellProps } from 'antd/es/descriptions/Item';
 import type React from 'react';
 import type { ProFieldFCMode } from '../provider';
 import type {
@@ -14,62 +10,68 @@ import type {
   RowEditableConfig,
 } from '../utils';
 import type { LabelTooltipType } from '../utils';
-import type { RequestData } from './useFetchData';
+import type { ProDescriptionsRequestResult } from './useFetchData';
 
-export interface DescriptionsItemProps {
-  prefixCls?: string;
-  className?: string;
-  style?: React.CSSProperties;
+/** antd Descriptions 单元格 props，与 `antd/es/descriptions/Item` 对齐 */
+export type DescriptionsItemProps = AntdDescriptionsCellProps;
+
+type ProDescriptionsCellLayout = Omit<
+  AntdDescriptionsCellProps,
+  'children' | 'label'
+> & {
   label?: React.ReactNode;
-  classNames?: CellSemanticClassNames;
-  styles?: CellSemanticStyles;
-  children: React.ReactNode;
-  span?:
-    | number
-    | 'filled'
-    | {
-        [key in Breakpoint]?: number;
-      };
-}
+  children?: React.ReactNode;
+};
 
-/** 描述列表单列：基于 {@link ProSchema}，含 hideInDescriptions、mode 等 */
-export type ProDescriptionsItemProps<
-  T = Record<string, any>,
-  ValueType = 'text',
+/**
+ * 描述列表单列配置（`columns` 数组元素）
+ */
+export type ProDescriptionsColumn<
+  TRecord = Record<string, unknown>,
+  TValueType = 'text',
 > = ProSchema<
-  T,
-  Omit<DescriptionsItemProps, 'children'> & {
+  TRecord,
+  ProDescriptionsCellLayout & {
     hide?: boolean;
     plain?: boolean;
     copyable?: boolean;
     ellipsis?: ProEllipsis;
     mode?: ProFieldFCMode;
-    children?: React.ReactNode;
     order?: number;
     index?: number;
   },
   ProSchemaComponentTypes,
-  ValueType
+  TValueType
 >;
+
+/**
+ * @deprecated 使用 {@link ProDescriptionsColumn}
+ */
+export type ProDescriptionsItemProps<
+  T = Record<string, unknown>,
+  ValueType = 'text',
+> = ProDescriptionsColumn<T, ValueType>;
 
 export type ProDescriptionsActionType = ProCoreActionType;
 
 export type ProDescriptionsProps<
-  RecordType = Record<string, any>,
-  ValueType = 'text',
-> = Omit<DescriptionsProps, 'children'> & {
-  params?: Record<string, any>;
+  TRecord extends Record<string, any> = Record<string, any>,
+  TValueType = 'text',
+> = Omit<DescriptionsProps, 'children' | 'items'> & {
+  params?: Record<string, unknown>;
   onRequestError?: (e: Error) => void;
-  request?: (params: Record<string, any> | undefined) => Promise<RequestData>;
-  columns?: ProDescriptionsItemProps<RecordType, ValueType>[];
+  request?: (
+    params: Record<string, unknown> | undefined,
+  ) => Promise<ProDescriptionsRequestResult<TRecord>>;
+  columns?: ProDescriptionsColumn<TRecord, TValueType>[];
   actionRef?: React.MutableRefObject<ProCoreActionType<any> | undefined>;
   loading?: boolean;
   onLoadingChange?: (loading?: boolean) => void;
   tooltip?: LabelTooltipType | string;
   formProps?: FormProps;
-  editable?: RowEditableConfig<RecordType>;
-  dataSource?: RecordType;
-  onDataSourceChange?: (value: RecordType) => void;
+  editable?: RowEditableConfig<TRecord>;
+  dataSource?: TRecord;
+  onDataSourceChange?: (value: TRecord | undefined) => void;
   emptyText?: React.ReactNode;
 };
 

--- a/src/descriptions/typing.ts
+++ b/src/descriptions/typing.ts
@@ -57,7 +57,7 @@ export type ProDescriptionsActionType = ProCoreActionType;
 export type ProDescriptionsProps<
   RecordType = Record<string, any>,
   ValueType = 'text',
-> = DescriptionsProps & {
+> = Omit<DescriptionsProps, 'children'> & {
   params?: Record<string, any>;
   onRequestError?: (e: Error) => void;
   request?: (params: Record<string, any> | undefined) => Promise<RequestData>;

--- a/src/descriptions/useFetchData.tsx
+++ b/src/descriptions/useFetchData.tsx
@@ -2,31 +2,34 @@ import { useControlledState } from '@rc-component/util';
 import { useCallback, useEffect } from 'react';
 import { useRefFunction } from '../utils';
 
-export type RequestData<T = any> = {
+export type ProDescriptionsRequestResult<T = unknown> = {
   data?: T;
   success?: boolean;
-  [key: string]: any;
-} & Record<string, any>;
-export type UseFetchDataAction<T extends RequestData> = {
-  dataSource: T['data'] | T;
-  setDataSource: (value: T['data'] | T) => void;
+};
+
+/** @deprecated 使用 {@link ProDescriptionsRequestResult} */
+export type RequestData<T = unknown> = ProDescriptionsRequestResult<T>;
+
+export type UseProDescriptionsFetchAction<TData> = {
+  dataSource: TData | undefined;
+  setDataSource: (value: TData | undefined) => void;
   loading?: boolean;
   reload: () => Promise<void>;
 };
 
-const useFetchData = <T extends RequestData>(
-  getData: () => Promise<T>,
+const useFetchData = <TData, TResponse extends ProDescriptionsRequestResult<TData>>(
+  getData: () => Promise<TResponse>,
   options?: {
-    effects?: any[];
+    effects?: unknown[];
     manual: boolean;
     loading?: boolean;
     onLoadingChange?: (loading?: boolean) => void;
     onRequestError?: (e: Error) => void;
-    dataSource?: T['data'];
-    defaultDataSource?: T['data'];
-    onDataSourceChange?: (value: T['data']) => void;
+    dataSource?: TData;
+    defaultDataSource?: TData;
+    onDataSourceChange?: (value: TData | undefined) => void;
   },
-): UseFetchDataAction<T> => {
+): UseProDescriptionsFetchAction<TData> => {
   const {
     onRequestError,
     effects,
@@ -35,16 +38,21 @@ const useFetchData = <T extends RequestData>(
     defaultDataSource,
     onDataSourceChange,
   } = options || {};
-  const [entity, setEntityInner] = useControlledState<T['data']>(
+  const [entity, setEntityInner] = useControlledState<TData | undefined>(
     defaultDataSource,
     dataSource,
   );
   const setEntity = useCallback(
-    (updater: T['data'] | ((prev: T['data']) => T['data'])) => {
+    (
+      updater:
+        | TData
+        | undefined
+        | ((prev: TData | undefined) => TData | undefined),
+    ) => {
       setEntityInner((prev) => {
         const next =
           typeof updater === 'function'
-            ? (updater as (p: T['data']) => T['data'])(prev)
+            ? (updater as (p: TData | undefined) => TData | undefined)(prev)
             : updater;
         onDataSourceChange?.(next);
         return next;
@@ -89,7 +97,7 @@ const useFetchData = <T extends RequestData>(
     [onLoadingChange],
   );
 
-  const updateDataAndLoading = (data: T) => {
+  const updateDataAndLoading = (data: TData | undefined) => {
     setEntity(data);
     setLoading(false);
   };

--- a/src/field/components/Money/InputNumberPopover.tsx
+++ b/src/field/components/Money/InputNumberPopover.tsx
@@ -11,7 +11,9 @@ export type InputNumberPopoverProps = InputNumberProps & {
   numberPopoverRender?: any;
 };
 
-const InputNumberPopover = React.forwardRef<any, InputNumberPopoverProps>(
+const InputNumberPopover: React.ForwardRefExoticComponent<
+  InputNumberPopoverProps & React.RefAttributes<any>
+> = React.forwardRef<any, InputNumberPopoverProps>(
   function InputNumberPopoverInner(
     {
       contentRender: content,
@@ -111,7 +113,5 @@ const InputNumberPopover = React.forwardRef<any, InputNumberPopoverProps>(
       </Popover>
     );
   },
-) as React.ForwardRefExoticComponent<
-  InputNumberPopoverProps & React.RefAttributes<any>
->;
+);
 export default InputNumberPopover;

--- a/tests/descriptions/editor.test.tsx
+++ b/tests/descriptions/editor.test.tsx
@@ -113,18 +113,14 @@ const DescriptionsDemo = (
     props.dataSource as any,
     props.dataSource,
   );
-  const setDataSource = useCallback(
-    (updater: DataSourceType | ((prev: DataSourceType) => DataSourceType)) => {
-      setDataSourceInner((prev) => {
-        const next =
-          typeof updater === 'function'
-            ? (updater as (p: DataSourceType) => DataSourceType)(prev)
-            : updater;
-        props.onDataSourceChange?.(next);
-        return next;
-      });
+  const handleDataSourceChange = useCallback(
+    (value: DataSourceType | undefined) => {
+      if (value !== undefined) {
+        setDataSourceInner(value);
+        props.onDataSourceChange?.(value);
+      }
     },
-    [props.onDataSourceChange],
+    [props.onDataSourceChange, setDataSourceInner],
   );
   return (
     <ProDescriptions<DataSourceType>
@@ -146,7 +142,7 @@ const DescriptionsDemo = (
         </a>
       }
       dataSource={dataSource}
-      onDataSourceChange={setDataSource}
+      onDataSourceChange={handleDataSourceChange}
       editable={{
         ...props,
         form,

--- a/tests/descriptions/index.test.tsx
+++ b/tests/descriptions/index.test.tsx
@@ -81,9 +81,9 @@ describe('descriptions', () => {
           },
         ]}
         request={async () => {
-          return new Promise((resolve) => {
+          return new Promise<{ data: Record<string, unknown> }>((resolve) => {
             setTimeout(() => {
-              resolve({ data: [] });
+              resolve({ data: {} });
             }, 5000);
           });
         }}
@@ -106,9 +106,9 @@ describe('descriptions', () => {
           ]}
           loading={false}
           request={async () => {
-            return new Promise((resolve) => {
+            return new Promise<{ data: Record<string, unknown> }>((resolve) => {
               setTimeout(() => {
-                resolve({ data: [] });
+                resolve({ data: {} });
               }, 5000);
             });
           }}
@@ -133,7 +133,10 @@ describe('descriptions', () => {
           title="高级定义列表 request"
           request={async () => {
             fn();
-            return new Promise((resolve) => {
+            return new Promise<{
+              success: boolean;
+              data: { id: string; date: string; money: string };
+            }>((resolve) => {
               setTimeout(() => {
                 resolve({
                   success: true,

--- a/tests/descriptions/index.test.tsx
+++ b/tests/descriptions/index.test.tsx
@@ -1,5 +1,5 @@
 ﻿import type { ProCoreActionType } from '@ant-design/pro-components';
-import { ProDescriptions, ProDescriptionsItem } from '@ant-design/pro-components';
+import { ProDescriptions } from '@ant-design/pro-components';
 import {
   cleanup,
   fireEvent,
@@ -157,21 +157,17 @@ describe('descriptions', () => {
               刷新
             </Button>
           }
-        >
-          test reload
-          <ProDescriptionsItem label="文本" dataIndex="id" />
-          <ProDescriptionsItem
-            dataIndex="date"
-            label="日期"
-            valueType="date"
-          />
-          <ProDescriptionsItem
-            label="money"
-            dataIndex="money"
-            valueType="money"
-            formItemRender={() => <Input />}
-          />
-        </ProDescriptions>
+          columns={[
+            { label: '文本', dataIndex: 'id' },
+            { dataIndex: 'date', label: '日期', valueType: 'date' },
+            {
+              label: 'money',
+              dataIndex: 'money',
+              valueType: 'money',
+              formItemRender: () => <Input />,
+            },
+          ]}
+        />
       );
     };
     const html = render(<Reload />);
@@ -223,15 +219,12 @@ describe('descriptions', () => {
             修改
           </Button>
         }
-      >
-        <ProDescriptionsItem label="文本" dataIndex="id" />
-        <ProDescriptionsItem dataIndex="date" label="日期" valueType="date" />
-        <ProDescriptionsItem
-          label="money"
-          dataIndex="money"
-          valueType="money"
-        />
-      </ProDescriptions>,
+        columns={[
+          { label: '文本', dataIndex: 'id' },
+          { dataIndex: 'date', label: '日期', valueType: 'date' },
+          { label: 'money', dataIndex: 'money', valueType: 'money' },
+        ]}
+      />,
     );
 
     // 等待数据加载完成
@@ -261,19 +254,12 @@ describe('descriptions', () => {
             </Button>
           }
           params={{ name: 'qixian' }}
-        >
-          <ProDescriptionsItem label="文本" dataIndex="id" />
-          <ProDescriptionsItem
-            dataIndex="date"
-            label="日期"
-            valueType="date"
-          />
-          <ProDescriptionsItem
-            label="money"
-            dataIndex="money"
-            valueType="money"
-          />
-        </ProDescriptions>,
+          columns={[
+            { label: '文本', dataIndex: 'id' },
+            { dataIndex: 'date', label: '日期', valueType: 'date' },
+            { label: 'money', dataIndex: 'money', valueType: 'money' },
+          ]}
+        />,
       );
     });
 
@@ -302,15 +288,12 @@ describe('descriptions', () => {
             修改
           </Button>
         }
-      >
-        <ProDescriptionsItem label="文本" dataIndex="id" />
-        <ProDescriptionsItem dataIndex="date" label="日期" valueType="date" />
-        <ProDescriptionsItem
-          label="money"
-          dataIndex="money"
-          valueType="money"
-        />
-      </ProDescriptions>,
+        columns={[
+          { label: '文本', dataIndex: 'id' },
+          { dataIndex: 'date', label: '日期', valueType: 'date' },
+          { label: 'money', dataIndex: 'money', valueType: 'money' },
+        ]}
+      />,
     );
 
     await waitFor(() => {
@@ -320,17 +303,13 @@ describe('descriptions', () => {
 
   it('🏊 Progress', async () => {
     const html = render(
-      <ProDescriptions>
-        <ProDescriptionsItem label="进度条1" valueType="progress">
-          40
-        </ProDescriptionsItem>
-        <ProDescriptionsItem label="进度条2" valueType="progress">
-          -1
-        </ProDescriptionsItem>
-        <ProDescriptionsItem label="进度条3" valueType="progress">
-          100
-        </ProDescriptionsItem>
-      </ProDescriptions>,
+      <ProDescriptions
+        columns={[
+          { label: '进度条1', valueType: 'progress', children: 40 },
+          { label: '进度条2', valueType: 'progress', children: -1 },
+          { label: '进度条3', valueType: 'progress', children: 100 },
+        ]}
+      />,
     );
     await waitFor(() => {
       expect(
@@ -365,18 +344,11 @@ describe('descriptions', () => {
             valueType: 'text',
             order: 100,
           },
+          { order: 9, label: '进度条1', valueType: 'progress', children: 40 },
+          { label: '进度条2', valueType: 'progress', children: -1 },
+          { order: 8, label: '进度条3', valueType: 'progress', children: 100 },
         ]}
-      >
-        <ProDescriptionsItem order={9} label="进度条1" valueType="progress">
-          40
-        </ProDescriptionsItem>
-        <ProDescriptionsItem label="进度条2" valueType="progress">
-          -1
-        </ProDescriptionsItem>
-        <ProDescriptionsItem order={8} label="进度条3" valueType="progress">
-          100
-        </ProDescriptionsItem>
-      </ProDescriptions>,
+      />,
     );
     expect(html.asFragment()).toMatchSnapshot();
   });

--- a/tests/field/__snapshots__/field.test.tsx.snap
+++ b/tests/field/__snapshots__/field.test.tsx.snap
@@ -567,7 +567,7 @@ exports[`Field > 🐴 money valueType is Object 10`] = `
 exports[`Field > 🐴 money valueType is Object 11`] = `
 <DocumentFragment>
   <span>
-    100 RSD
+    100,00 RSD
   </span>
 </DocumentFragment>
 `;
@@ -575,7 +575,7 @@ exports[`Field > 🐴 money valueType is Object 11`] = `
 exports[`Field > 🐴 money valueType is Object 12`] = `
 <DocumentFragment>
   <span>
-    RSD100 RSD
+    RSD100,00 RSD
   </span>
 </DocumentFragment>
 `;

--- a/tests/table/__snapshots__/editor-table-two.test.tsx.snap
+++ b/tests/table/__snapshots__/editor-table-two.test.tsx.snap
@@ -388,31 +388,35 @@ exports[`EditorProTable 2 > 📝 EditableProTable support recordCreatorProps.pos
                               class="ant-typography css-var-r30"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -495,31 +499,35 @@ exports[`EditorProTable 2 > 📝 EditableProTable support recordCreatorProps.pos
                               class="ant-typography css-var-r30"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -602,31 +610,35 @@ exports[`EditorProTable 2 > 📝 EditableProTable support recordCreatorProps.pos
                               class="ant-typography css-var-r30"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>

--- a/tests/table/__snapshots__/editor-table.test.tsx.snap
+++ b/tests/table/__snapshots__/editor-table.test.tsx.snap
@@ -304,31 +304,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps 1`] =
                               class="ant-typography css-var-rbr"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -411,31 +415,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps 1`] =
                               class="ant-typography css-var-rbr"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -518,31 +526,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps 1`] =
                               class="ant-typography css-var-rbr"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -933,31 +945,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps=false
                               class="ant-typography css-var-r1"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -1040,31 +1056,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps=false
                               class="ant-typography css-var-r1"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>
@@ -1147,31 +1167,35 @@ exports[`EditorProTable > 📝 EditableProTable support recordCreatorProps=false
                               class="ant-typography css-var-r1"
                               style="margin: 0px; padding: 0px;"
                             >
-                              <button
-                                aria-label="复制"
-                                class="ant-typography-copy ant-typography-copy-icon-only"
-                                type="button"
+                              <span
+                                class="ant-typography-actions"
                               >
-                                <span
-                                  aria-label="copy"
-                                  class="anticon anticon-copy"
-                                  role="img"
+                                <button
+                                  aria-label="复制"
+                                  class="ant-typography-copy ant-typography-copy-icon-only"
+                                  type="button"
                                 >
-                                  <svg
-                                    aria-hidden="true"
-                                    data-icon="copy"
-                                    fill="currentColor"
-                                    focusable="false"
-                                    height="1em"
-                                    viewBox="64 64 896 896"
-                                    width="1em"
+                                  <span
+                                    aria-label="copy"
+                                    class="anticon anticon-copy"
+                                    role="img"
                                   >
-                                    <path
-                                      d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
-                                    />
-                                  </svg>
-                                </span>
-                              </button>
+                                    <svg
+                                      aria-hidden="true"
+                                      data-icon="copy"
+                                      fill="currentColor"
+                                      focusable="false"
+                                      height="1em"
+                                      viewBox="64 64 896 896"
+                                      width="1em"
+                                    >
+                                      <path
+                                        d="M832 64H296c-4.4 0-8 3.6-8 8v56c0 4.4 3.6 8 8 8h496v688c0 4.4 3.6 8 8 8h56c4.4 0 8-3.6 8-8V96c0-17.7-14.3-32-32-32zM704 192H192c-17.7 0-32 14.3-32 32v530.7c0 8.5 3.4 16.6 9.4 22.6l173.3 173.3c2.2 2.2 4.7 4 7.4 5.5v1.9h4.2c3.5 1.3 7.2 2 11 2H704c17.7 0 32-14.3 32-32V224c0-17.7-14.3-32-32-32zM350 856.2L263.9 770H350v86.2zM664 888H414V746c0-22.1-17.9-40-40-40H232V264h432v624z"
+                                      />
+                                    </svg>
+                                  </span>
+                                </button>
+                              </span>
                             </span>
                           </span>
                         </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Remove the `ProDescriptionsItem` export; `ProDescriptions` uses **only** the `columns` prop.
- **Types**: introduce `ProDescriptionsColumn` (alias: `ProDescriptionsItemProps`); `DescriptionsItemProps` aligns with `antd/es/descriptions/Item`; `ProDescriptionsProps` omits `children` and **`items`** (items are built internally).
- **Data / request**: `request` returns `ProDescriptionsRequestResult<TRecord>`; `params` is `Record<string, unknown>`; `onDataSourceChange` may receive `undefined`; descriptions `useFetchData` is generic over row type.
- **Bugfix**: `getDataFromConfig` now treats `null` as missing (previously wrong `||` condition).
- **CI**: Fix `father build` TS2742 on `InputNumberPopover` (explicit `ForwardRefExoticComponent` type); refresh snapshots for antd Typography copy-button DOM.

## Breaking changes

See `site/changelog.md` / `site/changelog.en-US.md` under 3.1.3-0.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e7e5043-c561-444e-b8b5-bf1d33b83990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e7e5043-c561-444e-b8b5-bf1d33b83990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

