### PR TITLE
fix(field): use ColorPickerProps from antd

### DIFF
--- a/src/form/components/ColorPicker/index.tsx
+++ b/src/form/components/ColorPicker/index.tsx
@@ -1,13 +1,9 @@
-﻿import type { PopoverProps } from 'antd';
+﻿import type { PopoverProps, ColorPickerProps } from 'antd';
 import React from 'react';
 import { FieldColorPicker } from '../../../field';
 import { ProConfigProvider } from '../../../provider';
 import type { ProFormFieldItemProps } from '../../typing';
 import ProFromField from '../Field';
-type ColorPickerProps = {
-  value?: string;
-  onChange?: (color: string) => void;
-};
 
 export type ProFormColorPickerProps =
   ProFormFieldItemProps<ColorPickerProps> & {


### PR DESCRIPTION
ProFormColorPicker的`fieldProps`类型应该从antd引用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新说明

* **重构**
  * 改进了 ColorPicker 表单组件的类型声明管理，采用更规范的方式组织组件类型定义，进一步增强代码的可维护性和集成一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->