### PR TITLE
refactor(layout): 精简菜单数据与叶子菜单标题 DOM 构建

### DIFF
--- a/src/layout/components/SiderMenu/BaseMenu.tsx
+++ b/src/layout/components/SiderMenu/BaseMenu.tsx
@@ -365,6 +365,80 @@ class MenuUtil {
     return finalName;
   };
 
+  renderLeafMenuTitleDom = (params: {
+    itemPath: string;
+    title: React.ReactNode;
+    hasIcon: boolean;
+    icon: React.ReactNode | null;
+    defaultIcon: React.ReactNode | null;
+    noGroupLevel: number;
+    isHttpLink: boolean;
+  }) => {
+    const {
+      itemPath,
+      title,
+      hasIcon,
+      icon,
+      defaultIcon,
+      noGroupLevel,
+      isHttpLink,
+    } = params;
+    const { baseClassName, menu, collapsed, hashId } = this.props;
+
+    const iconSpan = (
+      <span
+        className={clsx(`${baseClassName}-item-icon`, hashId)}
+        style={{
+          display: defaultIcon === null && !icon ? 'none' : '',
+        }}
+      >
+        {icon || <span>{defaultIcon}</span>}
+      </span>
+    );
+
+    const textSpan = (
+      <span
+        className={clsx(`${baseClassName}-item-text`, hashId, {
+          [`${baseClassName}-item-text-has-icon`]:
+            hasIcon && (icon || defaultIcon),
+        })}
+      >
+        {title}
+      </span>
+    );
+
+    const titleClassName = clsx(`${baseClassName}-item-title`, hashId, {
+      [`${baseClassName}-item-title-collapsed`]: collapsed,
+      [`${baseClassName}-item-title-collapsed-level-${noGroupLevel}`]:
+        collapsed,
+      [`${baseClassName}-item-collapsed-show-title`]:
+        menu?.collapsedShowTitle && collapsed,
+      [`${baseClassName}-item-link`]: isHttpLink,
+    });
+
+    if (isHttpLink) {
+      return (
+        <span
+          key={itemPath}
+          onClick={() => {
+            window?.open?.(itemPath, '_blank');
+          }}
+          className={titleClassName}
+        >
+          {iconSpan}
+          {textSpan}
+        </span>
+      );
+    }
+
+    return (
+      <div key={itemPath} className={titleClassName}>
+        {iconSpan}
+        {textSpan}
+      </div>
+    );
+  };
+
   /**
    * 判断是否是http链接.返回 Link 或 a Judge whether it is http link.return a or Link
    *
@@ -402,73 +476,16 @@ class MenuUtil {
     const defaultIcon =
       collapsed && hasIcon ? getMenuTitleSymbol(menuItemTitle) : null;
 
-    let defaultItem = (
-      <div
-        key={itemPath}
-        className={clsx(`${baseClassName}-item-title`, this.props?.hashId, {
-          [`${baseClassName}-item-title-collapsed`]: collapsed,
-          [`${baseClassName}-item-title-collapsed-level-${noGroupLevel}`]:
-            collapsed,
-          [`${baseClassName}-item-collapsed-show-title`]:
-            menu?.collapsedShowTitle && collapsed,
-        })}
-      >
-        <span
-          className={clsx(`${baseClassName}-item-icon`, this.props?.hashId)}
-          style={{
-            display: defaultIcon === null && !icon ? 'none' : '',
-          }}
-        >
-          {icon || <span>{defaultIcon}</span>}
-        </span>
-        <span
-          className={clsx(`${baseClassName}-item-text`, this.props?.hashId, {
-            [`${baseClassName}-item-text-has-icon`]:
-              hasIcon && (icon || defaultIcon),
-          })}
-        >
-          {menuItemTitle}
-        </span>
-      </div>
-    );
     const isHttpUrl = isUrl(itemPath);
-
-    // Is it a http link
-    if (isHttpUrl) {
-      defaultItem = (
-        <span
-          key={itemPath}
-          onClick={() => {
-            window?.open?.(itemPath, '_blank');
-          }}
-          className={clsx(`${baseClassName}-item-title`, this.props?.hashId, {
-            [`${baseClassName}-item-title-collapsed`]: collapsed,
-            [`${baseClassName}-item-title-collapsed-level-${noGroupLevel}`]:
-              collapsed,
-            [`${baseClassName}-item-link`]: true,
-            [`${baseClassName}-item-collapsed-show-title`]:
-              menu?.collapsedShowTitle && collapsed,
-          })}
-        >
-          <span
-            className={clsx(`${baseClassName}-item-icon`, this.props?.hashId)}
-            style={{
-              display: defaultIcon === null && !icon ? 'none' : '',
-            }}
-          >
-            {icon || <span>{defaultIcon}</span>}
-          </span>
-          <span
-            className={clsx(`${baseClassName}-item-text`, this.props?.hashId, {
-              [`${baseClassName}-item-text-has-icon`]:
-                hasIcon && (icon || defaultIcon),
-            })}
-          >
-            {menuItemTitle}
-          </span>
-        </span>
-      );
-    }
+    const defaultItem = this.renderLeafMenuTitleDom({
+      itemPath,
+      title: menuItemTitle,
+      hasIcon,
+      icon,
+      defaultIcon,
+      noGroupLevel,
+      isHttpLink: isHttpUrl,
+    });
     if (menuItemRender) {
       const renderItemProps = {
         ...item,

--- a/src/layout/utils/getMenuData.ts
+++ b/src/layout/utils/getMenuData.ts
@@ -1,16 +1,6 @@
 import { transformRoute } from '@umijs/route-utils';
 import type { MenuDataItem, MessageDescriptor, Route } from '../typing';
 
-function fromEntries(iterable: any) {
-  return [...iterable].reduce(
-    (obj: Record<string, MenuDataItem>, [key, val]) => {
-      obj[key] = val;
-      return obj;
-    },
-    {},
-  );
-}
-
 const getMenuData = (
   routes: Readonly<Route[]>,
   menu?: { locale?: boolean },
@@ -30,7 +20,7 @@ const getMenuData = (
 
   if (!menuDataRender) {
     return {
-      breadcrumb: fromEntries(breadcrumb),
+      breadcrumb: Object.fromEntries(breadcrumb),
       breadcrumbMap: breadcrumb,
       menuData,
     };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replace the custom `fromEntries` helper in `getMenuData` with `Object.fromEntries` for the breadcrumb plain object.
- Deduplicate leaf menu title DOM in `BaseMenu` by extracting `MenuUtil.renderLeafMenuTitleDom`, keeping the same markup and classes for both normal and HTTP link items.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx tests/layout/mobile.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

