### PR TITLE
style(ProLayout): 缩小 inline 侧栏分组标题字号

### DIFF
--- a/src/layout/components/SiderMenu/style/menu.ts
+++ b/src/layout/components/SiderMenu/style/menu.ts
@@ -489,6 +489,16 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
     },
 
     [`${c}-link`]: { display: 'block' },
+
+    /** inline 侧栏分组标题略小于默认 `groupTitleFontSize`，与菜单项层级区分更清晰 */
+    ...(mode === 'inline'
+      ? {
+          [`${c} ${c}-group-title`]: {
+            fontSize: 'var(--ant-font-size-sm)',
+            lineHeight: 'calc(var(--ant-font-size-sm) + 6px)',
+          },
+        }
+      : {}),
   };
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- For `mode === 'inline'` only, reduce `.ant-pro-base-menu-inline-group-title` text size by overriding `font-size` to `var(--ant-font-size-sm)` and tightening `line-height` so it stays proportional to the smaller type.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx --testNamePattern="group"` (1 test matched)

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

