### PR TITLE
fix(ProLayout): 去掉收起一级菜单项外层的 Tooltip 包裹

### DIFF
--- a/src/layout/components/SiderMenu/BaseMenu.tsx
+++ b/src/layout/components/SiderMenu/BaseMenu.tsx
@@ -55,6 +55,19 @@ const MenuItemTooltip = (props: {
     return props.children as React.JSX.Element;
   }
 
+  // 展开时无需气泡；收起且标题为纯文本时用原生 title，避免 antd Tooltip / rc-trigger 额外包一层 DOM
+  if (!props.collapsed) {
+    return props.children as React.JSX.Element;
+  }
+
+  const canUseNativeTitle =
+    typeof props.title === 'string' || typeof props.title === 'number';
+  if (canUseNativeTitle && React.isValidElement(props.children)) {
+    return React.cloneElement(props.children as React.ReactElement, {
+      title: String(props.title),
+    });
+  }
+
   return (
     <Tooltip
       title={props.title}

--- a/tests/layout/__snapshots__/index.test.tsx.snap
+++ b/tests/layout/__snapshots__/index.test.tsx.snap
@@ -10,14 +10,14 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r5u"
+      class="ant-layout ant-layout-has-sider css-var-r5e"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); width: 240px; overflow: hidden; max-width: 240px; min-width: 240px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 240px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r5v"
+        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r5f"
         data-testid="pro-layout-sider"
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); max-width: 240px; min-width: 240px; width: 240px; flex-grow: 0; flex-shrink: 0; flex-basis: 240px;"
       >
@@ -167,7 +167,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
               style="padding: 24px;"
             >
               <div
-                class="ant-skeleton ant-skeleton-active css-var-r5v"
+                class="ant-skeleton ant-skeleton-active css-var-r5f"
               >
                 <div
                   class="ant-skeleton-section"
@@ -224,7 +224,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout css-var-r62"
+      class="ant-layout css-var-r5i"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
@@ -390,7 +390,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
                   style="margin-block-start: 16px;"
                 >
                   <div
-                    class="ant-skeleton ant-skeleton-active css-var-r65"
+                    class="ant-skeleton ant-skeleton-active css-var-r5l"
                   >
                     <div
                       class="ant-skeleton-section"
@@ -424,14 +424,14 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r68"
+      class="ant-layout ant-layout-has-sider css-var-r5o"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); width: 215px; overflow: hidden; max-width: 215px; min-width: 215px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 215px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-fixed-mix ant-pro-sider-layout-mix ant-pro-sider-light ant-pro-sider-mix css-var-r69"
+        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-fixed-mix ant-pro-sider-layout-mix ant-pro-sider-light ant-pro-sider-mix css-var-r5p"
         data-testid="pro-layout-sider"
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); max-width: 215px; min-width: 215px; width: 215px; flex-grow: 0; flex-shrink: 0; flex-basis: 215px;"
       >
@@ -445,7 +445,7 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
               style="padding: 24px;"
             >
               <div
-                class="ant-skeleton ant-skeleton-active css-var-r69"
+                class="ant-skeleton ant-skeleton-active css-var-r5p"
               >
                 <div
                   class="ant-skeleton-section"
@@ -853,14 +853,14 @@ exports[`BasicLayout > 🥩 contentStyle should change dom 1`] = `
       class="ant-pro-layout-bg-list"
     />
     <div
-      class="ant-layout ant-layout-has-sider css-var-r3p"
+      class="ant-layout ant-layout-has-sider css-var-r3n"
       style="min-height: 100%; flex-direction: row;"
     >
       <div
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); width: 240px; overflow: hidden; max-width: 240px; min-width: 240px; transition: all 0.2s ease 0s; flex-grow: 0; flex-shrink: 0; flex-basis: 240px;"
       />
       <aside
-        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r3q"
+        class="ant-layout-sider ant-layout-sider-light ant-pro-sider ant-pro-sider-fixed ant-pro-sider-layout-side ant-pro-sider-light css-var-r3o"
         data-testid="pro-layout-sider"
         style="--pro-layout-sider-bg: #f7f8f9; --pro-layout-sider-color-text: var(--ant-color-text-secondary); --pro-layout-sider-color-text-title: var(--ant-color-text); --pro-layout-sider-color-text-secondary: var(--ant-color-text-tertiary); --pro-layout-sider-padding-inline-menu: 8px; --pro-layout-sider-padding-block-menu: 12px; --pro-layout-sider-border-radius: var(--ant-border-radius); --pro-layout-sider-color-bg-hover: var(--ant-color-fill-secondary); --pro-layout-sider-font-size: var(--ant-font-size); max-width: 240px; min-width: 240px; width: 240px; flex-grow: 0; flex-shrink: 0; flex-basis: 240px;"
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `MenuItemTooltip` no longer wraps leaf items in antd `Tooltip` when the sider is **expanded** (no tooltip needed).
- When **collapsed** and the menu title is plain `string` / `number`, use the native HTML `title` on the title child via `cloneElement` instead of `Tooltip`, removing the extra wrapper `div` between `li` and the title row.
- Rich titles (`ReactNode` from `menuTextRender` etc.) still use `Tooltip` for hover content.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx` (snapshots refreshed for `css-var-*` class hash churn in two cases)

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

