### PR TITLE
feat(ProLayout): 多级子菜单展开指示与层级边线

### DIFF
--- a/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
+++ b/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
@@ -1,3 +1,4 @@
+import { DownOutlined } from '@ant-design/icons';
 import { clsx } from 'clsx';
 import type { CSSProperties, HTMLAttributes } from 'react';
 import React, {
@@ -238,7 +239,17 @@ function renderPopup(
           }
         }}
       >
-        {node.label}
+        <span className={`${baseClassName}-submenu-title-text`}>
+          {node.label}
+        </span>
+        <span
+          className={clsx(`${baseClassName}-submenu-arrow`, {
+            [`${baseClassName}-submenu-arrow--open`]: isOpen,
+          })}
+          aria-hidden
+        >
+          <DownOutlined />
+        </span>
       </button>
       {popupPanel}
     </React.Fragment>
@@ -279,10 +290,22 @@ function renderInlineSubmenu(
           }
         }}
       >
-        {node.label}
+        <span className={`${baseClassName}-submenu-title-text`}>
+          {node.label}
+        </span>
+        <span
+          className={clsx(`${baseClassName}-submenu-arrow`, {
+            [`${baseClassName}-submenu-arrow--open`]: isOpen,
+          })}
+          aria-hidden
+        >
+          <DownOutlined />
+        </span>
       </button>
       {isOpen ? (
         <ul
+          data-pro-layout-nav-submenu-children
+          data-depth={depth}
           className={clsx(
             `${baseClassName}-list`,
             `${baseClassName}-submenu-children`,

--- a/src/layout/components/SiderMenu/style/menu.ts
+++ b/src/layout/components/SiderMenu/style/menu.ts
@@ -217,14 +217,28 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
       [`${c}-submenu-title`]: {
         ...rowItem,
         font: 'inherit',
-        /** 子菜单标题内联 DOM（与 leaf 一致） */
-        [`> *`]: {
+        gap: v('itemGap'),
+        [`${c}-submenu-title-text`]: {
           flex: 1,
           minWidth: 0,
           display: 'flex',
           flexDirection: 'row',
           alignItems: 'center',
           gap: v('itemGap'),
+        },
+        [`${c}-submenu-arrow`]: {
+          flexShrink: 0,
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: v('iconBox'),
+          height: v('iconBox'),
+          fontSize: '10px',
+          color: v('colorIcon'),
+          transition: `transform var(--ant-motion-duration-mid, 0.2s)`,
+        },
+        [`${c}-submenu-arrow--open`]: {
+          transform: 'rotate(-180deg)',
         },
         '&:hover': {
           backgroundColor: v('colorBgHover'),
@@ -246,6 +260,14 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
           minWidth: 0,
         },
       },
+
+      /** 二级及以下子列表：左边线 + 内缩，区分多级深度 */
+      [`${c}-submenu-children[data-pro-layout-nav-submenu-children]:not([data-depth="0"])`]:
+        {
+          marginInlineStart: 4,
+          paddingInlineStart: 10,
+          borderInlineStart: `1px solid ${v('colorDivider')}`,
+        },
 
       [`${c}-submenu-popup`]: {
         position: 'fixed',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Submenu title row**: wrap label in `*-submenu-title-text` and append a `DownOutlined` arrow in `*-submenu-arrow`; rotate 180° when open (`*-submenu-arrow--open`) for inline and popup submenu title buttons.
- **Nested depth**: inline submenu child lists (`ul.*-submenu-children`) get `data-pro-layout-nav-submenu-children` and `data-depth={depth}`; for `depth > 0`, add left inset + `border-inline-start` using `--pro-layout-nav-color-divider` so second/third levels read as nested.
- **Title layout**: submenu title uses flex with label flexing and arrow fixed width; removed the generic `> *` flex rule that would break the two-child structure.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

