### PR TITLE
fix(ProLayout): 修复顶栏与混合布局子菜单弹层点击立即关闭

### DIFF
--- a/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
+++ b/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
@@ -394,9 +394,12 @@ export const ProLayoutNavMenu: React.FC<ProLayoutNavMenuProps> = ({
     if (!popupMode) return;
     const handlePointerDown = (e: MouseEvent | TouchEvent) => {
       const root = rootNavRef.current;
+      const panel = popupPanelRef.current;
       const target = e.target as Node;
       if (!popupOpenKey) return;
       if (root?.contains(target)) return;
+      // 子菜单面板通过 portal 挂在 body 上，不在 rootNav 内；点在面板内不应视为「外部」关闭
+      if (panel?.contains(target)) return;
       setPopupOpenKey(null);
     };
     document.addEventListener('mousedown', handlePointerDown);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Horizontal / collapsed-vertical menus use `popupMode` with the submenu panel rendered via `createPortal` on `document.body`.
- The outside-click handler only checked `rootNavRef`, so any interaction inside the portal panel was treated as an outside click and immediately cleared `popupOpenKey`, making nested menus appear broken.
- Also treat `popupPanelRef.current` as part of the menu when deciding whether to close.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

