### PR TITLE
fix(ProLayout): 顶栏 fixed 滚动态与 mix 布局宽度对齐

### DIFF
--- a/src/layout/components/Header/index.tsx
+++ b/src/layout/components/Header/index.tsx
@@ -1,6 +1,12 @@
 import { ConfigProvider, Layout } from 'antd';
 import { clsx } from 'clsx';
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { isNeedOpenHash, ProProvider } from '../../../provider';
 import type { WithFalse } from '../../typing';
 import { clearMenuItem } from '../../utils/utils';
@@ -47,11 +53,31 @@ const DefaultHeader: React.FC<HeaderViewProps & PrivateSiderMenuProps> = (
     layout,
     headerRender,
     headerContentRender,
+    hasSiderMenu,
+    siderWidth,
   } = props;
   const { token } = useContext(ProProvider);
   const context = useContext(ConfigProvider.ConfigContext);
   const [isFixedHeaderScroll, setIsFixedHeaderScroll] = useState(false);
   const needFixedHeader = fixedHeader || layout === 'mix';
+
+  /** mix + fixed：顶栏 `position:fixed` 相对视口全宽会盖住侧栏，需与主内容区对齐 */
+  const fixedHeaderMixStyle = useMemo(() => {
+    if (!needFixedHeader || layout !== 'mix' || isMobile || !hasSiderMenu) {
+      return undefined;
+    }
+    const w =
+      typeof siderWidth === 'number'
+        ? siderWidth
+        : Number.parseInt(String(siderWidth ?? ''), 10);
+    if (!Number.isFinite(w) || w <= 0) {
+      return undefined;
+    }
+    return {
+      insetInlineStart: w,
+      width: `calc(100% - ${w}px)`,
+    } as const;
+  }, [needFixedHeader, layout, isMobile, hasSiderMenu, siderWidth]);
 
   const renderContent = useCallback(() => {
     const isTop = layout === 'top';
@@ -78,37 +104,23 @@ const DefaultHeader: React.FC<HeaderViewProps & PrivateSiderMenuProps> = (
     return defaultDom;
   }, [headerContentRender, headerRender, isMobile, layout, onCollapse, props]);
   useEffect(() => {
-    const dom = context?.getTargetContainer?.() || document.body;
-
-    const isFixedHeaderFn = () => {
-      const scrollTop = (dom as HTMLElement).scrollTop;
-
-      if (
-        scrollTop > (token.layout?.header?.heightLayoutHeader || 56) &&
-        !isFixedHeaderScroll
-      ) {
-        setIsFixedHeaderScroll(true);
-        return true;
-      }
-      if (isFixedHeaderScroll) {
-        setIsFixedHeaderScroll(false);
-      }
-      return false;
-    };
-
     if (!needFixedHeader) return;
     if (typeof window === 'undefined') return;
-    dom.addEventListener('scroll', isFixedHeaderFn, {
-      passive: true,
-    });
-    return () => {
-      dom.removeEventListener('scroll', isFixedHeaderFn);
+
+    const dom = context?.getTargetContainer?.() || document.body;
+    const threshold = token.layout?.header?.heightLayoutHeader || 56;
+
+    const handleScroll = () => {
+      const scrollTop = (dom as HTMLElement).scrollTop;
+      setIsFixedHeaderScroll(scrollTop > threshold);
     };
-  }, [
-    token.layout?.header?.heightLayoutHeader,
-    needFixedHeader,
-    isFixedHeaderScroll,
-  ]);
+
+    handleScroll();
+    dom.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      dom.removeEventListener('scroll', handleScroll);
+    };
+  }, [context, needFixedHeader, token.layout?.header?.heightLayoutHeader]);
 
   const isTop = layout === 'top';
   const baseClassName = `${prefixCls}-layout-header`;
@@ -154,12 +166,13 @@ const DefaultHeader: React.FC<HeaderViewProps & PrivateSiderMenuProps> = (
                 backgroundColor: 'transparent',
                 zIndex: 19,
                 ...style,
+                ...fixedHeaderMixStyle,
               }}
             />
           )}
           <Header
             className={className}
-            style={style}
+            style={{ ...style, ...fixedHeaderMixStyle }}
             data-testid="pro-layout-header"
           >
             {renderContent()}

--- a/tests/layout/__snapshots__/index.test.tsx.snap
+++ b/tests/layout/__snapshots__/index.test.tsx.snap
@@ -489,11 +489,12 @@ exports[`BasicLayout > 🥩 BasicLayout menu support menu.true 1`] = `
       >
         <header
           class="ant-layout-header"
-          style="height: 56px; line-height: 56px; background-color: transparent; z-index: 19;"
+          style="height: 56px; line-height: 56px; background-color: transparent; z-index: 19; inset-inline-start: 215px; width: calc(100% - 215px);"
         />
         <header
           class="ant-layout-header ant-pro-layout-header ant-pro-layout-header-fixed-header ant-pro-layout-header-mix ant-pro-layout-header-fixed-header-action ant-pro-layout-header-header"
           data-testid="pro-layout-header"
+          style="inset-inline-start: 215px; width: calc(100% - 215px);"
         >
           <div
             class="ant-pro-global-header"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Scroll state bug**: The fixed-header scroll listener always cleared `fixed-header-scroll` on every scroll event once `isFixedHeaderScroll` was true (wrong `if (isFixedHeaderScroll) set false` branch). Rework to `setIsFixedHeaderScroll(scrollTop > threshold)` and run once on mount.
- **Mix + fixed layout**: When `layout === 'mix'` with a sider (`hasSiderMenu`) and fixed header behavior, `position: fixed` + `width: 100%` pins the header to the viewport and overlaps the sider. Apply `inset-inline-start: siderWidth` + `width: calc(100% - siderWidth)` to both the spacer header and the real header so the fixed bar aligns with the main column (RTL-safe via logical properties).

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx` (snapshot updated for mix layout header inline styles)

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

