### PR TITLE
style(ProLayout): 优化侧栏收起时菜单项对齐动画

### DIFF
--- a/src/layout/components/SiderMenu/BaseMenu.tsx
+++ b/src/layout/components/SiderMenu/BaseMenu.tsx
@@ -87,6 +87,11 @@ export type BaseMenuProps = {
   iconPrefixes?: string;
   /** 合并到自研菜单根节点 `nav` 上的 DOM 属性（不再透传 antd Menu） */
   menuProps?: ProLayoutNavMenuDomProps;
+  /**
+   * 侧栏收起宽度动画结束后（ms）再在根 `nav` 上标记 `data-pro-layout-nav-collapse-settled`，
+   * 用于「动画中左对齐、落定后居中」的菜单项布局；`0` 表示立即 settled（顶栏等场景）。
+   */
+  collapseLayoutDelayMs?: number;
   style?: React.CSSProperties;
   formatMessage?: (message: MessageDescriptor) => string;
 
@@ -528,6 +533,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
     onSelect: propsOnSelect,
     menuRenderType,
     openKeys: propsOpenKeys,
+    collapseLayoutDelayMs = 0,
   } = props;
 
   const baseClassName = `${prefixClsProp}-base-menu-${mode}`;
@@ -666,6 +672,26 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
 
   const { wrapSSR, hashId } = useStyle(baseClassName, mode);
 
+  const needCollapseLayoutSettle =
+    mode === 'vertical' && !!props.collapsed && collapseLayoutDelayMs > 0;
+  const [collapseLayoutSettled, setCollapseLayoutSettled] = useState(
+    () => !needCollapseLayoutSettle,
+  );
+
+  useEffect(() => {
+    if (!needCollapseLayoutSettle) {
+      setCollapseLayoutSettled(true);
+      return;
+    }
+    setCollapseLayoutSettled(false);
+    const timer = window.setTimeout(() => {
+      setCollapseLayoutSettled(true);
+    }, collapseLayoutDelayMs);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [needCollapseLayoutSettle, collapseLayoutDelayMs, props.collapsed]);
+
   const menuUtils = useMemo(() => {
     return new MenuUtil({
       ...props,
@@ -729,6 +755,7 @@ const BaseMenu: React.FC<BaseMenuProps & PrivateSiderMenuProps> = (props) => {
       hashId={hashId}
       mode={mode!}
       collapsed={props.collapsed}
+      collapseLayoutSettled={collapseLayoutSettled}
       selectedKeys={(selectedKeys || []).map((k) => String(k))}
       openKeys={inlineOpenKeys}
       defaultOpenKeys={defaultOpenKeysRef.current.map((k) => String(k))}

--- a/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
+++ b/src/layout/components/SiderMenu/ProLayoutNavMenu.tsx
@@ -22,6 +22,8 @@ export type ProLayoutNavMenuProps = {
   hashId: string;
   mode: MenuMode;
   collapsed?: boolean;
+  /** 侧栏宽度收起动画结束后为 true，用于延迟应用「图标居中」布局 */
+  collapseLayoutSettled?: boolean;
   selectedKeys?: string[];
   openKeys?: string[];
   defaultOpenKeys?: string[];
@@ -327,6 +329,7 @@ export const ProLayoutNavMenu: React.FC<ProLayoutNavMenuProps> = ({
   hashId,
   mode,
   collapsed,
+  collapseLayoutSettled = true,
   selectedKeys = [],
   openKeys: openKeysProp = [],
   defaultOpenKeys = [],
@@ -514,6 +517,11 @@ export const ProLayoutNavMenu: React.FC<ProLayoutNavMenuProps> = ({
           [`${baseClassName}--horizontal`]: true,
           [`${baseClassName}--collapsed`]: !!collapsed,
         })}
+        data-pro-layout-nav-collapse-settled={
+          mode === 'vertical' && collapsed && collapseLayoutSettled
+            ? ''
+            : undefined
+        }
         style={style}
         role="menubar"
       >
@@ -530,6 +538,11 @@ export const ProLayoutNavMenu: React.FC<ProLayoutNavMenuProps> = ({
       className={clsx(className, hashId, baseClassName, listClassName, {
         [`${baseClassName}--collapsed`]: !!collapsed,
       })}
+      data-pro-layout-nav-collapse-settled={
+        mode === 'vertical' && collapsed && collapseLayoutSettled
+          ? ''
+          : undefined
+      }
       style={style}
       role="menu"
     >

--- a/src/layout/components/SiderMenu/SiderMenu.tsx
+++ b/src/layout/components/SiderMenu/SiderMenu.tsx
@@ -196,6 +196,9 @@ export type SiderMenuProps = {
   style?: CSSProperties;
 } & Pick<BaseMenuProps, Exclude<keyof BaseMenuProps, ['onCollapse']>>;
 
+/** 与 `Sider` 上 `transition: all 0.2s` 对齐，收起宽度动画结束后再切换菜单项居中布局 */
+export const PRO_LAYOUT_SIDER_COLLAPSE_LAYOUT_DELAY_MS = 200;
+
 export type PrivateSiderMenuProps = {
   matchMenuKeys: string[];
   originCollapsed?: boolean;
@@ -281,6 +284,7 @@ const SiderMenu: React.FC<SiderMenuProps & PrivateSiderMenuProps> = (props) => {
           key="base-menu"
           mode={collapsed && !isMobile ? 'vertical' : 'inline'}
           onOpenChange={onOpenChange}
+          collapseLayoutDelayMs={!isMobile ? PRO_LAYOUT_SIDER_COLLAPSE_LAYOUT_DELAY_MS : 0}
           style={{
             width: '100%',
           }}

--- a/src/layout/components/SiderMenu/style/menu.ts
+++ b/src/layout/components/SiderMenu/style/menu.ts
@@ -432,18 +432,27 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
       gap: v('stackGap'),
     },
 
-    /** vertical 侧栏收起：标题区占满行并左对齐，避免宽度从 100% 收到 20px + margin:auto 时的「先居中再落定」观感 */
+    /** vertical 收起：侧栏宽度动画中左对齐；`data-pro-layout-nav-collapse-settled` 后再收窄居中（由 BaseMenu 延迟设置） */
     ...(mode === 'vertical'
       ? {
-          [`&--collapsed ${c}-item-title-collapsed`]: {
-            width: '100%',
-            minWidth: 0,
-            maxWidth: '100%',
-            marginInline: 0,
-            alignSelf: 'stretch',
-            justifyContent: 'flex-start',
-            alignItems: 'flex-start',
-          },
+          [`&--collapsed:not([data-pro-layout-nav-collapse-settled]) ${c}-item-title-collapsed`]:
+            {
+              width: '100%',
+              minWidth: 0,
+              maxWidth: '100%',
+              marginInline: 0,
+              alignSelf: 'stretch',
+              justifyContent: 'flex-start',
+              alignItems: 'flex-start',
+            },
+          [`&--collapsed[data-pro-layout-nav-collapse-settled] ${c}-item-title-collapsed`]:
+            {
+              width: 20,
+              minWidth: 20,
+              maxWidth: 20,
+              marginInline: 'auto',
+              alignSelf: 'center',
+            },
         }
       : {}),
 

--- a/src/layout/components/SiderMenu/style/menu.ts
+++ b/src/layout/components/SiderMenu/style/menu.ts
@@ -432,15 +432,17 @@ const genProLayoutBaseMenuStyle: GenerateStyle<ProLayoutBaseMenuToken> = (
       gap: v('stackGap'),
     },
 
-    /** vertical（侧栏收起）下标题区收窄为 20px 宽，便于在窄侧栏内居中 */
+    /** vertical 侧栏收起：标题区占满行并左对齐，避免宽度从 100% 收到 20px + margin:auto 时的「先居中再落定」观感 */
     ...(mode === 'vertical'
       ? {
           [`&--collapsed ${c}-item-title-collapsed`]: {
-            width: 20,
-            minWidth: 20,
-            maxWidth: 20,
-            marginInline: 'auto',
-            alignSelf: 'center',
+            width: '100%',
+            minWidth: 0,
+            maxWidth: '100%',
+            marginInline: 0,
+            alignSelf: 'stretch',
+            justifyContent: 'flex-start',
+            alignItems: 'flex-start',
           },
         }
       : {}),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **First commit**: vertical collapsed menu title row stays start-aligned during sider width transition (no centering drift).
- **This commit**: after sider `0.2s` width animation, apply narrow centered title strip again:
  - `SiderMenu` passes `collapseLayoutDelayMs={PRO_LAYOUT_SIDER_COLLAPSE_LAYOUT_DELAY_MS}` (200) to `BaseMenu` (desktop only).
  - `BaseMenu` toggles `collapseLayoutSettled` with `setTimeout`; `ProLayoutNavMenu` sets `data-pro-layout-nav-collapse-settled` on the root `nav` when vertical + collapsed + settled.
  - CSS: `--collapsed` without attribute = full-width start layout; `--collapsed[data-pro-layout-nav-collapse-settled]` = 20px + `margin-inline: auto` + `align-self: center`.

## Testing

- `pnpm exec vitest run tests/layout/index.test.tsx tests/layout/mobile.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd7be216-bca1-4abd-9fef-c7ea1ae1f5cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

