### PR TITLE
fix(site): external link SVG inherits theme color in dark mode

### DIFF
--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,7 +1,31 @@
 // 全局样式文件
 // 用于定制文档站点的样式
 
-// Markdown 外链旁装饰 SVG（常为硬编码深色 fill）：与文字链同色，暗色模式下可见
+// 外链图标：Less 里若写 content: url(data:image/svg+xml;base64,...) 未整体加引号，
+// 分号会被当成语句结束导致编译失败；应用 url("data:...")、~"url(...)" 或改用下方 mask。
+// 使用 mask + currentColor，暗色模式与链接文字同色；已有内联 svg 时不重复追加（:has）
+
+@markdown-external-link-icon-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMCAxaDF2NGgtMVYzLjRMNi43IDYuNyA2IDZsNC00VjF6TTIgM2gzdjFIM3Y2aDZWOGgxdjNhMSAxIDAgMDEtMSAxSDNhMSAxIDAgMDEtMS0xVjRhMSAxIDAgMDExLTF6Ii8+PC9zdmc+';
+
+.markdown a[target='_blank']:not(:has(svg))::after {
+  content: '';
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-inline-start: 0.25em;
+  vertical-align: -0.125em;
+  background-color: currentcolor;
+  mask-image: url(@markdown-external-link-icon-data-uri);
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  -webkit-mask-image: url(@markdown-external-link-icon-data-uri);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
+}
+
+// Markdown 内外链旁内联 SVG（常为硬编码深色 fill）：与文字链同色
 .markdown a[target='_blank'] svg {
   fill: currentcolor;
   stroke: currentcolor;

--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,56 +1,6 @@
 // 全局样式文件
 // 用于定制文档站点的样式
 
-// 外链图标：Less 里若写 content: url(data:image/svg+xml;base64,...) 未整体加引号，
-// 分号会被当成语句结束导致编译失败；应用 url("data:...")、~"url(...)" 或改用下方 mask。
-// 使用 mask + currentColor，暗色模式与链接文字同色；已有内联 svg 时不重复追加（:has）
-
-// 亮色 / 暗色可各用一套 base64 外形；换图时只改对应变量
-@markdown-external-link-icon-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMCAxaDF2NGgtMVYzLjRMNi43IDYuNyA2IDZsNC00VjF6TTIgM2gzdjFIM3Y2aDZWOGgxdjNhMSAxIDAgMDEtMSAxSDNhMSAxIDAgMDEtMS0xVjRhMSAxIDAgMDExLTF6Ii8+PC9zdmc+';
-@markdown-external-link-icon-dark-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMSAxSDd2MWgyLjU5TDUuMjkgNi4yOWwuNzEuNzFMMTAgMi41OVY1aDFWMXpNMSAzdjhoOFY2SDh2NEgyVjRoNFYzSDF6Ii8+PC9zdmc+';
-
-.markdown a[target='_blank']:not(:has(svg))::after {
-  content: '';
-  display: inline-block;
-  width: 0.85em;
-  height: 0.85em;
-  margin-inline-start: 0.25em;
-  vertical-align: -0.125em;
-  background-color: currentcolor;
-  mask-image: url(@markdown-external-link-icon-data-uri);
-  mask-repeat: no-repeat;
-  mask-position: center;
-  mask-size: contain;
-  -webkit-mask-image: url(@markdown-external-link-icon-data-uri);
-  -webkit-mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  -webkit-mask-size: contain;
-}
-
-[data-prefers-color='dark'] .markdown a[target='_blank']:not(:has(svg))::after {
-  mask-image: url(@markdown-external-link-icon-dark-data-uri);
-  -webkit-mask-image: url(@markdown-external-link-icon-dark-data-uri);
-}
-
-// Markdown 内外链旁内联 SVG（常为硬编码深色 fill）：与文字链同色
-.markdown a[target='_blank'] svg {
-  fill: currentcolor;
-  stroke: currentcolor;
-  vertical-align: -0.125em;
-
-  path,
-  polygon,
-  circle,
-  rect {
-    &:not([fill='none']) {
-      fill: currentcolor;
-    }
-    &[stroke]:not([stroke='none']) {
-      stroke: currentcolor;
-    }
-  }
-}
-
 // 代码块样式优化
 .markdown {
   pre {

--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -5,7 +5,9 @@
 // 分号会被当成语句结束导致编译失败；应用 url("data:...")、~"url(...)" 或改用下方 mask。
 // 使用 mask + currentColor，暗色模式与链接文字同色；已有内联 svg 时不重复追加（:has）
 
+// 亮色 / 暗色可各用一套 base64 外形；换图时只改对应变量
 @markdown-external-link-icon-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMCAxaDF2NGgtMVYzLjRMNi43IDYuNyA2IDZsNC00VjF6TTIgM2gzdjFIM3Y2aDZWOGgxdjNhMSAxIDAgMDEtMSAxSDNhMSAxIDAgMDEtMS0xVjRhMSAxIDAgMDExLTF6Ii8+PC9zdmc+';
+@markdown-external-link-icon-dark-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMSAxSDd2MWgyLjU5TDUuMjkgNi4yOWwuNzEuNzFMMTAgMi41OVY1aDFWMXpNMSAzdjhoOFY2SDh2NEgyVjRoNFYzSDF6Ii8+PC9zdmc+';
 
 .markdown a[target='_blank']:not(:has(svg))::after {
   content: '';
@@ -23,6 +25,11 @@
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;
   -webkit-mask-size: contain;
+}
+
+[data-prefers-color='dark'] .markdown a[target='_blank']:not(:has(svg))::after {
+  mask-image: url(@markdown-external-link-icon-dark-data-uri);
+  -webkit-mask-image: url(@markdown-external-link-icon-dark-data-uri);
 }
 
 // Markdown 内外链旁内联 SVG（常为硬编码深色 fill）：与文字链同色

--- a/.dumi/global.less
+++ b/.dumi/global.less
@@ -1,6 +1,25 @@
 // 全局样式文件
 // 用于定制文档站点的样式
 
+// Markdown 外链旁装饰 SVG（常为硬编码深色 fill）：与文字链同色，暗色模式下可见
+.markdown a[target='_blank'] svg {
+  fill: currentcolor;
+  stroke: currentcolor;
+  vertical-align: -0.125em;
+
+  path,
+  polygon,
+  circle,
+  rect {
+    &:not([fill='none']) {
+      fill: currentcolor;
+    }
+    &[stroke]:not([stroke='none']) {
+      stroke: currentcolor;
+    }
+  }
+}
+
 // 代码块样式优化
 .markdown {
   pre {

--- a/.dumirc.ts
+++ b/.dumirc.ts
@@ -1,5 +1,6 @@
-import { defineConfig } from 'dumi';
 import path from 'path';
+
+import { defineConfig } from 'dumi';
 
 export default defineConfig({
   title: 'ProComponents',
@@ -57,6 +58,7 @@ export default defineConfig({
   resolve: {
     docDirs: ['site'],
   },
+  plugins: [path.join(__dirname, 'site-dumi-plugin')],
   styles: [
     `.markdown table{table-layout: fixed;}`,
     // 组件文档：标题层级与示例块节奏（dumi 默认 previewer 已有 margin，此处补足文内排版）

--- a/site-dumi-plugin.ts
+++ b/site-dumi-plugin.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+
+import type { IApi } from 'umi';
+
+/**
+ * 文档站：将 site/theme 下的 Less 作为入口样式引入（走 Less 管线），
+ * 勿使用 .dumirc `styles` 传入整文件内容（会被当成外链 href）。
+ */
+export default function siteDumiPlugin(api: IApi) {
+  api.addEntryImports(() => {
+    return [
+      {
+        source: path.join(
+          api.paths.cwd,
+          'site/theme/markdownExternalLink.less',
+        ),
+      },
+    ];
+  });
+}

--- a/site/theme/markdownExternalLink.less
+++ b/site/theme/markdownExternalLink.less
@@ -1,0 +1,47 @@
+// Markdown 外链装饰：Less 里未加引号的 url(data:image/svg+xml;base64,...) 会在分号处截断，
+// 故 data URI 必须用引号包一层；mask + currentcolor 适配亮/暗色链接色。
+
+@markdown-external-link-icon-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMCAxaDF2NGgtMVYzLjRMNi43IDYuNyA2IDZsNC00VjF6TTIgM2gzdjFIM3Y2aDZWOGgxdjNhMSAxIDAgMDEtMSAxSDNhMSAxIDAgMDEtMS0xVjRhMSAxIDAgMDExLTF6Ii8+PC9zdmc+';
+// 暗色可选用不同外形（与亮色同一套则将变量改为相同字符串）
+@markdown-external-link-icon-dark-data-uri: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMiAxMiI+PHBhdGggZmlsbD0iYmxhY2siIGQ9Ik0xMSAxSDd2MWgyLjU5TDUuMjkgNi4yOWwuNzEuNzFMMTAgMi41OVY1aDFWMXpNMSAzdjhoOFY2SDh2NEgyVjRoNFYzSDF6Ii8+PC9zdmc+';
+
+.markdown a[target='_blank']:not(:has(svg))::after {
+  content: '';
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-inline-start: 0.25em;
+  vertical-align: -0.125em;
+  background-color: currentcolor;
+  mask-image: url(@markdown-external-link-icon-data-uri);
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: contain;
+  -webkit-mask-image: url(@markdown-external-link-icon-data-uri);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  -webkit-mask-size: contain;
+}
+
+[data-prefers-color='dark'] .markdown a[target='_blank']:not(:has(svg))::after {
+  mask-image: url(@markdown-external-link-icon-dark-data-uri);
+  -webkit-mask-image: url(@markdown-external-link-icon-dark-data-uri);
+}
+
+.markdown a[target='_blank'] svg {
+  fill: currentcolor;
+  stroke: currentcolor;
+  vertical-align: -0.125em;
+
+  path,
+  polygon,
+  circle,
+  rect {
+    &:not([fill='none']) {
+      fill: currentcolor;
+    }
+    &[stroke]:not([stroke='none']) {
+      stroke: currentcolor;
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Markdown `target="_blank"` links show an external-link decoration. Embedding raw Less in `.dumirc.ts` `styles` is unsafe: long strings become `<link href="…">` in static HTML.

This PR:

1. Keeps **`site/theme/markdownExternalLink.less`** as the editable source (mask SVG data URIs with quoted strings; separate icon for `[data-prefers-color=dark]`; `:not(:has(svg))` to avoid double icons + inline SVG `currentColor` overrides).
2. **`site-dumi-plugin.ts`** uses **`api.addEntryImports`** to import that Less file through the normal Less/Webpack pipeline (compiled into the main CSS bundle).
3. **`.dumirc.ts`** registers the plugin; `.dumi/global.less` stays the original doc-only tweaks only.

## Test plan

- `pnpm exec cross-env SITE_DEPLOY='TRUE' dumi build` succeeds.
- Built HTML has no bogus `<link>` to Less source; `umi.*.css` contains the markdown external-link rules.

Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6338d53c-023f-4ff6-b697-77915ee855ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6338d53c-023f-4ff6-b697-77915ee855ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 为Markdown外部链接添加了视觉指示器，标记将在新标签页打开的链接
  * 支持亮色和暗色主题的图标样式自适应

<!-- end of auto-generated comment: release notes by coderabbit.ai -->