### PR TITLE
fix(nanoid): guard window access so SSR / Cloudflare Workers don't crash

### DIFF
--- a/src/utils/nanoid/index.ts
+++ b/src/utils/nanoid/index.ts
@@ -22,8 +22,9 @@ let genNanoid = (t = 21) => {
  * @description 生成uuid，如果不支持 randomUUID，就用 genNanoid
  */
 export const nanoid = (): string => {
-  if (window?.crypto?.randomUUID && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
+  if (typeof window === 'undefined') return genNanoid();
+  if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+    return window.crypto.randomUUID();
   }
   return genNanoid();
 };


### PR DESCRIPTION
### Background

`src/utils/nanoid/index.ts` currently does:

```ts
export const nanoid = (): string => {
  if (window?.crypto?.randomUUID && typeof crypto.randomUUID === 'function') {
    return crypto.randomUUID();
  }
  return genNanoid();
};
```

`window?.crypto?.randomUUID` still references the bare identifier `window`, so in any non-browser runtime (Node SSR, Next.js server components, edge runtimes such as Cloudflare Workers, Vitest/Jest with `testEnvironment: 'node'`, etc.) this throws `ReferenceError: window is not defined` the moment a Pro component that uses `nanoid` (e.g. `ProForm`, `ProTable` internals) is imported on the server.

`genNanoid` already handles the `typeof window === 'undefined'` case, but `nanoid` itself does not, so we never reach that fallback.

### Change

- Early-return `genNanoid()` when `typeof window === 'undefined'`.
- Access `window.crypto.randomUUID` through the `window` object instead of the bare `crypto` global, matching the guard condition.

No behavior change in the browser: when `window.crypto.randomUUID` is available it is still used; otherwise `genNanoid()` is returned. Only the SSR/edge crash is fixed.

### Repro (before)

```ts
// next.js server component / edge runtime
import { nanoid } from '@ant-design/pro-components/es/utils/nanoid';
nanoid();
// ReferenceError: window is not defined
```

### After

Runs without throwing on server, returns a `genNanoid()` id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了在非浏览器环境下的兼容性，确保在各种运行环境中都能正常工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->