### PR TITLE
fix: accept deprecated layout mix in ProSettings for tsc

### DIFF
--- a/src/layout/defaultSettings.ts
+++ b/src/layout/defaultSettings.ts
@@ -11,13 +11,14 @@ export type RenderSetting = {
 export type PureSettings = {
   /**
    * @name layout 的布局方式
-   * @type  'side' | 'top'
+   * @type  'side' | 'top' | 'mix'
    *
    * @example 顶部菜单 layout="top"
    * @example 侧边菜单 layout="side"
    * @example 顶栏一级菜单 + 侧栏子菜单：layout="side" 且 `splitMenus`，或用 `headerMenuRender` 自定义顶栏菜单
+   * @deprecated `layout="mix"` 仍会被接受，运行时按 `side` 处理，见 ProLayout 内注释
    */
-  layout?: 'side' | 'top';
+  layout?: 'side' | 'top' | 'mix';
   /** @name layout of content: `Fluid` or `Fixed`, only works when layout is top */
   contentWidth?: ContentWidth;
   /** @name sticky header */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`ProLayout` already normalizes `layout="mix"` to `side` at runtime, but `ProSettings['layout']` was typed as only `'side' | 'top'`, which made `tests/layout/index.test.tsx` fail `tsc`.

Widen the public type to include `'mix'` and document it as deprecated so TypeScript matches runtime behavior.

## Verification

- `pnpm run tsc`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c400606-3993-4bfe-bf4f-3787248a63cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c400606-3993-4bfe-bf4f-3787248a63cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新特性

* 新增混合布局模式。应用现在支持侧边栏、顶部和混合三种布局选项，为用户提供更加灵活的界面配置选择。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->