### PR TITLE
refactor(layout): declare mix layout on ProLayoutProps only

### DIFF
--- a/src/layout/ProLayout.tsx
+++ b/src/layout/ProLayout.tsx
@@ -75,7 +75,32 @@ type GlobalTypes = Omit<
   'collapsed'
 >;
 
-export type ProLayoutProps = GlobalTypes & {
+/** ProLayout 根 props 上的 `layout`；含历史 `mix`（运行时按 `side` 处理） */
+export type ProLayoutLayoutMode = 'side' | 'top' | 'mix';
+
+const menuLayoutForPureSettings = (
+  layout: ProLayoutLayoutMode | undefined,
+): NonNullable<ProSettings['layout']> =>
+  layout === 'mix' || layout === undefined ? 'side' : layout;
+
+/** `menuRender` 回调首参：与 Header 一致，不含历史 `mix` */
+export type ProLayoutMenuRenderCallbackProps = Omit<ProLayoutProps, 'layout'> & {
+  layout?: NonNullable<ProSettings['layout']>;
+};
+
+const toMenuRenderCallbackProps = (
+  p: ProLayoutProps,
+): ProLayoutMenuRenderCallbackProps => ({
+  ...p,
+  layout: menuLayoutForPureSettings(p.layout),
+});
+
+export type ProLayoutProps = Omit<GlobalTypes, 'layout'> & {
+  /**
+   * @name layout 的布局方式（根组件）
+   * @deprecated `layout="mix"` 仍会被接受，运行时按 `side` 处理
+   */
+  layout?: ProLayoutLayoutMode;
   /** 受控菜单选中项 */
   selectedKeys?: string[];
   /** 受控子菜单展开项，`false` 表示非受控 */
@@ -286,6 +311,7 @@ const headerRender = (
     <Header
       matchMenuKeys={matchMenuKeys}
       {...props}
+      layout={menuLayoutForPureSettings(props.layout)}
       stylish={props.stylish?.header}
     />
   );
@@ -344,6 +370,7 @@ const renderSiderMenu = (
       <SiderMenu
         matchMenuKeys={matchMenuKeys}
         {...props}
+        layout={menuLayoutForPureSettings(props.layout)}
         hide
         stylish={props.stylish?.sider}
       />
@@ -354,13 +381,14 @@ const renderSiderMenu = (
     <SiderMenu
       matchMenuKeys={matchMenuKeys}
       {...props}
+      layout={menuLayoutForPureSettings(props.layout)}
       // 这里走了可以少一次循环
       menuData={clearMenuData}
       stylish={props.stylish?.sider}
     />
   );
   if (menuRender) {
-    return menuRender(props, defaultDom);
+    return menuRender(toMenuRenderCallbackProps(props), defaultDom);
   }
 
   return defaultDom;
@@ -588,10 +616,9 @@ const BaseProLayout: React.FC<ProLayoutProps> = (props) => {
   };
 
   /** 历史 `mix` 已移除，按侧栏布局处理，避免旧配置直接失效 */
-  const propsLayout: NonNullable<ProSettings['layout']> =
-    (propsLayoutRaw as string | undefined) === 'mix'
-      ? 'side'
-      : propsLayoutRaw ?? 'side';
+  const propsLayout = menuLayoutForPureSettings(
+    propsLayoutRaw as ProLayoutLayoutMode | undefined,
+  );
 
   const colSize = useBreakpoint();
 

--- a/src/layout/defaultSettings.ts
+++ b/src/layout/defaultSettings.ts
@@ -11,14 +11,13 @@ export type RenderSetting = {
 export type PureSettings = {
   /**
    * @name layout 的布局方式
-   * @type  'side' | 'top' | 'mix'
+   * @type  'side' | 'top'
    *
    * @example 顶部菜单 layout="top"
    * @example 侧边菜单 layout="side"
    * @example 顶栏一级菜单 + 侧栏子菜单：layout="side" 且 `splitMenus`，或用 `headerMenuRender` 自定义顶栏菜单
-   * @description `mix` 为历史值，ProLayout 内会按侧栏布局处理
    */
-  layout?: 'side' | 'top' | 'mix';
+  layout?: 'side' | 'top';
   /** @name layout of content: `Fluid` or `Fixed`, only works when layout is top */
   contentWidth?: ContentWidth;
   /** @name sticky header */

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -35,7 +35,11 @@ import { TopNavHeader } from './components/TopNavHeader';
 import type { RouteContextType } from './context/RouteContext';
 import { RouteContext } from './context/RouteContext';
 import { getPageTitle } from './getPageTitle';
-import type { ProLayoutProps } from './ProLayout';
+import type {
+  ProLayoutLayoutMode,
+  ProLayoutMenuRenderCallbackProps,
+  ProLayoutProps,
+} from './ProLayout';
 import { ProLayout } from './ProLayout';
 import { getMenuData } from './utils/getMenuData';
 
@@ -76,6 +80,8 @@ export type {
   ProLayoutNavMenuDomProps,
   ProLayoutNavMenuProps,
   ProLayoutNavMenuSelectInfo,
+  ProLayoutLayoutMode,
+  ProLayoutMenuRenderCallbackProps,
   ProLayoutProps,
   RouteContextType,
   TopNavHeaderProps,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`PureSettings.layout` in `defaultSettings` is again only `'side' | 'top'`. The deprecated root value `layout="mix"` is typed on `ProLayout` via `ProLayoutLayoutMode` on `ProLayoutProps` (`Omit<GlobalTypes, 'layout'>` so it does not widen `SiderMenuProps` / `BaseMenuProps`).

Runtime: `mix` is normalized to `side` when passing `layout` into `Header` and `SiderMenu`, and when invoking `menuRender` (new `ProLayoutMenuRenderCallbackProps` + `toMenuRenderCallbackProps` so the callback receives `HeaderViewProps`-compatible props).

## Exports

- `ProLayoutLayoutMode`
- `ProLayoutMenuRenderCallbackProps` (from `src/layout/index.tsx`)

## Verification

- `pnpm run tsc`
- `pnpm exec vitest run tests/layout/index.test.tsx`

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c400606-3993-4bfe-bf4f-3787248a63cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c400606-3993-4bfe-bf4f-3787248a63cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **改进**
  * 优化了布局配置系统，简化了可用的布局选项。已移除对特定已弃用布局模式的支持，现仅保留更稳定高效的布局方案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->