### PR TITLE
fix(site): avoid default otk-agentic-bubble-list layout in docs

### DIFF
--- a/site-dumi-plugin.ts
+++ b/site-dumi-plugin.ts
@@ -15,6 +15,12 @@ export default function siteDumiPlugin(api: IApi) {
           'site/theme/markdownExternalLink.less',
         ),
       },
+      {
+        source: path.join(
+          api.paths.cwd,
+          'site/theme/otkAgenticBubbleListReset.less',
+        ),
+      },
     ];
   });
 }

--- a/site/theme/otkAgenticBubbleListReset.less
+++ b/site/theme/otkAgenticBubbleListReset.less
@@ -1,0 +1,15 @@
+// 文档/演示中嵌入的 Ant Design Agentic 气泡列表默认包了一层固定布局；
+// 覆盖这些规则，避免在 ProComponents 站点中占用 flex/gap/滚动与最小高度行为。
+.otk-agentic-bubble-list {
+  display: block;
+  flex-direction: initial;
+  gap: 0;
+  min-height: 0;
+  padding: 0;
+  overflow: visible;
+}
+
+.otk-agentic-bubble-list .otk-agentic-bubble-list-content-list {
+  padding-top: 0;
+  padding-bottom: 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The class `.otk-agentic-bubble-list` (from Ant Design Agentic) applies a fixed flex column layout with `gap: 32px`, `min-height: 200px`, padding, and scroll overflow. This change adds a **site-level override** so the ProComponents dumi site does not inherit that behavior for embedded Agentic bubble lists.

## Changes

- New `site/theme/otkAgenticBubbleListReset.less` to reset those properties to neutral values (`display: block`, `gap: 0`, `min-height: 0`, no extra padding, `overflow: visible`, and zero vertical padding on `.otk-agentic-bubble-list-content-list`).
- Register the file in `site-dumi-plugin.ts` next to `markdownExternalLink.less`.

## Note

`pnpm run tsc` was not run in this environment because `node_modules` is not installed.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c2b249d-4311-4a9e-bd74-183bc6ff3cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c2b249d-4311-4a9e-bd74-183bc6ff3cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

