### PR TITLE
fix(site): otk-task-list-simple default padding and content height

### DIFF
--- a/site-dumi-plugin.ts
+++ b/site-dumi-plugin.ts
@@ -15,6 +15,12 @@ export default function siteDumiPlugin(api: IApi) {
           'site/theme/markdownExternalLink.less',
         ),
       },
+      {
+        source: path.join(
+          api.paths.cwd,
+          'site/theme/otkTaskListSimpleSiteDefaults.less',
+        ),
+      },
     ];
   });
 }

--- a/site/theme/otkTaskListSimpleSiteDefaults.less
+++ b/site/theme/otkTaskListSimpleSiteDefaults.less
@@ -1,0 +1,8 @@
+// 文档/演示中嵌入的 Agentic 任务列表：站点侧默认与组件库一致
+.otk-task-list-simple {
+  padding: 0 4px;
+}
+
+.otk-task-list-simple-content {
+  height: 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set site (dumi) defaults for embedded Ant Design Agentic task list classes:

- `.otk-task-list-simple`: `padding: 0 4px`
- `.otk-task-list-simple-content`: `height: 0`

## Changes

- New `site/theme/otkTaskListSimpleSiteDefaults.less`
- Import it from `site-dumi-plugin.ts` via `addEntryImports` (same pattern as `markdownExternalLink.less`)

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c2b249d-4311-4a9e-bd74-183bc6ff3cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c2b249d-4311-4a9e-bd74-183bc6ff3cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 为任务列表组件添加了新的样式定义，包括水平内边距配置和初始折叠布局行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->