### PR TITLE
docs(site): ant-task-list-simple embed padding and collapsed content

### DIFF
--- a/site-dumi-plugin.ts
+++ b/site-dumi-plugin.ts
@@ -15,6 +15,12 @@ export default function siteDumiPlugin(api: IApi) {
           'site/theme/markdownExternalLink.less',
         ),
       },
+      {
+        source: path.join(
+          api.paths.cwd,
+          'site/theme/antTaskListSimpleSiteDefaults.less',
+        ),
+      },
     ];
   });
 }

--- a/site/theme/antTaskListSimpleSiteDefaults.less
+++ b/site/theme/antTaskListSimpleSiteDefaults.less
@@ -1,0 +1,10 @@
+// 文档/演示中嵌入的 Agentic 任务列表：站点侧默认与组件库一致
+.ant-task-list-simple {
+  padding: 0 4px;
+}
+
+.ant-task-list-simple.ant-task-list-simple-collapsed .ant-task-list-simple-content,
+.ant-task-list-simple .ant-task-list-simple-content.ant-task-list-simple-content-collapsed {
+  height: 0;
+  overflow: hidden;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds site-level Less defaults for embedded Agentic task list UI (`.ant-task-list-simple`).

## Changes

- **`site/theme/antTaskListSimpleSiteDefaults.less`**
  - `.ant-task-list-simple` uses `padding: 0 4px`
  - When collapsed (`.ant-task-list-simple-collapsed` on the root, or `.ant-task-list-simple-content-collapsed` on the content node), `.ant-task-list-simple-content` uses `height: 0` and `overflow: hidden` so the body does not reserve space when folded
- **`site-dumi-plugin.ts`**: import the new Less file through the existing entry pipeline (same pattern as `markdownExternalLink.less`)

If the embed only toggles a class on the root, use `ant-task-list-simple-collapsed` on `.ant-task-list-simple`. If it only marks the content node, use `ant-task-list-simple-content-collapsed` on `.ant-task-list-simple-content`.

> Submitted by Cursor
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a27c764-6b48-4e5b-a7a2-c076a89f9b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a27c764-6b48-4e5b-a7a2-c076a89f9b4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

