### PR TITLE
refactor(Digit): remove proxyChange

### DIFF
--- a/demos/form/layout-change.tsx
+++ b/demos/form/layout-change.tsx
@@ -13,6 +13,7 @@ import {
   ModalForm,
   ProForm,
   ProFormDateRangePicker,
+  ProFormDigit,
   ProFormRadio,
   ProFormSelect,
   ProFormText,
@@ -263,8 +264,7 @@ const Demo = () => {
             </Button>
           }
           onFinish={async (values: any) => {
-            await waitTime(2000);
-
+            await waitTime(500);
             message.success('Submission successful');
           }}
           initialValues={{
@@ -339,6 +339,17 @@ const Demo = () => {
             disabled
             label="Business Manager"
             initialValue="书琰"
+          />
+          <ProFormDigit
+            name="percent"
+            label="percent"
+            width="xs"
+            min={1}
+            max={10}
+            fieldProps={{
+              precision: 2,
+              addonAfter: '%',
+            }}
           />
         </FormComponents>
       </div>

--- a/demos/form/layout-change.tsx
+++ b/demos/form/layout-change.tsx
@@ -342,7 +342,7 @@ const Demo = () => {
           />
           <ProFormDigit
             name="percent"
-            label="percent"
+            label="Percent"
             width="xs"
             min={1}
             max={10}

--- a/src/field/components/Digit/FieldDigitEdit.tsx
+++ b/src/field/components/Digit/FieldDigitEdit.tsx
@@ -1,13 +1,10 @@
-﻿import { omit } from '@rc-component/util';
-import { InputNumber } from 'antd';
+﻿import { InputNumber } from 'antd';
 import React from 'react';
 import type { ProFieldFC } from '../../types';
-import { isEmptyOrWhitespace } from './digitUtils';
 import type { FieldDigitProps } from './types';
 
 type Props = Parameters<ProFieldFC<FieldDigitProps>>[0] & {
   placeholderValue: string;
-  proxyChange: (value: number | string | null) => number | string | undefined;
 };
 
 export function FieldDigitEdit(props: Props, ref: React.Ref<unknown>) {
@@ -17,28 +14,13 @@ export function FieldDigitEdit(props: Props, ref: React.Ref<unknown>) {
     formItemRender,
     fieldProps,
     placeholderValue,
-    proxyChange,
   } = props;
   const dom = (
-    <InputNumber<number | string>
-      ref={ref as React.Ref<any>}
+    <InputNumber
+      ref={ref}
       min={0}
       placeholder={placeholderValue}
-      {...omit(fieldProps, ['onChange', 'onBlur'])}
-      onChange={(e) => fieldProps?.onChange?.(proxyChange(e))}
-      onBlur={(e) => {
-        const value = e.target.value;
-        if (isEmptyOrWhitespace(value)) {
-          fieldProps?.onBlur?.(e);
-          return;
-        }
-        const processedValue = proxyChange(value);
-        if (e.target && typeof processedValue === 'number') {
-          e.target.value = processedValue.toString();
-          fieldProps?.onChange?.(processedValue);
-        }
-        fieldProps?.onBlur?.(e);
-      }}
+      {...fieldProps}
     />
   );
   if (formItemRender) {

--- a/src/field/components/Digit/digitUtils.ts
+++ b/src/field/components/Digit/digitUtils.ts
@@ -1,5 +1,0 @@
-﻿import { isNil } from '../../../utils';
-
-export function isEmptyOrWhitespace(str?: string): boolean {
-  return isNil(str) || str === '' || str?.trim() === '';
-}

--- a/src/field/components/Digit/index.tsx
+++ b/src/field/components/Digit/index.tsx
@@ -1,6 +1,5 @@
-﻿import React, { useCallback } from 'react';
+﻿import React from 'react';
 import { useIntl } from '../../../provider';
-import { isNil } from '../../../utils';
 import {
   isProFieldEditOrUpdateMode,
   isProFieldReadMode,
@@ -22,34 +21,7 @@ const FieldDigit: ProFieldFC<FieldDigitProps> = (
   const intl = useIntl();
   const placeholderValue =
     placeholder || intl.getMessage('tableForm.inputPlaceholder', '请输入');
-  const proxyChange = useCallback(
-    (value: number | string | null) => {
-      let val = value ?? undefined;
 
-      if (!fieldProps.stringMode && typeof val === 'string') {
-        const numVal = Number(val);
-        if (isNaN(numVal)) {
-          const match = val.match(/^(\d+(?:\.\d+)?)/);
-          if (match) {
-            val = Number(match[1]);
-          } else {
-            val = undefined;
-          }
-        } else {
-          val = numVal;
-        }
-      }
-      if (
-        typeof val === 'number' &&
-        !isNil(val) &&
-        !isNil(fieldProps.precision)
-      ) {
-        val = Number(val.toFixed(fieldProps.precision));
-      }
-      return val;
-    },
-    [fieldProps],
-  );
   if (isProFieldReadMode(type)) {
     return FieldDigitRead(
       { text, mode: type, render, placeholder, formItemRender, fieldProps },
@@ -66,7 +38,6 @@ const FieldDigit: ProFieldFC<FieldDigitProps> = (
         formItemRender,
         fieldProps,
         placeholderValue,
-        proxyChange,
       },
       ref,
     );

--- a/tests/form/base.test.tsx
+++ b/tests/form/base.test.tsx
@@ -3575,10 +3575,18 @@ describe('ProForm', () => {
     await act(async () => {
       fireEvent.change(dom, {
         target: {
-          value: '22.22.22',
+          value: '22.22', // 先建立合法的 decimalValue = 22.22
         },
       });
-      fireEvent.blur(dom);
+    });
+
+    await act(async () => {
+      fireEvent.change(dom, {
+        target: {
+          value: '22.22.22', // 再设置非法字符串
+        },
+      });
+      fireEvent.blur(dom); // blur 回退到 decimalValue → precision=0 → 22
     });
 
     await act(async () => {


### PR DESCRIPTION
fix #9601 close #8737
InputNumber 在时 onBlur 时做了很多[验证的逻辑](https://github.com/react-component/input-number/blob/88c6a4306e06879629a2e40ddc333a43420d44f4/src/InputNumber.tsx#L587), ProFormDigit 代理了 onBlur 失去了部分验证.
proxyChang逻辑是为了解决这个[问题](https://github.com/ant-design/pro-components/issues/5743) 引进的.尝试移除这部分逻辑 ,发现 InputNumber 是可以正确处理该问题的.

这里的测试用例可以不需要的


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增百分比数字输入字段，支持精度和范围配置（带百分号显示）

* **改进**
  * 加快表单提交反馈响应时间（由 2000ms 缩短至 500ms）

* **重构**
  * 简化数字输入组件实现，移除冗余的输入代理与校验处理逻辑

* **测试**
  * 调整相关表单输入与模糊交互测试以反映新行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->