### PR TITLE
fix(utils): prevent isDeepEqualReact stack overflow on circular refs

### DIFF
--- a/src/utils/isDeepEqualReact/index.ts
+++ b/src/utils/isDeepEqualReact/index.ts
@@ -16,26 +16,15 @@ export function isDeepEqualReact(
 
     // Track ancestor path only (not all visited nodes) so shared DAG refs
     // across sibling branches can still compare structurally.
+    // Cycle edges must point to ancestors at the same relative depth.
     let currA = stackA;
     let currB = stackB;
-    let hasA = false;
-    let hasB = false;
-    while (currA) {
-      if (currA.val === a) {
-        hasA = true;
-        break;
-      }
+    while (currA && currB) {
+      if (currA.val === a) return currB.val === b;
+      if (currB.val === b) return false;
       currA = currA.next;
-    }
-    while (currB) {
-      if (currB.val === b) {
-        hasB = true;
-        break;
-      }
       currB = currB.next;
     }
-    if (hasA && hasB) return true;
-    if (hasA || hasB) return false;
 
     const nextStackA: EqualStack = { val: a, next: stackA };
     const nextStackB: EqualStack = { val: b, next: stackB };

--- a/src/utils/isDeepEqualReact/index.ts
+++ b/src/utils/isDeepEqualReact/index.ts
@@ -1,10 +1,19 @@
 ﻿// do not edit .js files directly - edit src/index.jst
 
-export function isDeepEqualReact(a: any, b: any, ignoreKeys?: string[]) {
+export function isDeepEqualReact(
+  a: any,
+  b: any,
+  ignoreKeys?: string[],
+  seen: WeakMap<object, object> = new WeakMap(),
+) {
   if (a === b) return true;
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
     if (a.constructor !== b.constructor) return false;
+
+    const seenB = seen.get(a);
+    if (seenB) return seenB === b;
+    seen.set(a, b);
 
     let length;
     let i;
@@ -13,7 +22,7 @@ export function isDeepEqualReact(a: any, b: any, ignoreKeys?: string[]) {
       length = a.length;
       if (length != b.length) return false;
       for (i = length; i-- !== 0; )
-        if (!isDeepEqualReact(a[i], b[i], ignoreKeys)) return false;
+        if (!isDeepEqualReact(a[i], b[i], ignoreKeys, seen)) return false;
       return true;
     }
 
@@ -21,7 +30,7 @@ export function isDeepEqualReact(a: any, b: any, ignoreKeys?: string[]) {
       if (a.size !== b.size) return false;
       for (i of a.entries()) if (!b.has(i[0])) return false;
       for (i of a.entries())
-        if (!isDeepEqualReact(i[1], b.get(i[0]), ignoreKeys)) return false;
+        if (!isDeepEqualReact(i[1], b.get(i[0]), ignoreKeys, seen)) return false;
       return true;
     }
 
@@ -67,7 +76,7 @@ export function isDeepEqualReact(a: any, b: any, ignoreKeys?: string[]) {
         continue;
       }
 
-      if (!isDeepEqualReact(a[key], b[key], ignoreKeys)) {
+      if (!isDeepEqualReact(a[key], b[key], ignoreKeys, seen)) {
         return false;
       }
     }

--- a/src/utils/isDeepEqualReact/index.ts
+++ b/src/utils/isDeepEqualReact/index.ts
@@ -1,19 +1,44 @@
 ﻿// do not edit .js files directly - edit src/index.jst
 
+type EqualStack = { val: object; next: EqualStack | null } | null;
+
 export function isDeepEqualReact(
   a: any,
   b: any,
   ignoreKeys?: string[],
-  seen: WeakMap<object, object> = new WeakMap(),
+  stackA: EqualStack = null,
+  stackB: EqualStack = null,
 ) {
   if (a === b) return true;
 
   if (a && b && typeof a === 'object' && typeof b === 'object') {
     if (a.constructor !== b.constructor) return false;
 
-    const seenB = seen.get(a);
-    if (seenB) return seenB === b;
-    seen.set(a, b);
+    // Track ancestor path only (not all visited nodes) so shared DAG refs
+    // across sibling branches can still compare structurally.
+    let currA = stackA;
+    let currB = stackB;
+    let hasA = false;
+    let hasB = false;
+    while (currA) {
+      if (currA.val === a) {
+        hasA = true;
+        break;
+      }
+      currA = currA.next;
+    }
+    while (currB) {
+      if (currB.val === b) {
+        hasB = true;
+        break;
+      }
+      currB = currB.next;
+    }
+    if (hasA && hasB) return true;
+    if (hasA || hasB) return false;
+
+    const nextStackA: EqualStack = { val: a, next: stackA };
+    const nextStackB: EqualStack = { val: b, next: stackB };
 
     let length;
     let i;
@@ -22,7 +47,8 @@ export function isDeepEqualReact(
       length = a.length;
       if (length != b.length) return false;
       for (i = length; i-- !== 0; )
-        if (!isDeepEqualReact(a[i], b[i], ignoreKeys, seen)) return false;
+        if (!isDeepEqualReact(a[i], b[i], ignoreKeys, nextStackA, nextStackB))
+          return false;
       return true;
     }
 
@@ -30,7 +56,10 @@ export function isDeepEqualReact(
       if (a.size !== b.size) return false;
       for (i of a.entries()) if (!b.has(i[0])) return false;
       for (i of a.entries())
-        if (!isDeepEqualReact(i[1], b.get(i[0]), ignoreKeys, seen)) return false;
+        if (
+          !isDeepEqualReact(i[1], b.get(i[0]), ignoreKeys, nextStackA, nextStackB)
+        )
+          return false;
       return true;
     }
 
@@ -76,7 +105,9 @@ export function isDeepEqualReact(
         continue;
       }
 
-      if (!isDeepEqualReact(a[key], b[key], ignoreKeys, seen)) {
+      if (
+        !isDeepEqualReact(a[key], b[key], ignoreKeys, nextStackA, nextStackB)
+      ) {
         return false;
       }
     }

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -1118,6 +1118,15 @@ describe('utils', () => {
     expect(isDeepEqualReact(projectA, projectB)).toBe(false);
   });
 
+  it('🪓 isDeepEqualReact should handle shared references (DAG) without false negatives', () => {
+    const shared = { x: 1 };
+    const a = { left: shared, right: shared };
+    const b = { left: { x: 1 }, right: { x: 1 } };
+
+    expect(isDeepEqualReact(a, b)).toBe(true);
+  });
+
+
   it('🪓 nanoid', () => {
     if (!window.crypto.randomUUID) {
       window.crypto.randomUUID = () => '1' as any;

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -1126,6 +1126,19 @@ describe('utils', () => {
     expect(isDeepEqualReact(a, b)).toBe(true);
   });
 
+  it('🪓 isDeepEqualReact should reject cycles at different ancestor depths', () => {
+    const aRoot: any = { id: 'r' };
+    const aChild: any = { id: 'c', up: aRoot };
+    aRoot.down = aChild;
+
+    const bRoot: any = { id: 'r' };
+    const bChild: any = { id: 'c' };
+    bRoot.down = bChild;
+    bChild.up = bChild;
+
+    expect(isDeepEqualReact(aRoot, bRoot)).toBe(false);
+  });
+
 
   it('🪓 nanoid', () => {
     if (!window.crypto.randomUUID) {

--- a/tests/utils/index.test.tsx
+++ b/tests/utils/index.test.tsx
@@ -1102,6 +1102,22 @@ describe('utils', () => {
     await html.findByText('not equal');
   });
 
+  it('🪓 isDeepEqualReact should handle circular references', () => {
+    const projectA: any = { id: '1', name: 'A' };
+    const paymentA: any = { id: 'p1', amount: 100, project: projectA };
+    projectA.payments = [paymentA];
+
+    const projectB: any = { id: '1', name: 'A' };
+    const paymentB: any = { id: 'p1', amount: 100, project: projectB };
+    projectB.payments = [paymentB];
+
+    expect(() => isDeepEqualReact(projectA, projectB)).not.toThrow();
+    expect(isDeepEqualReact(projectA, projectB)).toBe(true);
+
+    projectB.name = 'B';
+    expect(isDeepEqualReact(projectA, projectB)).toBe(false);
+  });
+
   it('🪓 nanoid', () => {
     if (!window.crypto.randomUUID) {
       window.crypto.randomUUID = () => '1' as any;


### PR DESCRIPTION
## Summary

- Add cycle detection to `isDeepEqualReact` via ancestor-path stacks (`stackA` / `stackB`) threaded through the recursion, so recursive `Object.keys` walks terminate on circular object graphs instead of throwing `RangeError: Maximum call stack size exceeded`
- Only ancestors on the current recursion path are tracked (not a global visited set), so shared references across sibling branches (DAGs) still compare structurally and are never misjudged as cycles
- Cycle edges are required to point to the ancestor at the same relative depth on both sides — asymmetric cycle topologies (e.g. back-edge to root vs. self-loop) are correctly rejected as not equal
- Add unit tests covering: symmetric parent/child back-references (e.g. `project.payments[0].project === project`), DAG shared references without false negatives, and cycles at different ancestor depths being rejected

Fixes the `RangeError: Maximum call stack size exceeded` when ProTable / `useDeepCompareEffect` deep-compares `dataSource` rows that contain legitimate circular references from domain models.

Closes #9666

## Why ancestor stacks instead of a WeakMap/WeakSet visited set

A global visited set would mis-handle DAGs: when the same object is reached from two sibling branches (e.g. `{ left: shared, right: shared }`), the second visit would hit the visited marker and either early-return a wrong result or be treated as a cycle. Ancestor-path stacks only record the current DFS path, so sibling branches are independent, and the memory cost is O(recursion depth) instead of O(node count).

## Test plan

- [x] `pnpm exec vitest run tests/utils/index.test.tsx -t "isDeepEqualReact"` — both existing and new circular-ref cases pass
- [ ] CI green