### PR TITLE
fix(QueryFilter): Replace QueryFilter props.containerStyle with containerStyle

### DIFF
--- a/src/form/layouts/QueryFilter/index.tsx
+++ b/src/form/layouts/QueryFilter/index.tsx
@@ -466,7 +466,7 @@ function QueryFilter<T = Record<string, any>>(props: QueryFilterProps<T>) {
     onCollapse,
     labelWidth = '80',
     style,
-
+    containerStyle,
     split,
     preserve = true,
     ignoreRules,
@@ -547,7 +547,7 @@ function QueryFilter<T = Record<string, any>>(props: QueryFilterProps<T>) {
         <div
           ref={ref}
           className={clsx(`${baseClassName}-container`, hashId)}
-          style={props.containerStyle}
+          style={containerStyle}
         >
           <BaseForm
             isKeyPressSubmit


### PR DESCRIPTION
React does not recognize the `containerStyle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `containerstyle` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化查询筛选器容器样式的应用方式，确保自定义样式能够正常生效。
  * 保持现有渲染逻辑及默认值行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->