### PR TITLE
[codex] Fix ProField forwardRef type

### DIFF
--- a/src/field/ProFieldCore.tsx
+++ b/src/field/ProFieldCore.tsx
@@ -49,11 +49,14 @@ export interface CreateProFieldOptions {
 
 /**
  * @param render 单函数时读写共用（兼容旧用法）；对象时分别指定只读 / 编辑渲染
+ * 显式返回组件类型，避免 PropsWithoutRef 对带索引签名的 ProFieldPropsType 执行 Omit 后丢失具名属性。
  */
 export function createProField(
   render: ProFieldRenderText | ProFieldDualRender,
   options: CreateProFieldOptions,
-) {
+): React.ForwardRefExoticComponent<
+  ProFieldPropsType & React.RefAttributes<any>
+> {
   const renderRead = isProFieldDualRender(render) ? render.renderRead : render;
   const renderEdit = isProFieldDualRender(render) ? render.renderEdit : render;
 
@@ -149,5 +152,5 @@ export function createProField(
     return <React.Fragment>{renderedDom}</React.Fragment>;
   };
 
-  return React.forwardRef(ProFieldComponent) as typeof ProFieldComponent;
+  return React.forwardRef(ProFieldComponent);
 }

--- a/tests/field/proFieldType.test.tsx
+++ b/tests/field/proFieldType.test.tsx
@@ -1,0 +1,17 @@
+import {
+  ProField,
+  type ProFieldPropsType,
+  PureProField,
+} from '@ant-design/pro-components';
+import type React from 'react';
+import { expect, it } from 'vitest';
+
+type ProFieldComponent = React.ForwardRefExoticComponent<
+  ProFieldPropsType & React.RefAttributes<any>
+>;
+
+it('exposes ProField components as forwardRef components', () => {
+  const components: ProFieldComponent[] = [ProField, PureProField];
+
+  expect(components).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary

- Return the actual `ForwardRefExoticComponent` type from `createProField` instead of asserting it back to `ForwardRefRenderFunction`.
- Preserve named `ProFieldPropsType` properties in the public type so callback props keep their contextual types.
- Add regression coverage for both `ProField` and `PureProField`.

## Root cause

`React.forwardRef(ProFieldComponent) as typeof ProFieldComponent` replaced the component returned by `forwardRef` with its render-function type. That render function is not a valid JSX element type with React 19 types and TypeScript 6.

Relying only on the inferred `forwardRef` return type is also insufficient here because `ProFieldPropsType` has a string index signature. React's `PropsWithoutRef` applies `Omit<ProFieldPropsType, 'ref'>`, which erases the named properties used for contextual callback typing. The explicit `ForwardRefExoticComponent<ProFieldPropsType & RefAttributes<any>>` return type fixes JSX compatibility without regressing those prop types.

Fixes #9671

## Validation

- `pnpm exec eslint src/field/ProFieldCore.tsx tests/field/proFieldType.test.tsx`
- `pnpm exec vitest run tests/field/proFieldType.test.tsx`
- `pnpm exec vitest run tests/field/field.test.tsx` (246 tests)
- `pnpm tsc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修正 ProField 组件的类型声明，避免带索引签名的属性类型在使用时丢失具名属性。
  * 确保 ProField 和 PureProField 以支持 ref 的组件形式正确导出。

* **测试**
  * 新增类型测试，验证相关组件的 forwardRef 类型兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->