### PR TITLE
fix(table): sync submitted search fields to URL

### DIFF
--- a/src/table/components/Form/FormRender.tsx
+++ b/src/table/components/Form/FormRender.tsx
@@ -89,7 +89,7 @@ const getFormConfigs = (isForm: boolean, formConfig: any) => {
 };
 
 export type TableFormItem<T, U = any> = {
-  onSubmit?: (value: T, firstLoad: boolean) => void;
+  onSubmit?: (value: T, firstLoad: boolean) => boolean | void;
   onReset?: (value: T) => void;
   form?: Omit<ProFormProps, 'form'>;
   type?: ProSchemaComponentTypes;
@@ -238,7 +238,7 @@ const FormRender = <T, U = any>({
           onReset?.(values);
         }}
         onFinish={(values: T) => {
-          onSubmit?.(values, false);
+          return onSubmit?.(values, false);
         }}
         initialValues={formConfig?.initialValues}
       />

--- a/src/table/components/Form/index.tsx
+++ b/src/table/components/Form/index.tsx
@@ -79,6 +79,7 @@ const FormSearch = <T, U>(props: BaseFormProps<T, U> & { ghost?: boolean }) => {
       return;
     }
     runSubmit();
+    return true;
   });
 
   const onResetHandler = useRefFunction((value: Partial<U>) => {

--- a/tests/table/form.test.tsx
+++ b/tests/table/form.test.tsx
@@ -15,6 +15,46 @@ afterEach(() => {
 });
 
 describe('BasicTable Search', () => {
+  it('🎏 syncs submitted search fields to URL', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      'http://localhost?current=1&pageSize=20',
+    );
+
+    const { container } = render(
+      <ProTable
+        rowKey="id"
+        columns={[
+          {
+            title: '用户 ID',
+            dataIndex: 'pid',
+          },
+        ]}
+        request={async () => ({ data: [], success: true, total: 0 })}
+        form={{
+          syncToUrl: true,
+          syncToUrlAsImportant: true,
+          syncToInitialValues: true,
+        }}
+      />,
+    );
+
+    const input = container.querySelector<HTMLInputElement>('input#pid');
+    expect(input).toBeTruthy();
+
+    fireEvent.change(input!, { target: { value: '10001' } });
+    fireEvent.click(
+      container.querySelector('.ant-form button.ant-btn-primary')!,
+    );
+
+    await waitFor(() => {
+      expect(new URLSearchParams(window.location.search).get('pid')).toBe(
+        '10001',
+      );
+    });
+  });
+
   it('🎏 table type=form', async () => {
     const fn = vi.fn();
     const { container } = render(


### PR DESCRIPTION
## Summary
- return the ProTable search submit result from FormRender
- mark synchronous search submissions as successful so BaseForm runs syncToUrl
- add a regression test that submitted search fields are written to the URL

## Test plan
- pnpm exec vitest run tests/table/form.test.tsx
- pnpm exec tsc --noEmit

Fixes #9665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 表单提交支持返回成功状态，提升提交流程的控制能力。
  * 搜索表单可将查询条件同步到浏览器地址栏，便于分享、刷新后保留筛选条件。

* **测试**
  * 增加搜索条件同步至 URL 的验证，确保输入内容能够正确保存为查询参数。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->