### PR TITLE
replace Spin with Skeleton for loading state in BaseForm component

### DIFF
--- a/src/form/BaseForm/BaseForm.tsx
+++ b/src/form/BaseForm/BaseForm.tsx
@@ -693,7 +693,12 @@ export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
 
   if (request && initialDataLoading) {
     return (
-        <Skeleton />
+      <Skeleton
+      active
+      title={false}
+      paragraph={{ rows: 5 }}
+      className={`${prefixCls}-body-skeleton`}
+    />
     );
   }
 

--- a/src/form/BaseForm/BaseForm.tsx
+++ b/src/form/BaseForm/BaseForm.tsx
@@ -7,7 +7,7 @@ import {
   warning,
 } from '@rc-component/util';
 import type { FormInstance, FormItemProps, FormProps } from 'antd';
-import { ConfigProvider, Form, Spin } from 'antd';
+import { ConfigProvider, Form, Skeleton } from 'antd';
 import type { NamePath } from 'antd/lib/form/interface';
 import { clsx } from 'clsx';
 import type dayjs from 'dayjs';
@@ -693,9 +693,7 @@ export function BaseForm<T = Record<string, any>, U = Record<string, any>>(
 
   if (request && initialDataLoading) {
     return (
-      <div style={{ paddingTop: 50, paddingBottom: 50, textAlign: 'center' }}>
-        <Spin />
-      </div>
+        <Skeleton />
     );
   }
 


### PR DESCRIPTION
closes #9679
保持和 antd 加载风格一致. 由于 loading component 是 BaseForm 里面的.所以这里改动后 ProForm 的 loading component 都会变成Skeleton 样式. 是破坏性更改.

https://github.com/ant-design/ant-design/blob/fa1d88699ed3257bd8d446575c7cd04890be6821/components/drawer/DrawerPanel.tsx#L231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **界面优化**
  * 表单加载时改用骨架屏展示，提供更贴近表单内容的加载占位效果。
  * 骨架屏显示 5 行内容且不显示标题，提升加载过程中的视觉体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->