### PR TITLE
fix(table): prevent recursive formItemRender loop

### DIFF
--- a/src/form/components/SchemaForm/valueType/field.tsx
+++ b/src/form/components/SchemaForm/valueType/field.tsx
@@ -41,7 +41,12 @@ export const field: ProSchemaRenderValueTypeFunction<any, any> = (
 
   const formItemRender = item?.formItemRender
     ? (_: any, config: any) => {
-        const renderConfig = omitUndefined({ ...config, onChange: undefined });
+        const renderConfig = omitUndefined({
+          ...config,
+          onChange: undefined,
+          // Avoid forwarding this internal callback into nested ProForm fields.
+          formItemRender: undefined,
+        });
         return item?.formItemRender?.(
           {
             type,

--- a/tests/table/search.test.tsx
+++ b/tests/table/search.test.tsx
@@ -1,6 +1,12 @@
 import type { ProFormInstance } from '@ant-design/pro-components';
 import { ProFormSelect, ProTable } from '@ant-design/pro-components';
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import type { FormInstance, RefSelectProps } from 'antd';
 import { Input, Select } from 'antd';
 import dayjs from 'dayjs';
@@ -461,23 +467,18 @@ describe('BasicTable Search', () => {
       />,
     );
 
-    expect(html.baseElement.querySelector('.ant-select')).toBeTruthy();
+    const select = html.getByRole('combobox');
     expect(renderConfigs.length).toBeGreaterThan(0);
     expect(renderConfigs.every((config) => !('formItemRender' in config))).toBe(
       true,
     );
 
     act(() => {
-      fireEvent.mouseDown(html.baseElement.querySelector('.ant-select')!);
+      fireEvent.mouseDown(select);
     });
-    const courseOption = Array.from(
-      document.body.querySelectorAll<HTMLElement>(
-        '.ant-select-item-option-content',
-      ),
-    ).find((item) => item.textContent === 'Course');
-    expect(courseOption).toBeTruthy();
+    const courseOption = screen.getByText('Course');
     act(() => {
-      fireEvent.click(courseOption!);
+      fireEvent.click(courseOption);
     });
     expect(formRef.current?.getFieldValue('type')).toEqual(['course']);
     html.unmount();
@@ -520,17 +521,13 @@ describe('BasicTable Search', () => {
       />,
     );
 
+    const select = html.getByRole('combobox');
     act(() => {
-      fireEvent.mouseDown(html.baseElement.querySelector('.ant-select')!);
+      fireEvent.mouseDown(select);
     });
-    const openOption = Array.from(
-      document.body.querySelectorAll<HTMLElement>(
-        '.ant-select-item-option-content',
-      ),
-    ).find((item) => item.textContent === 'Open');
-    expect(openOption).toBeTruthy();
+    const openOption = screen.getByText('Open');
     act(() => {
-      fireEvent.click(openOption!);
+      fireEvent.click(openOption);
     });
     expect(formRef.current?.getFieldValue('status')).toBe('open');
     html.unmount();

--- a/tests/table/search.test.tsx
+++ b/tests/table/search.test.tsx
@@ -1,8 +1,8 @@
 import type { ProFormInstance } from '@ant-design/pro-components';
-import { ProTable } from '@ant-design/pro-components';
+import { ProFormSelect, ProTable } from '@ant-design/pro-components';
 import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
-import type { FormInstance } from 'antd';
-import { Input } from 'antd';
+import type { FormInstance, RefSelectProps } from 'antd';
+import { Input, Select } from 'antd';
 import dayjs from 'dayjs';
 import React, { act, createRef } from 'react';
 import {
@@ -431,6 +431,108 @@ describe('BasicTable Search', () => {
       expect(fn).toHaveBeenCalledWith('12');
     });
 
+    html.unmount();
+  });
+
+  it('does not loop when formItemRender config is spread into ProFormSelect', () => {
+    const formRef: React.MutableRefObject<ProFormInstance | undefined> = {
+      current: undefined,
+    };
+    const renderConfigs: object[] = [];
+    const html = render(
+      <ProTable
+        formRef={formRef}
+        columns={[
+          {
+            title: 'Type',
+            dataIndex: 'type',
+            valueType: 'select',
+            valueEnum: {
+              course: { text: 'Course' },
+              test: { text: 'Test' },
+            },
+            formItemRender: (_, config) => {
+              renderConfigs.push(config);
+              return <ProFormSelect {...config} mode="multiple" />;
+            },
+          },
+        ]}
+        dataSource={[]}
+      />,
+    );
+
+    expect(html.baseElement.querySelector('.ant-select')).toBeTruthy();
+    expect(renderConfigs.length).toBeGreaterThan(0);
+    expect(renderConfigs.every((config) => !('formItemRender' in config))).toBe(
+      true,
+    );
+
+    act(() => {
+      fireEvent.mouseDown(html.baseElement.querySelector('.ant-select')!);
+    });
+    const courseOption = Array.from(
+      document.body.querySelectorAll<HTMLElement>(
+        '.ant-select-item-option-content',
+      ),
+    ).find((item) => item.textContent === 'Course');
+    expect(courseOption).toBeTruthy();
+    act(() => {
+      fireEvent.click(courseOption!);
+    });
+    expect(formRef.current?.getFieldValue('type')).toEqual(['course']);
+    html.unmount();
+  });
+
+  it('keeps antd Select controlled when formItemRender config is spread', () => {
+    const formRef: React.MutableRefObject<ProFormInstance | undefined> = {
+      current: undefined,
+    };
+    const CustomSelect = React.forwardRef<
+      RefSelectProps,
+      Pick<React.ComponentProps<typeof Select>, 'onChange' | 'value'>
+    >(({ onChange, value }, ref) => (
+      <Select
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        options={[
+          { label: 'Open', value: 'open' },
+          { label: 'Closed', value: 'closed' },
+        ]}
+      />
+    ));
+    CustomSelect.displayName = 'CustomSelect';
+    const html = render(
+      <ProTable
+        formRef={formRef}
+        columns={[
+          {
+            title: 'Status',
+            dataIndex: 'status',
+            valueType: 'select',
+            formItemRender: (
+              _,
+              { type: _type, defaultRender: _defaultRender, ...rest },
+            ) => <CustomSelect {...rest} />,
+          },
+        ]}
+        dataSource={[]}
+      />,
+    );
+
+    act(() => {
+      fireEvent.mouseDown(html.baseElement.querySelector('.ant-select')!);
+    });
+    const openOption = Array.from(
+      document.body.querySelectorAll<HTMLElement>(
+        '.ant-select-item-option-content',
+      ),
+    ).find((item) => item.textContent === 'Open');
+    expect(openOption).toBeTruthy();
+    act(() => {
+      fireEvent.click(openOption!);
+    });
+    expect(formRef.current?.getFieldValue('status')).toBe('open');
     html.unmount();
   });
 


### PR DESCRIPTION
## Summary

- stop SchemaForm's internal `formItemRender` callback from leaking into the user render config
- preserve controlled field behavior and the remaining public render config
- add regressions for `ProFormSelect` config spreading and a custom antd `Select`

Fixes #9676

## Testing

- `pnpm exec vitest run tests/table/search.test.tsx -t "config is spread" --reporter=verbose`
- `pnpm exec vitest run tests/table/search.test.tsx --reporter=verbose`
- `pnpm exec vitest run tests/form/getFieldInstance.test.tsx --reporter=verbose`
- `pnpm run tsc`
- `pnpm exec eslint src/form/components/SchemaForm/valueType/field.tsx tests/table/search.test.tsx`
- `pnpm exec prettier --check src/form/components/SchemaForm/valueType/field.tsx tests/table/search.test.tsx`
- `git diff --check`

> Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复嵌套表单字段使用自定义渲染器时可能产生循环的问题。
  * 优化表单配置传递，避免内部回调被重复传入。
  * 修复选择操作后表单字段值未正确更新的问题。

* **测试**
  * 增加对自定义表单选择器及下拉选择组件的相关验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->