### PR TITLE
fix(select): support showSearch object config

### DIFF
--- a/src/field/components/Select/SearchSelect/index.tsx
+++ b/src/field/components/Select/SearchSelect/index.tsx
@@ -100,15 +100,17 @@ export interface SearchSelectProps<T = Record<string, any>> extends Omit<
 const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
   const {
     mode,
-    onSearch,
+    onSearch: propsOnSearch,
     onFocus,
     onChange,
-    autoClearSearchValue = true,
+    autoClearSearchValue: propsAutoClearSearchValue = true,
     searchOnFocus = false,
     resetAfterSelect = false,
     fetchDataOnSearch = true,
-    optionFilterProp = 'label',
+    optionFilterProp: propsOptionFilterProp = 'label',
     optionLabelProp = 'label',
+    filterOption: propsFilterOption,
+    filterSort: propsFilterSort,
     className,
     disabled,
     options,
@@ -123,6 +125,17 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
     ...restProps
   } = props;
 
+  const showSearchConfig = typeof showSearch === 'object' ? showSearch : {};
+  const onSearch = showSearchConfig.onSearch ?? propsOnSearch;
+  const autoClearSearchValue =
+    showSearchConfig.autoClearSearchValue ?? propsAutoClearSearchValue;
+  const optionFilterProp =
+    showSearchConfig.optionFilterProp ?? propsOptionFilterProp;
+  const filterOption = showSearchConfig.filterOption ?? propsFilterOption;
+  const filterSort = showSearchConfig.filterSort ?? propsFilterSort;
+  const mergedPropsSearchValue =
+    showSearchConfig.searchValue ?? propsSearchValue;
+
   const {
     label: labelPropsName = 'label',
     value: valuePropsName = 'value',
@@ -131,7 +144,7 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
 
   const [searchValue, setSearchValue] = useControlledState(
     defaultSearchValue,
-    propsSearchValue,
+    mergedPropsSearchValue,
   );
 
   const selectRef = useRef<any>();
@@ -235,6 +248,62 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
       } as DefaultOptionType;
     });
   };
+
+  const mergedFilterOption: SelectProps<any>['filterOption'] =
+    filterOption == false
+      ? false
+      : (inputValue, option) => {
+          const effectiveSearchValue =
+            searchValue === '' ? '' : inputValue || searchValue;
+          if (!effectiveSearchValue) {
+            return true;
+          }
+          if (typeof filterOption === 'function') {
+            return filterOption(effectiveSearchValue, {
+              ...option,
+              label: option?.data_title,
+            });
+          }
+          return !!(
+            option?.data_title
+              ?.toString()
+              .toLowerCase()
+              .includes(effectiveSearchValue.toLowerCase()) ||
+            (Array.isArray(optionFilterProp)
+              ? optionFilterProp
+              : [optionFilterProp]
+            ).some((prop) =>
+              option?.[prop]
+                ?.toString()
+                .toLowerCase()
+                .includes(effectiveSearchValue.toLowerCase()),
+            )
+          );
+        };
+
+  const handleSearch = showSearch
+    ? (value: string) => {
+        if (fetchDataOnSearch) {
+          fetchData(value);
+        }
+        onSearch?.(value);
+        setSearchValue(value);
+      }
+    : undefined;
+
+  const mergedShowSearch =
+    typeof showSearch === 'object'
+      ? {
+          ...showSearch,
+          autoClearSearchValue,
+          filterOption: mergedFilterOption,
+          filterSort,
+          onSearch: handleSearch,
+          optionFilterProp,
+          searchValue,
+        }
+      : showSearch;
+
   return (
     <Select<any>
       ref={selectRef}
@@ -243,10 +312,11 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
       autoClearSearchValue={autoClearSearchValue}
       disabled={disabled}
       mode={mode}
-      showSearch={showSearch}
+      showSearch={mergedShowSearch}
       searchValue={searchValue}
       optionFilterProp={optionFilterProp}
       optionLabelProp={optionLabelProp}
+      filterSort={filterSort}
       onClear={() => {
         onClear?.();
         fetchData(undefined);
@@ -256,49 +326,8 @@ const SearchSelect = <T,>(props: SearchSelectProps<T[]>, ref: any) => {
         }
       }}
       {...restProps}
-      filterOption={
-        restProps.filterOption == false
-          ? false
-          : (inputValue, option) => {
-              // 当 inputValue 为空或 searchValue 为空时，显示所有选项
-              // 这样可以确保 searchOnFocus 时能够显示所有选项
-              const effectiveSearchValue =
-                searchValue === '' ? '' : inputValue || searchValue;
-              if (!effectiveSearchValue) {
-                return true;
-              }
-              if (
-                restProps.filterOption &&
-                typeof restProps.filterOption === 'function'
-              ) {
-                return restProps.filterOption(effectiveSearchValue, {
-                  ...option,
-                  label: option?.data_title,
-                });
-              }
-              return !!(
-                option?.data_title
-                  ?.toString()
-                  .toLowerCase()
-                  .includes(effectiveSearchValue.toLowerCase()) ||
-                option?.[optionFilterProp as string]
-                  ?.toString()
-                  .toLowerCase()
-                  .includes(effectiveSearchValue.toLowerCase())
-              );
-            }
-      } // 这里使用pro-components的过滤逻辑
-      onSearch={
-        showSearch
-          ? (value) => {
-              if (fetchDataOnSearch) {
-                fetchData(value);
-              }
-              onSearch?.(value);
-              setSearchValue(value);
-            }
-          : undefined
-      }
+      filterOption={mergedFilterOption} // 这里使用pro-components的过滤逻辑
+      onSearch={handleSearch}
       onChange={(value, optionList, ...rest) => {
         // 将搜索框置空 和 antd 行为保持一致
         if (showSearch && autoClearSearchValue) {

--- a/tests/form/base.test.tsx
+++ b/tests/form/base.test.tsx
@@ -1265,6 +1265,56 @@ describe('ProForm', () => {
     wrapper.unmount();
   });
 
+  it('📦 SearchSelect supports showSearch object config', async () => {
+    const onSearch = vi.fn();
+    const wrapper = render(
+      <ProForm>
+        <ProFormSelect.SearchSelect
+          name="userQuery"
+          fieldProps={{
+            mode: 'multiple',
+            showSearch: {
+              autoClearSearchValue: false,
+              onSearch,
+              optionFilterProp: 'value',
+            },
+          }}
+          options={[{ label: 'Alpha', value: 'matching-value' }]}
+        />
+      </ProForm>,
+    );
+
+    fireEvent.mouseDown(wrapper.baseElement.querySelector('.ant-select')!);
+
+    const searchInput = await waitFor(() => {
+      const input =
+        wrapper.baseElement.querySelector<HTMLInputElement>(
+          '.ant-select-input',
+        );
+      expect(input).toBeTruthy();
+      return input!;
+    });
+
+    fireEvent.change(searchInput, { target: { value: 'matching-value' } });
+
+    await waitFor(() => {
+      expect(onSearch).toHaveBeenCalledWith('matching-value');
+      expect(
+        document.body.querySelector('.ant-select-item-option-content'),
+      ).toHaveTextContent('Alpha');
+    });
+
+    fireEvent.click(
+      document.body.querySelector('.ant-select-item-option-content')!,
+    );
+
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('matching-value');
+    });
+
+    wrapper.unmount();
+  });
+
   it('📦 SearchSelect onSearch support valueEnum', async () => {
     const onSearch = vi.fn();
     const wrapper = render(


### PR DESCRIPTION
## Summary

- normalize the Ant Design 6 `showSearch` object before ProComponents applies its custom search behavior
- let object-form search settings override their deprecated top-level equivalents
- keep remote fetching, controlled search state, custom filtering, sorting, and search callbacks on the same effective configuration
- support `string[]` for `optionFilterProp`

## Problem

`ProFormSelect.SearchSelect` forwards the `showSearch` object to Ant Design, but its own filtering and state handlers still read only the legacy top-level props. As a result, object-form settings such as `optionFilterProp`, `autoClearSearchValue`, `onSearch`, `searchValue`, `filterOption`, and `filterSort` are either ignored by the ProComponents layer or bypass its fetch/state wrapper.

The regression test searches an option by its value while its label does not match, then selects it and verifies that `autoClearSearchValue: false` preserves the search text. It fails on the base head with an empty option list and passes with this change.

Fixes #9680.

## Validation

- `pnpm test` — 74 files, 1194 tests passed
- `pnpm run tsc`
- focused ESLint for the changed source and test
- `pnpm build` — UMD, ES, CJS, and declarations built successfully
- `git diff --check`

AI assistance disclosure: Codex was used to trace the Select/TreeSelect configuration paths, implement the compatibility logic, run validation, and draft this report. The failing base behavior, final diff, and test results were verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 搜索选择组件支持更灵活的对象式搜索配置，可自定义搜索、清空、过滤、排序及搜索值行为。
  * 支持按选项值进行搜索，并兼容自定义过滤逻辑、标签匹配和远程搜索。

* **问题修复**
  * 优化多选搜索体验，配置关闭自动清空后，选择选项时可保留搜索输入值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->