### PR TITLE
fix(table): preserve fixed columns after settings drag

### DIFF
--- a/src/table/utils/genProColumnToColumn.tsx
+++ b/src/table/utils/genProColumnToColumn.tsx
@@ -166,7 +166,7 @@ export function genProColumnToColumn<T extends AnyObject>(params: {
         children,
       } = columnProps as ProColumns<T, any>;
       const columnKey = genColumnKey(
-        key || dataIndex?.toString(),
+        key || (dataIndex as React.Key),
         [parents?.key, columnsIndex].filter(Boolean).join('-'),
       );
       const noNeedPro = !valueEnum && !valueType && !children;

--- a/tests/table/columnSetting.test.tsx
+++ b/tests/table/columnSetting.test.tsx
@@ -1180,6 +1180,81 @@ describe('Table ColumnSetting', () => {
     await waitForWaitTime(1000);
   });
 
+  it('🎏 columnSetting drag should preserve fixed state for array dataIndex', async () => {
+    const onChange = vi.fn();
+    const html = render(
+      <ProTable
+        size="small"
+        columnsState={{ onChange }}
+        columns={[
+          {
+            title: 'Nested name',
+            dataIndex: ['test', 'name'],
+            fixed: 'left',
+          },
+          {
+            title: 'Created at',
+            dataIndex: 'createdAt',
+          },
+          {
+            title: 'Updated at',
+            dataIndex: 'updatedAt',
+          },
+        ]}
+        dataSource={[
+          {
+            key: 1,
+            test: { name: 'ProComponents' },
+          },
+        ]}
+        rowKey="key"
+      />,
+    );
+
+    await waitForWaitTime(200);
+    act(() => {
+      html.baseElement
+        .querySelector<HTMLDivElement>(
+          '.ant-pro-table-list-toolbar-setting-item .anticon-setting',
+        )
+        ?.click();
+    });
+    await waitForWaitTime(300);
+
+    const nodes = html.baseElement.querySelectorAll<HTMLDivElement>(
+      '.ant-tree-treenode > .ant-tree-node-content-wrapper',
+    );
+    act(() => {
+      fireDragEvent(nodes[1], 'dragStart', {
+        clientX: 500,
+        clientY: 500,
+      });
+    });
+    await waitForWaitTime(200);
+    act(() => {
+      fireDragEvent(nodes[2], 'dragEnter', {
+        clientX: 400,
+        clientY: 600,
+      });
+    });
+    await waitForWaitTime(200);
+    act(() => {
+      fireDragEvent(nodes[2], 'dragOver', {
+        clientX: 400,
+        clientY: 600,
+      });
+    });
+    await waitForWaitTime(200);
+    act(() => {
+      fireEvent.drop(nodes[2]);
+    });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    const lastColumnsState = (onChange.mock as any).lastCall[0];
+    expect(lastColumnsState['test-name']).toMatchObject({ fixed: 'left' });
+    expect(lastColumnsState['test,name']).toBeUndefined();
+  });
+
   it('🎏 columnSetting support hideInSetting', async () => {
     const html = render(
       <ProTable

--- a/tests/table/columnSetting.test.tsx
+++ b/tests/table/columnSetting.test.tsx
@@ -1,4 +1,4 @@
-import { ProTable } from '@ant-design/pro-components';
+import { ProTable, type ColumnsState } from '@ant-design/pro-components';
 import {
   cleanup,
   createEvent,
@@ -1181,7 +1181,7 @@ describe('Table ColumnSetting', () => {
   });
 
   it('🎏 columnSetting drag should preserve fixed state for array dataIndex', async () => {
-    const onChange = vi.fn();
+    const onChange = vi.fn<(map: Record<string, ColumnsState>) => void>();
     const html = render(
       <ProTable
         size="small"
@@ -1250,7 +1250,7 @@ describe('Table ColumnSetting', () => {
     });
 
     await waitFor(() => expect(onChange).toHaveBeenCalled());
-    const lastColumnsState = (onChange.mock as any).lastCall[0];
+    const lastColumnsState = onChange.mock.lastCall![0];
     expect(lastColumnsState['test-name']).toMatchObject({ fixed: 'left' });
     expect(lastColumnsState['test,name']).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

- keep array `dataIndex` columns on the same normalized key used by the column-settings store
- preserve a column's configured `fixed` state when settings drag-and-drop adds ordering metadata
- add a regression covering the duplicate `test-name` / `test,name` state reported in #9688

## Root cause

The store normalizes an array `dataIndex` through `genColumnKey`, which joins its segments with `-`. `genProColumnToColumn` converted the same array to a string first, producing a comma-separated key. After a drag, the new comma-keyed entry contained only `order`; because it now existed, it overrode the column-prop fallback and removed `fixed`.

## Validation

- Exact-base regression failed with an unexpected `{ order: 0 }` entry at `test,name`
- Fixed focused regression: 1 passed
- Complete `columnSetting` file: 24 passed
- Complete repository suite: 74 files, 1,194 tests passed
- `pnpm exec tsc --noEmit`
- focused ESLint and `git diff --check`
- complete UMD, ES, CJS, and declaration build

Fixes #9688.

AI assistance disclosure: Codex was used to trace the two key-generation paths, construct the exact-base regression, and run validation. The submitted behavior and test results were verified locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复列设置拖拽后，使用数组形式字段标识的列键值异常问题。
  - 确保固定列状态在拖拽后保持不变，并使用规范化的字段键值。

- **Tests**
  - 新增列设置拖拽回归测试，验证列键值和固定状态的正确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->