### PR TITLE
fix(locale): correct zh-TW line item glyphs

### DIFF
--- a/src/provider/locale/zh_TW.tsx
+++ b/src/provider/locale/zh_TW.tsx
@@ -2,8 +2,8 @@ import type { ProLocale } from './zh_CN';
 
 const zhTW: ProLocale = {
   moneySymbol: 'NT$',
-  deleteThisLine: '刪除此项',
-  copyThisLine: '複製此项',
+  deleteThisLine: '刪除此項',
+  copyThisLine: '複製此項',
   form: {
     lightFilter: {
       more: '更多篩選',

--- a/tests/provider/index.test.tsx
+++ b/tests/provider/index.test.tsx
@@ -4,6 +4,7 @@ import {
   ProFormMoney,
   createIntl,
   useStyle,
+  zhTWIntl,
 } from '@ant-design/pro-components';
 import { cleanup, render } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
@@ -62,5 +63,10 @@ describe('ProConfigProvider', () => {
     const input = container.querySelector('input#amount') as HTMLInputElement;
     expect(input).toBeTruthy();
     expect(input.value).toBe('!? 44.33');
+  });
+
+  it('uses Traditional Chinese glyphs for line actions', () => {
+    expect(zhTWIntl.getMessage('deleteThisLine', '')).toBe('刪除此項');
+    expect(zhTWIntl.getMessage('copyThisLine', '')).toBe('複製此項');
   });
 });


### PR DESCRIPTION
## Summary

- replace the Simplified Chinese glyph `项` with the Traditional Chinese `項` in the two zh-TW line-action messages
- add a regression test through the public `zhTWIntl` export

The same locale already uses `項` for `form.lightFilter.itemUnit` and `alert.item`, so this keeps the two line-action labels internally consistent.

## Verification

- Exact-base regression: `tests/provider/index.test.tsx` failed with `expected '刪除此项' to be '刪除此項'`
- Fixed: `./node_modules/.bin/vitest run tests/provider/index.test.tsx` — 3/3 passed
- Provider scope: `./node_modules/.bin/vitest run tests/provider` — 3/3 passed
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/eslint src/provider/locale/zh_TW.tsx tests/provider/index.test.tsx`
- `./node_modules/.bin/prettier --check src/provider/locale/zh_TW.tsx tests/provider/index.test.tsx`
- `git diff --check`

No open issue mentioning `zh_TW` and no open PR changing either touched file were found before submission.

AI assistance disclosure: Codex was used to inspect locale consistency, check open-PR overlap, add the focused regression, and run verification. The final two-string change and test results were reviewed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修正繁體中文介面用字，將「此项」更新為「此項」。
  - 更新刪除與複製行操作的繁體中文提示文字。

- **Tests**
  - 新增測試，確認繁體中文提示分別顯示為「刪除此項」與「複製此項」。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->