### PR TITLE
fix(descriptions): merge user styles with internal defaults instead of overriding

### DIFF
--- a/src/descriptions/ProDescriptions.tsx
+++ b/src/descriptions/ProDescriptions.tsx
@@ -37,6 +37,7 @@ const ProDescriptions = <
     actionRef,
     onRequestError,
     emptyText: _emptyText,
+    styles,
     ...rest
   } = props;
 
@@ -169,11 +170,17 @@ const ProDescriptions = <
           <Descriptions
             className={className}
             {...rest}
-            styles={{
-              content: {
-                minWidth: 0,
-              },
-            }}
+            styles={
+              typeof styles === 'function'
+                ? styles
+                : {
+                    ...styles,
+                    content: {
+                      minWidth: 0,
+                      ...styles?.content,
+                    },
+                  }
+            }
             extra={
               options || rest.extra ? (
                 <Space>

--- a/tests/descriptions/index.test.tsx
+++ b/tests/descriptions/index.test.tsx
@@ -427,6 +427,34 @@ describe('descriptions', () => {
     wrapper.unmount();
   });
 
+  it('🐛 styles 属性应透传给 Descriptions 且保留内置默认 minWidth', async () => {
+    const html = render(
+      <ProDescriptions
+        title="标题"
+        dataSource={{ id: 'text' }}
+        columns={[{ title: '文本', dataIndex: 'id' }]}
+        styles={{
+          title: { color: '#ff4d4f' },
+          content: { color: '#1677ff' },
+        }}
+      />,
+    );
+
+    const titleEl = html.container.querySelector<HTMLElement>(
+      '.ant-descriptions-title',
+    );
+    const contentEl = html.container.querySelector<HTMLElement>(
+      '.ant-descriptions-item-content',
+    );
+
+    expect(titleEl).toBeTruthy();
+    // happy-dom 不做颜色标准化，保留原始十六进制值
+    expect(titleEl?.style.color).toBe('#ff4d4f');
+    expect(contentEl?.style.color).toBe('#1677ff');
+    // 内置的 content minWidth: 0 默认值不应被用户的 styles 覆盖丢失
+    expect(contentEl?.style.minWidth).toBe('0');
+  });
+
   it('🐛 copyable 复制 renderText 返回 JSX 时应使用原始值而非 [object Object]', async () => {
     const RAW_VALUE = '13800138000';
     const writeTextMock = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- `ProDescriptions` hardcoded `styles={{ content: { minWidth: 0 } }}` after `{...rest}` on the antd `Descriptions` element, which unconditionally overrode the user-supplied `styles` prop, so it never took effect
- merge user styles with the internal default instead: object-form styles keep all semantic slots (`root` / `header` / `title` / `extra` / `label` / `content`) with `minWidth: 0` as the content fallback (user values win); function-form styles (antd 6 `stylesAndFn`) are passed through untouched
- add a regression test covering both the pass-through and the retained default

## Test plan
- [x] `pnpm exec vitest run tests/descriptions/` → 28 passed
- [x] `pnpm exec tsc --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * `ProDescriptions` 现支持通过 `styles` 属性自定义标题和内容区域样式。
  * 自定义样式会与默认内容布局样式兼容，确保内容区域正常展示。

* **测试**
  * 增加了样式透传及默认内容样式保留的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->