### PR TITLE
fix(card): apply semantic classNames/styles to actions area

### DIFF
--- a/src/card/components/Actions/index.tsx
+++ b/src/card/components/Actions/index.tsx
@@ -11,14 +11,21 @@ export type ProCardActionsProps = {
   prefixCls?: string;
   /** 操作按钮 */
   actions?: React.ReactNode[] | React.ReactNode;
+  /** 语义化 classNames.actions，透传到操作区根节点 */
+  className?: string;
+  /** 语义化 styles.actions，透传到操作区根节点 */
+  style?: React.CSSProperties;
 };
 
 const ProCardActions: React.FC<ProCardActionsProps> = (props) => {
-  const { actions, prefixCls } = props;
+  const { actions, prefixCls, className, style } = props;
   const { wrapSSR, hashId } = useStyle(prefixCls);
   if (Array.isArray(actions) && actions?.length) {
     return wrapSSR(
-      <ul className={clsx(`${prefixCls}-actions`, hashId)}>
+      <ul
+        className={clsx(`${prefixCls}-actions`, hashId, className)}
+        style={style}
+      >
         {actions.map((action, index) => (
           <li
             style={{ width: `${100 / actions.length}%`, padding: 0, margin: 0 }}
@@ -32,7 +39,12 @@ const ProCardActions: React.FC<ProCardActionsProps> = (props) => {
     );
   }
   return wrapSSR(
-    <ul className={clsx(`${prefixCls}-actions`, hashId)}>{actions}</ul>,
+    <ul
+      className={clsx(`${prefixCls}-actions`, hashId, className)}
+      style={style}
+    >
+      {actions}
+    </ul>,
   );
 };
 

--- a/src/card/components/Card/index.tsx
+++ b/src/card/components/Card/index.tsx
@@ -374,7 +374,12 @@ const Card = React.forwardRef((props: CardProps, ref: any) => {
         </div>
       )}
       {actions ? (
-        <Actions actions={actions} prefixCls={prefixCls} />
+        <Actions
+          actions={actions}
+          prefixCls={prefixCls}
+          className={classNames?.actions}
+          style={mergedStyles.actions}
+        />
       ) : null}
     </div>,
   );

--- a/tests/card/index.test.tsx
+++ b/tests/card/index.test.tsx
@@ -260,4 +260,24 @@ describe('Card', () => {
     expect(fn).toHaveBeenCalledWith('tab2');
     wrapper.unmount();
   });
+
+  it('🥩 classNames.actions and styles.actions applied to actions ul', async () => {
+    const wrapper = render(
+      <ProCard
+        title="操作区"
+        actions={[<a key="setting">设置</a>, <a key="edit">编辑</a>]}
+        classNames={{ actions: 'custom-actions-cls' }}
+        styles={{ actions: { marginTop: 10 } }}
+      >
+        内容
+      </ProCard>,
+    );
+    const actionsUl = wrapper.baseElement.querySelector<HTMLUListElement>(
+      '.ant-pro-card-actions',
+    );
+    expect(actionsUl).toBeTruthy();
+    expect(actionsUl?.className).toContain('custom-actions-cls');
+    expect(actionsUl?.style.marginTop).toBe('10px');
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Summary
- ProCard declared `classNames.actions` / `styles.actions` in its props (mirroring antd Card's semantic DOM API), but they were never wired up: the `Actions` component ignored them and `mergedStyles.actions` was computed but unused
- pass both through to the actions `<ul>`, so the semantic API now works for all slots: root / header / body / extra / title / cover / **actions**
- add a regression test asserting the custom class and style land on `ul.ant-pro-card-actions`

## Test plan
- [x] `pnpm exec vitest run tests/card/` — 17/17 passed
- [x] `pnpm exec vitest run` — 74 files / 1194 tests passed (no regression)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint src/card tests/card` — clean

Related to #9545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - ProCard 操作区支持通过 `classNames.actions` 和 `styles.actions` 自定义样式。
  - 支持为操作区设置自定义类名及内联样式，提升界面定制能力。

- **测试**
  - 新增操作区类名和样式应用的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->