### PR TITLE
fix(LightFilter)label 重复问题

### DIFF
--- a/src/form/components/FormItem/warpField.tsx
+++ b/src/form/components/FormItem/warpField.tsx
@@ -279,7 +279,11 @@ export function warpField<P extends ProFormFieldItemProps = any>(
       );
     }, [fieldProFieldProps, fieldFieldProps, rest, mergedFieldRef]);
 
-    const isLightMode = proFieldProps?.light === true && !customLightMode;
+    // light 模式：label 由轻量控件自己渲染（LightWrapper 或 customLightMode 控件内部的 FieldLabel），
+    // Form.Item 不能再渲染一遍，否则 label 会重复
+    const isLight = proFieldProps?.light === true;
+    // customLightMode 的控件自行处理下拉逻辑，不需要 LightWrapper 包裹
+    const isLightMode = isLight && !customLightMode;
 
     // 使用useMemo包裹避免不必要的re-render
     const formItem = useDeepCompareMemo(() => {
@@ -325,8 +329,8 @@ export function warpField<P extends ProFormFieldItemProps = any>(
           key={props.proFormFieldKey || otherProps.name?.toString()}
           {...otherProps}
           // 轻量模式下 Form.Item 不展示 label/tooltip，放在展开之后确保不被覆盖
-          label={isLightMode ? undefined : label}
-          tooltip={isLightMode ? undefined : tooltip}
+          label={isLight ? undefined : label}
+          tooltip={isLight ? undefined : tooltip}
           ignoreFormItem={ignoreFormItem}
           transform={transform}
           dataFormat={fieldProps?.format}
@@ -341,6 +345,7 @@ export function warpField<P extends ProFormFieldItemProps = any>(
         </ProFormItem>
       );
     }, [
+      isLight,
       isLightMode,
       label,
       tooltip,

--- a/tests/form/lightFilter.test.tsx
+++ b/tests/form/lightFilter.test.tsx
@@ -49,6 +49,26 @@ describe('LightFilter', () => {
     expect(fieldLabel?.textContent).toContain('名称');
   });
 
+  it(' 🪕 should not render Form.Item label for customLightMode fields', async () => {
+    const { container } = render(
+      <LightFilter initialValues={{ sex: 'man' }}>
+        <LightFilter.select
+          name="sex"
+          label="性别"
+          valueEnum={{ man: '男', woman: '女' }}
+        />
+      </LightFilter>,
+    );
+
+    const fieldLabel = await waitFor(() => {
+      return container.querySelector('.ant-pro-core-field-label');
+    });
+    expect(fieldLabel?.textContent).toContain('性别');
+    // label 只由轻量控件自己渲染，Form.Item 不能再渲染一遍
+    expect(container.querySelector('.ant-form-item-label')).toBeFalsy();
+    expect(container.querySelectorAll('[title="性别"]')).toHaveLength(0);
+  });
+
   it(' 🪕 should support initialValues', async () => {
     const onValuesChange = vi.fn();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复自定义轻量模式下表单字段重复显示标签的问题。
  - 在该模式下，普通表单项不再渲染额外的标签和提示信息，避免与轻量控件自身显示的标签重复。

- **测试**
  - 新增测试，验证自定义轻量模式下仅保留轻量控件的标签，不显示额外的表单项标签或提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->